### PR TITLE
v2.3.0 W2: token-efficiency reporting (decision-support) + versioned schema

### DIFF
--- a/docs/adrs/0168-efficiency-report-and-filtered-tokens.md
+++ b/docs/adrs/0168-efficiency-report-and-filtered-tokens.md
@@ -1,0 +1,48 @@
+---
+id: '0168'
+title: Efficiency report as decision-support (relevant-set coverage + budget-margin), aggregated from existing data; cost estimate opt-in
+status: ACCEPTED
+date: 2026-06-16
+triggered_by: v2.3.0 W2 — no token-efficiency or cost reporting exists, despite the data being mostly collected already
+loop: planning
+---
+
+# ADR-0168: Efficiency report from existing data + a token field on FilteredFile
+
+## Context
+
+`auto_context` already collects most of what a savings report needs. `AutoContextResult` carries `budget: BudgetSummary{total, used, remaining}`, `sections: PackedSections` (whose `PackedFileSection` has a `tokens: usize` field and `files: Vec<PackedFile{path, score, …}>`), and `filtered_out: Vec<FilteredFile>`; the index carries `total_tokens`; and at assembly the `kept` candidate list (post-noise `ScoredFileEntry{path, score, …}`, mod.rs:119) and every file's relevance score (`scorer.score_all`, mod.rs:96) are in scope. What is missing is (a) any aggregation/reporting of these into an efficiency view, and (b) a token count on filtered files — `FilteredFile` is `{path, reason}` (noise.rs), so "tokens saved by filtering" is not derivable today.
+
+A naive coverage metric (`selected_tokens / repo_tokens`) is near-useless: on any large repo it is always a tiny single-digit percentage, and that is *correct* behavior — so the number tells the caller nothing actionable. The report should instead answer **"is this context good enough, and what should I change?"** — which requires metrics relative to the *relevant set*, not the whole repo.
+
+## Options considered
+
+- **Option A — decision-support report from existing data + add `FilteredFile.tokens` (chosen):** add `efficiency: EfficiencyReport` whose **headline is `relevant_coverage`** = (relevant candidates packed) / (relevant candidates = the post-noise `kept` set), with `selected/repo` retained only as a demoted `absolute_coverage` sanity field. Add **`marginal_included_score` / `marginal_excluded_score`** (lowest score in vs. highest score out, over `kept`) — a near-tie means the budget cut sits at the natural margin (healthy); a wide gap means the context is starved. Add a derived **`advisory: Vec<String>`** that speaks only when actionable (starving at a tight margin → raise budget; budget headroom + files filtered → lower threshold) and is silent when healthy. Plus `BudgetSummary` utilization and a new `tokens: usize` on `FilteredFile` (the noise filter has the count at filter time) for filtering savings. Cost estimate is **opt-in only** (`--cost <model>` / `cost_model` MCP param) using a small, dated rate table. All decision-grade signals compute at assembly (mod.rs:278) from data already in scope — **no `briefing.rs` change**; `PackedFile` already carries `score`. Pros: actionable guidance, not a passive dashboard; honest numbers from data we already have plus one field; cost figures never shown unless asked. Cons: one additive field; a few more report fields; rate table needs occasional updates. Chosen as the minimal way to make the report *useful*, not merely descriptive.
+- **Option B — descriptive metrics only (`selected/repo` coverage, budget, savings), no decision-grade signals:** Pros: simplest; zero new computation. Cons: `selected/repo` is near-meaningless on large repos, and the report tells the caller nothing to *act* on. Rejected — a metric nobody acts on is decoration.
+- **Option C — efficiency without filtering savings:** report only coverage and budget, leave `FilteredFile` unchanged. Pros: zero schema change. Cons: omits one of the most compelling numbers (tokens filtered as noise). Someone could prefer it to avoid touching the struct.
+- **Option D — full cost dashboard with live pricing:** Pros: rich. Cons: live pricing is drift-prone and a maintenance/availability liability; scope creep. Rejected.
+
+## Decision
+
+Option A. `EfficiencyReport` is **decision-support**: relevant-set coverage as the headline, budget-margin scores, and a silent-unless-actionable advisory, all aggregated from existing fields at assembly; add `tokens` to `FilteredFile`; cost estimate opt-in with clearly-dated built-in rates.
+
+## Consequences
+
+### Positive
+- The report answers "is this context good enough, and what do I change?" — coverage *of the relevant set*, the budget margin, and one line of guidance — instead of a passive readout.
+- `relevant_coverage` + marginal scores localize the binding constraint (budget vs. relevance threshold), so the caller can act with one knob.
+- A measurable "saved N tokens by filtering" story from data already collected plus one field.
+- Cost numbers appear only on explicit request, so stale rates never silently mislead.
+
+### Negative
+- `FilteredFile` gains a field (additive; serialized output grows slightly).
+- The built-in rate table will need periodic updates; it is dated and opt-in to contain the risk.
+
+### Neutral
+- Rendered through the existing md/json/xml renderers; off the selection critical path.
+
+## Revisit if
+- Rates change often enough that a built-in table is a burden — externalize it (config / fetched table) behind the same opt-in.
+- Users want a per-section or per-file cost breakdown — extend `EfficiencyReport` rather than add a parallel report.
+- The `kept`-based relevant set proves too narrow — add a **structural-closure coverage** signal (of the 1-hop dependency closure of the included files, what fraction is also included), reusing the graph, as an additional field rather than replacing `relevant_coverage`.
+- The advisory's thresholds (`OMISSION`-style tuning: the 0.5 budget-headroom cutoff, the 0.15 margin gap) prove noisy or too quiet — tune against real runs, keeping them covered by the silent-when-healthy test.

--- a/docs/adrs/0169-versioned-context-format-schema.md
+++ b/docs/adrs/0169-versioned-context-format-schema.md
@@ -1,0 +1,40 @@
+---
+id: '0169'
+title: Publish a versioned context-format schema over the existing JSON output, not a new format
+status: ACCEPTED
+date: 2026-06-14
+triggered_by: v2.3.0 W2 — the roadmap's "context format standard" was never built; cxpak already emits JSON
+loop: planning
+---
+
+# ADR-0169: Versioned context-format schema over the existing JSON output
+
+## Context
+
+cxpak already renders structured output as markdown, JSON, and XML (`output/`), and v2.0.0 established semver stability for the MCP API (tool names, params, response structures stable across 2.x). The roadmap's "context format interchange standard" (old Priority 9) was never built. The temptation is to design a new interchange format; the existing JSON output already *is* the de-facto format and is API-stable.
+
+## Options considered
+
+- **Option A — document + version the existing JSON (chosen):** add a top-level `format_version` field to the JSON output, publish a JSON Schema for it in `docs/`, and add `cxpak --emit-schema` (or `cxpak schema`) to print it. Pros: elevates what already exists and is already stable; consumers get a machine-checkable contract; zero new serialization. Cons: commits us to schema evolution discipline (already implied by the v2.x API promise). Chosen because it satisfies the interchange goal by formalizing reality.
+- **Option B — design a new interchange format:** a fresh schema distinct from the current output. Pros: a clean slate unconstrained by current shapes. Cons: duplicates the existing JSON, splits the surface, and directly violates the release's extend-don't-add constraint. Someone could prefer it only if the current JSON were unfit — it is not.
+- **Option C — do nothing:** Pros: no work. Cons: no published contract, no ecosystem adoption path. Someone could prefer it if the standard play is deprioritized.
+
+## Decision
+
+Option A. Version and publish the existing JSON output as the interchange schema; add `format_version` and a schema-emit command. No new format.
+
+## Consequences
+
+### Positive
+- A machine-checkable, versioned contract that other tools can target.
+- No new serialization code; the existing renderer gains one field.
+
+### Negative
+- We now owe schema-evolution discipline: additive changes bump the minor schema version, breaking changes bump major with a documented migration.
+
+### Neutral
+- `format_version` is additive; existing consumers ignore unknown fields.
+
+## Revisit if
+- The JSON shape needs a breaking change — bump `format_version` major and ship a migration note; do not silently reshape.
+- An external standard emerges that the ecosystem converges on — map to it rather than maintain a parallel one.

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -167,3 +167,5 @@
 | [0161](0161-theme-attribute-not-light-dark.md) | Attribute-based theming (data-theme on <html>) instead of CSS light-dark() | ACCEPTED | 2026-04-17 |
 | [0162](0162-v1-api-param-normalization-two-normalizers.md) | v1 API parameter validation: two normalizers (path vs symbol), JSON error envelope, and caps | ACCEPTED | 2026-04-17 |
 | [0163](0163-windows-build-git2-no-default-features.md) | Enable Windows builds by dropping git2 default features (cxpak does only local git) | ACCEPTED | 2026-06-14 |
+| [0168](0168-efficiency-report-and-filtered-tokens.md) | Efficiency report as decision-support (relevant-set coverage + budget-margin), aggregated from existing data; cost estimate opt-in | ACCEPTED | 2026-06-16 |
+| [0169](0169-versioned-context-format-schema.md) | Publish a versioned context-format schema over the existing JSON output, not a new format | ACCEPTED | 2026-06-14 |

--- a/src/auto_context/efficiency.rs
+++ b/src/auto_context/efficiency.rs
@@ -75,8 +75,12 @@ pub fn compute_efficiency(i: EfficiencyInputs) -> EfficiencyReport {
             .iter()
             .find(|(name, _)| *name == m)
             .map(|(name, rate)| CostEstimate {
+                // Base the estimate on the authoritative packed-token total
+                // (budget.used), which counts ALL packed sections — DNA, API
+                // surface, blast radius, cross-language — not just the file
+                // sections in `selected_tokens`, which would under-report.
                 model: (*name).to_string(),
-                input_usd: i.selected_tokens as f64 / 1_000_000.0 * rate,
+                input_usd: i.budget_used as f64 / 1_000_000.0 * rate,
                 rates_dated: RATES_DATED,
             })
     });

--- a/src/auto_context/efficiency.rs
+++ b/src/auto_context/efficiency.rs
@@ -1,0 +1,233 @@
+//! Token-efficiency reporting for auto_context (ADR-0168).
+//!
+//! Decision-support, not a dashboard: the report answers "is this context good
+//! enough, and what should I change?" via relevant-set coverage (of what cxpak
+//! deemed relevant, what fraction fit the budget), the budget-margin scores
+//! (lowest included vs. highest excluded), and a silent-unless-actionable advisory.
+use serde::Serialize;
+
+/// Built-in, dated input-token rates (USD per 1M tokens). Updated 2026-06-14.
+/// Opt-in only; never shown unless a model is explicitly requested.
+const RATES_USD_PER_MTOK: &[(&str, f64)] = &[
+    ("claude-opus-4-8", 15.0),
+    ("claude-sonnet-4-6", 3.0),
+    ("claude-haiku-4-5", 0.80),
+];
+
+const RATES_DATED: &str = "2026-06-14";
+
+pub struct EfficiencyInputs {
+    pub repo_tokens: usize,
+    pub selected_tokens: usize,
+    pub budget_total: usize,
+    pub budget_used: usize,
+    pub filtered_tokens: usize,
+    /// Count of files cxpak deemed relevant (post-noise `kept` set).
+    pub relevant_total: usize,
+    /// Of those, how many were packed into the final context.
+    pub relevant_covered: usize,
+    /// Lowest relevance score among INCLUDED files (the budget margin from above).
+    pub marginal_included_score: Option<f64>,
+    /// Highest relevance score among EXCLUDED files (the budget margin from below).
+    pub marginal_excluded_score: Option<f64>,
+    pub cost_model: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CostEstimate {
+    pub model: String,
+    pub input_usd: f64,
+    pub rates_dated: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EfficiencyReport {
+    pub repo_tokens: usize,
+    pub selected_tokens: usize,
+    /// Headline: of the relevant set, what fraction was packed. Actionable.
+    pub relevant_coverage: f64,
+    pub relevant_total: usize,
+    pub relevant_covered: usize,
+    /// Demoted sanity field: selected/repo. Always ~tiny on large repos; not actionable.
+    pub absolute_coverage: f64,
+    pub budget_total: usize,
+    pub budget_used: usize,
+    pub budget_utilization: f64,
+    pub marginal_included_score: Option<f64>,
+    pub marginal_excluded_score: Option<f64>,
+    pub tokens_saved_filtering: usize,
+    pub cost_estimate: Option<CostEstimate>,
+    /// Human-readable, derived guidance (empty when the selection is healthy).
+    pub advisory: Vec<String>,
+}
+
+fn ratio(num: usize, den: usize) -> f64 {
+    if den == 0 {
+        0.0
+    } else {
+        num as f64 / den as f64
+    }
+}
+
+pub fn compute_efficiency(i: EfficiencyInputs) -> EfficiencyReport {
+    let cost_estimate = i.cost_model.as_ref().and_then(|m| {
+        RATES_USD_PER_MTOK
+            .iter()
+            .find(|(name, _)| *name == m)
+            .map(|(name, rate)| CostEstimate {
+                model: (*name).to_string(),
+                input_usd: i.selected_tokens as f64 / 1_000_000.0 * rate,
+                rates_dated: RATES_DATED,
+            })
+    });
+    let relevant_coverage = ratio(i.relevant_covered, i.relevant_total);
+    let budget_utilization = ratio(i.budget_used, i.budget_total);
+
+    // Derived advisory: only speak when there is something to act on.
+    let mut advisory = Vec::new();
+    // Starving: budget is the binding constraint AND the cut is well above the noise floor.
+    if relevant_coverage < 1.0 {
+        if let (Some(inc), Some(exc)) = (i.marginal_included_score, i.marginal_excluded_score) {
+            // A near-tie at the boundary is healthy (cut at the natural margin);
+            // a large gap excluded means we're dropping clearly-relevant files.
+            if exc > 0.5 && (inc - exc) < 0.15 {
+                advisory.push(format!(
+                    "Budget is the binding constraint: {} of {} relevant files packed; \
+                     the highest-scoring excluded file ({exc:.2}) is close to the lowest included ({inc:.2}). \
+                     Raise --tokens to include more.",
+                    i.relevant_covered, i.relevant_total
+                ));
+            }
+        }
+    }
+    // Headroom: budget barely used AND files were filtered — threshold may be too strict.
+    if budget_utilization < 0.5 && i.filtered_tokens > 0 {
+        advisory.push(format!(
+            "{:.0}% budget headroom with {} tokens filtered out — lower the relevance \
+             threshold or raise --tokens to use the spare budget.",
+            (1.0 - budget_utilization) * 100.0,
+            i.filtered_tokens
+        ));
+    }
+
+    EfficiencyReport {
+        repo_tokens: i.repo_tokens,
+        selected_tokens: i.selected_tokens,
+        relevant_coverage,
+        relevant_total: i.relevant_total,
+        relevant_covered: i.relevant_covered,
+        absolute_coverage: ratio(i.selected_tokens, i.repo_tokens),
+        budget_total: i.budget_total,
+        budget_used: i.budget_used,
+        budget_utilization,
+        marginal_included_score: i.marginal_included_score,
+        marginal_excluded_score: i.marginal_excluded_score,
+        tokens_saved_filtering: i.filtered_tokens,
+        cost_estimate,
+        advisory,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base_inputs() -> EfficiencyInputs {
+        EfficiencyInputs {
+            repo_tokens: 100_000,
+            selected_tokens: 9_700,
+            budget_total: 50_000,
+            budget_used: 9_700,
+            filtered_tokens: 12_000,
+            relevant_total: 10,
+            relevant_covered: 10,
+            marginal_included_score: Some(0.42),
+            marginal_excluded_score: None,
+            cost_model: None,
+        }
+    }
+
+    #[test]
+    fn efficiency_reconciles_coverage_and_savings() {
+        let r = compute_efficiency(base_inputs());
+        assert_eq!(r.repo_tokens, 100_000);
+        assert!((r.relevant_coverage - 1.0).abs() < 1e-9); // 10/10 relevant packed
+        assert!((r.absolute_coverage - 0.097).abs() < 1e-9); // demoted sanity field
+        assert!((r.budget_utilization - 0.194).abs() < 1e-9);
+        assert_eq!(r.tokens_saved_filtering, 12_000);
+        assert!(r.cost_estimate.is_none());
+    }
+
+    #[test]
+    fn advisory_warns_when_starving_at_a_tight_margin() {
+        // 7/10 relevant packed, and the best excluded file (0.80) is right next to
+        // the worst included (0.83) → budget is the binding constraint.
+        let r = compute_efficiency(EfficiencyInputs {
+            relevant_total: 10,
+            relevant_covered: 7,
+            marginal_included_score: Some(0.83),
+            marginal_excluded_score: Some(0.80),
+            budget_used: 50_000, // fully used
+            ..base_inputs()
+        });
+        assert!(r.advisory.iter().any(|a| a.contains("binding constraint")));
+    }
+
+    #[test]
+    fn advisory_warns_on_headroom_with_filtering() {
+        let r = compute_efficiency(EfficiencyInputs {
+            budget_total: 50_000,
+            budget_used: 5_000,
+            filtered_tokens: 8_000,
+            ..base_inputs()
+        });
+        assert!(r.advisory.iter().any(|a| a.contains("budget headroom")));
+    }
+
+    #[test]
+    fn healthy_selection_is_silent() {
+        // full coverage, budget well-used → no nagging.
+        let r = compute_efficiency(EfficiencyInputs {
+            relevant_total: 10,
+            relevant_covered: 10,
+            budget_total: 50_000,
+            budget_used: 40_000,
+            filtered_tokens: 0,
+            ..base_inputs()
+        });
+        assert!(r.advisory.is_empty());
+    }
+
+    #[test]
+    fn cost_estimate_only_when_model_requested() {
+        let r = compute_efficiency(EfficiencyInputs {
+            cost_model: Some("claude-opus-4-8".to_string()),
+            ..base_inputs()
+        });
+        let est = r
+            .cost_estimate
+            .expect("cost estimate present when model given");
+        assert_eq!(est.model, "claude-opus-4-8");
+        assert!(est.input_usd > 0.0);
+    }
+
+    #[test]
+    fn ratios_zero_denominator_are_zero_not_nan() {
+        let r = compute_efficiency(EfficiencyInputs {
+            repo_tokens: 0,
+            selected_tokens: 0,
+            budget_total: 0,
+            budget_used: 0,
+            filtered_tokens: 0,
+            relevant_total: 0,
+            relevant_covered: 0,
+            marginal_included_score: None,
+            marginal_excluded_score: None,
+            cost_model: None,
+        });
+        assert_eq!(r.relevant_coverage, 0.0);
+        assert_eq!(r.absolute_coverage, 0.0);
+        assert_eq!(r.budget_utilization, 0.0);
+        assert!(r.advisory.is_empty());
+    }
+}

--- a/src/auto_context/mod.rs
+++ b/src/auto_context/mod.rs
@@ -292,11 +292,16 @@ pub fn auto_context(
         + packed.sections.test_files.tokens
         + packed.sections.schema_context.tokens;
     let filtered_tokens: usize = filtered.filtered_out.iter().map(|f| f.tokens).sum();
+    // A relevant candidate counts as "covered" if it was packed into ANY file
+    // section — target, test, or schema — not just target_files (else a kept file
+    // packed as a test would be miscounted as excluded, skewing coverage + advisory).
     let included: std::collections::HashSet<&str> = packed
         .sections
         .target_files
         .files
         .iter()
+        .chain(packed.sections.test_files.files.iter())
+        .chain(packed.sections.schema_context.files.iter())
         .map(|f| f.path.as_str())
         .collect();
     let relevant_total = kept.len();
@@ -436,6 +441,34 @@ mod tests {
         let result = auto_context("a", &index, &default_opts(10_000));
         assert_eq!(result.format_version, FORMAT_VERSION);
         assert_eq!(FORMAT_VERSION, "2.3");
+    }
+
+    #[test]
+    fn schema_documents_every_serialized_field() {
+        // Drift guard (ADR-0169): a real serialized AutoContextResult must have
+        // every top-level key AND every `sections` key documented in the published
+        // schema. Adding a struct field without updating the schema fails here.
+        let (index, _dir) = make_index(&[("src/a.rs", "pub fn a() {}")]);
+        let result = auto_context("a", &index, &default_opts(10_000));
+        let json = serde_json::to_value(&result).unwrap();
+        let schema = crate::commands::schema::auto_context_schema();
+
+        let props = schema["properties"].as_object().unwrap();
+        for key in json.as_object().unwrap().keys() {
+            assert!(
+                props.contains_key(key),
+                "schema is missing documented top-level field: {key}"
+            );
+        }
+        let sect_props = schema["properties"]["sections"]["properties"]
+            .as_object()
+            .unwrap();
+        for key in json["sections"].as_object().unwrap().keys() {
+            assert!(
+                sect_props.contains_key(key),
+                "schema sections is missing documented field: {key}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/auto_context/mod.rs
+++ b/src/auto_context/mod.rs
@@ -23,6 +23,8 @@ pub struct AutoContextOpts {
     pub include_tests: bool,
     pub include_blast_radius: bool,
     pub mode: String, // "full" (default) or "briefing"
+    /// Opt-in cost model name; when `Some`, the efficiency report includes a USD estimate.
+    pub cost_model: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -330,12 +332,20 @@ mod tests {
 
     fn default_opts(tokens: usize) -> AutoContextOpts {
         AutoContextOpts {
+            cost_model: None,
             tokens,
             focus: None,
             include_tests: false,
             include_blast_radius: false,
             mode: "full".to_string(),
         }
+    }
+
+    #[test]
+    fn opts_default_has_no_cost_model() {
+        // Default opts must not request a cost estimate (cost is strictly opt-in).
+        let opts = default_opts(10_000);
+        assert!(opts.cost_model.is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -458,6 +468,7 @@ mod tests {
             ("src/db/query.rs", "pub fn run_query() {}"),
         ]);
         let opts = AutoContextOpts {
+            cost_model: None,
             tokens: 50_000,
             focus: Some("src/api/".to_string()),
             include_tests: false,
@@ -568,6 +579,7 @@ mod tests {
             "pub fn authenticate(user: &str) -> bool { true }",
         )]);
         let opts = AutoContextOpts {
+            cost_model: None,
             tokens: 50_000,
             focus: None,
             include_tests: false,
@@ -617,6 +629,7 @@ mod tests {
             ),
         ]);
         let opts = AutoContextOpts {
+            cost_model: None,
             tokens: 50_000,
             focus: None,
             include_tests: false,
@@ -693,6 +706,7 @@ mod tests {
         );
 
         let opts = AutoContextOpts {
+            cost_model: None,
             tokens: 50_000,
             focus: None,
             include_tests: true,
@@ -751,6 +765,7 @@ mod tests {
         );
 
         let opts = AutoContextOpts {
+            cost_model: None,
             tokens: 50_000,
             focus: None,
             include_tests: true,
@@ -800,6 +815,7 @@ mod tests {
             ("src/session.rs", "pub fn make_session() {}"),
         ]);
         let opts = AutoContextOpts {
+            cost_model: None,
             tokens: 50_000,
             focus: None,
             include_tests: false,

--- a/src/auto_context/mod.rs
+++ b/src/auto_context/mod.rs
@@ -308,12 +308,16 @@ pub fn auto_context(
         .iter()
         .filter(|e| included.contains(e.path.as_str()))
         .map(|e| e.score)
-        .fold(None, |acc: Option<f64>, s| Some(acc.map_or(s, |a| a.min(s))));
+        .fold(None, |acc: Option<f64>, s| {
+            Some(acc.map_or(s, |a| a.min(s)))
+        });
     let marginal_excluded_score = kept
         .iter()
         .filter(|e| !included.contains(e.path.as_str()))
         .map(|e| e.score)
-        .fold(None, |acc: Option<f64>, s| Some(acc.map_or(s, |a| a.max(s))));
+        .fold(None, |acc: Option<f64>, s| {
+            Some(acc.map_or(s, |a| a.max(s)))
+        });
     let efficiency = crate::auto_context::efficiency::compute_efficiency(
         crate::auto_context::efficiency::EfficiencyInputs {
             repo_tokens: index.total_tokens,
@@ -403,10 +407,8 @@ mod tests {
 
     #[test]
     fn auto_context_result_has_efficiency_block() {
-        let (index, _dir) = make_index(&[
-            ("src/a.rs", "pub fn a() {}"),
-            ("src/b.rs", "pub fn b() {}"),
-        ]);
+        let (index, _dir) =
+            make_index(&[("src/a.rs", "pub fn a() {}"), ("src/b.rs", "pub fn b() {}")]);
         let opts = default_opts(10_000);
         let result = auto_context("explain a", &index, &opts);
 

--- a/src/auto_context/mod.rs
+++ b/src/auto_context/mod.rs
@@ -27,8 +27,14 @@ pub struct AutoContextOpts {
     pub cost_model: Option<String>,
 }
 
+/// Version of the `auto_context` output contract (ADR-0169). Bump on a breaking
+/// change to the serialized shape; additive fields do not require a bump.
+pub const FORMAT_VERSION: &str = "2.3";
+
 #[derive(Debug, Serialize)]
 pub struct AutoContextResult {
+    /// Version of this output contract (see [`FORMAT_VERSION`]).
+    pub format_version: &'static str,
     pub task: String,
     pub dna: String,
     pub budget: crate::auto_context::briefing::BudgetSummary,
@@ -324,6 +330,7 @@ pub fn auto_context(
     );
 
     AutoContextResult {
+        format_version: FORMAT_VERSION,
         task: task.to_string(),
         dna: effective_dna,
         budget: packed.budget,
@@ -419,6 +426,14 @@ mod tests {
             assert!(result.efficiency.marginal_included_score.is_some());
         }
         assert!(result.efficiency.cost_estimate.is_none()); // default opts
+    }
+
+    #[test]
+    fn result_advertises_format_version() {
+        let (index, _dir) = make_index(&[("src/a.rs", "pub fn a() {}")]);
+        let result = auto_context("a", &index, &default_opts(10_000));
+        assert_eq!(result.format_version, FORMAT_VERSION);
+        assert_eq!(FORMAT_VERSION, "2.3");
     }
 
     // -----------------------------------------------------------------------

--- a/src/auto_context/mod.rs
+++ b/src/auto_context/mod.rs
@@ -1,5 +1,6 @@
 pub mod briefing;
 pub mod diff;
+pub mod efficiency;
 pub mod noise;
 
 use crate::auto_context::noise::{FilteredFile, ScoredFileEntry};

--- a/src/auto_context/mod.rs
+++ b/src/auto_context/mod.rs
@@ -34,6 +34,8 @@ pub struct AutoContextResult {
     pub budget: crate::auto_context::briefing::BudgetSummary,
     pub sections: crate::auto_context::briefing::PackedSections,
     pub filtered_out: Vec<FilteredFile>,
+    // v2.3.0 efficiency / cost reporting (ADR-0168)
+    pub efficiency: crate::auto_context::efficiency::EfficiencyReport,
     // v1.2.0 compound intelligence
     pub health: HealthScore,
     pub risks: Vec<RiskEntry>,
@@ -278,12 +280,56 @@ pub fn auto_context(
         }
     };
 
+    // Efficiency report (ADR-0168) — computed from data in scope, before `packed`
+    // and `filtered` are moved into the result. `kept` is the relevant set.
+    let selected_tokens = packed.sections.target_files.tokens
+        + packed.sections.test_files.tokens
+        + packed.sections.schema_context.tokens;
+    let filtered_tokens: usize = filtered.filtered_out.iter().map(|f| f.tokens).sum();
+    let included: std::collections::HashSet<&str> = packed
+        .sections
+        .target_files
+        .files
+        .iter()
+        .map(|f| f.path.as_str())
+        .collect();
+    let relevant_total = kept.len();
+    let relevant_covered = kept
+        .iter()
+        .filter(|e| included.contains(e.path.as_str()))
+        .count();
+    let marginal_included_score = kept
+        .iter()
+        .filter(|e| included.contains(e.path.as_str()))
+        .map(|e| e.score)
+        .fold(None, |acc: Option<f64>, s| Some(acc.map_or(s, |a| a.min(s))));
+    let marginal_excluded_score = kept
+        .iter()
+        .filter(|e| !included.contains(e.path.as_str()))
+        .map(|e| e.score)
+        .fold(None, |acc: Option<f64>, s| Some(acc.map_or(s, |a| a.max(s))));
+    let efficiency = crate::auto_context::efficiency::compute_efficiency(
+        crate::auto_context::efficiency::EfficiencyInputs {
+            repo_tokens: index.total_tokens,
+            selected_tokens,
+            budget_total: packed.budget.total,
+            budget_used: packed.budget.used,
+            filtered_tokens,
+            relevant_total,
+            relevant_covered,
+            marginal_included_score,
+            marginal_excluded_score,
+            cost_model: opts.cost_model.clone(),
+        },
+    );
+
     AutoContextResult {
         task: task.to_string(),
         dna: effective_dna,
         budget: packed.budget,
         sections: packed.sections,
         filtered_out: filtered.filtered_out,
+        efficiency,
         health,
         risks,
         architecture,
@@ -346,6 +392,33 @@ mod tests {
         // Default opts must not request a cost estimate (cost is strictly opt-in).
         let opts = default_opts(10_000);
         assert!(opts.cost_model.is_none());
+    }
+
+    #[test]
+    fn auto_context_result_has_efficiency_block() {
+        let (index, _dir) = make_index(&[
+            ("src/a.rs", "pub fn a() {}"),
+            ("src/b.rs", "pub fn b() {}"),
+        ]);
+        let opts = default_opts(10_000);
+        let result = auto_context("explain a", &index, &opts);
+
+        assert_eq!(result.efficiency.repo_tokens, index.total_tokens);
+        assert!(result.efficiency.selected_tokens <= result.efficiency.repo_tokens);
+        assert!(
+            result.efficiency.relevant_coverage >= 0.0
+                && result.efficiency.relevant_coverage <= 1.0
+        );
+        assert!(result.efficiency.relevant_covered <= result.efficiency.relevant_total);
+        assert!(
+            result.efficiency.absolute_coverage >= 0.0
+                && result.efficiency.absolute_coverage <= 1.0
+        );
+        // marginal_included is Some when at least one relevant file was packed
+        if result.efficiency.relevant_covered > 0 {
+            assert!(result.efficiency.marginal_included_score.is_some());
+        }
+        assert!(result.efficiency.cost_estimate.is_none()); // default opts
     }
 
     // -----------------------------------------------------------------------

--- a/src/auto_context/noise.rs
+++ b/src/auto_context/noise.rs
@@ -207,6 +207,8 @@ pub struct ScoredFileEntry {
 pub struct FilteredFile {
     pub path: String,
     pub reason: String,
+    /// Token cost of the file that was filtered out — summed for "tokens saved by filtering".
+    pub tokens: usize,
 }
 
 /// The result of running `filter_noise()`.
@@ -260,6 +262,7 @@ pub fn filter_noise(
                 "blocklist: unknown".to_string()
             };
             filtered_out.push(FilteredFile {
+                tokens: entry.token_count,
                 path: entry.path,
                 reason,
             });
@@ -270,6 +273,7 @@ pub fn filter_noise(
         if let Some(file) = index.files.iter().find(|f| f.relative_path == entry.path) {
             if has_generated_marker(&file.content) {
                 filtered_out.push(FilteredFile {
+                    tokens: entry.token_count,
                     path: entry.path,
                     reason: "generated_file".to_string(),
                 });
@@ -296,11 +300,20 @@ pub fn filter_noise(
         })
         .collect();
 
+    // Token cost per path, captured before `after_blocklist` is consumed by dedup —
+    // the dedup result yields only (filtered_path, kept_path), no token count.
+    let token_by_path: HashMap<String, usize> = after_blocklist
+        .iter()
+        .map(|e| (e.path.clone(), e.token_count))
+        .collect();
+
     let (after_dedup, dedup_reasons) =
         dedup_similar_files(after_blocklist, &symbols_by_path, pagerank);
 
     for (filtered_path, kept_path) in dedup_reasons {
+        let tokens = token_by_path.get(&filtered_path).copied().unwrap_or(0);
         filtered_out.push(FilteredFile {
+            tokens,
             path: filtered_path,
             reason: format!("similar_to: {kept_path}"),
         });
@@ -310,6 +323,7 @@ pub fn filter_noise(
     for entry in after_dedup {
         if entry.score < DEFAULT_RELEVANCE_FLOOR {
             filtered_out.push(FilteredFile {
+                tokens: entry.token_count,
                 path: entry.path,
                 reason: format!("below_relevance_floor: {:.4}", entry.score),
             });
@@ -331,6 +345,16 @@ mod tests {
     use crate::budget::counter::TokenCounter;
     use crate::scanner::ScannedFile;
     use std::collections::HashMap;
+
+    #[test]
+    fn filtered_file_carries_token_count() {
+        let f = FilteredFile {
+            path: "src/x.rs".to_string(),
+            reason: "blocklist: generated".to_string(),
+            tokens: 1234,
+        };
+        assert_eq!(f.tokens, 1234);
+    }
 
     // -----------------------------------------------------------------------
     // Task 2 tests

--- a/src/auto_context/noise.rs
+++ b/src/auto_context/noise.rs
@@ -638,6 +638,80 @@ mod tests {
     }
 
     #[test]
+    fn test_dedup_filtered_file_carries_tokens() {
+        use crate::parser::language::{ParseResult, Symbol, SymbolKind, Visibility};
+
+        // Build an index where two files share an identical symbol set so the
+        // similarity-dedup layer drops one. Verifies the dropped file's token
+        // count is propagated onto the FilteredFile (Layer-2 `tokens` propagation).
+        let sym = |name: &str| Symbol {
+            name: name.into(),
+            kind: SymbolKind::Function,
+            visibility: Visibility::Public,
+            signature: format!("fn {name}()"),
+            body: "{}".into(),
+            start_line: 1,
+            end_line: 1,
+        };
+        let symbols = vec![sym("alpha"), sym("beta"), sym("gamma")];
+
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut files = Vec::new();
+        let mut pr: HashMap<String, ParseResult> = HashMap::new();
+        for rel in ["src/a.rs", "src/b.rs"] {
+            let abs = dir.path().join(rel.replace('/', "_"));
+            std::fs::write(&abs, "pub fn alpha() {}\n").unwrap();
+            files.push(ScannedFile {
+                relative_path: rel.to_string(),
+                absolute_path: abs,
+                language: Some("rust".into()),
+                size_bytes: 18,
+            });
+            pr.insert(
+                rel.to_string(),
+                ParseResult {
+                    symbols: symbols.clone(),
+                    imports: vec![],
+                    exports: vec![],
+                },
+            );
+        }
+        let index = crate::index::CodebaseIndex::build(files, pr, &counter);
+
+        let mut pagerank = HashMap::new();
+        pagerank.insert("src/a.rs".to_string(), 0.9); // higher rank → kept on score tie
+        pagerank.insert("src/b.rs".to_string(), 0.1); // lower rank → dropped
+        let candidates = vec![
+            ScoredFileEntry {
+                path: "src/a.rs".to_string(),
+                score: 0.9,
+                token_count: 111,
+            },
+            ScoredFileEntry {
+                path: "src/b.rs".to_string(),
+                score: 0.9,
+                token_count: 222,
+            },
+        ];
+        let result = filter_noise(candidates, &index, &pagerank);
+        let sim: Vec<&FilteredFile> = result
+            .filtered_out
+            .iter()
+            .filter(|f| f.reason.starts_with("similar_to"))
+            .collect();
+        assert_eq!(sim.len(), 1, "one file should be dropped as similar");
+        assert_eq!(
+            sim[0].path, "src/b.rs",
+            "lower-pagerank dup should be dropped"
+        );
+        assert_eq!(
+            sim[0].tokens, 222,
+            "dedup-filtered file must carry its own token count"
+        );
+    }
+
+    #[test]
     fn test_relevance_floor_boundary() {
         let index = make_minimal_index(&[("src/boundary.rs", "fn boundary() {}")]);
         let pagerank = HashMap::new();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,6 +44,8 @@ pub enum Commands {
         #[arg(default_value = ".")]
         path: PathBuf,
     },
+    /// Print the JSON Schema for the auto_context output contract (versioned, ADR-0169)
+    Schema,
     /// Show token-budgeted change summary with dependency context
     Diff {
         #[arg(long, default_value = "50k")]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod onboard;
 pub mod overview;
 #[cfg(feature = "plugins")]
 pub mod plugin;
+pub mod schema;
 #[cfg(feature = "daemon")]
 pub mod serve;
 pub mod trace;

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -169,4 +169,10 @@ mod tests {
         // valid, serializable JSON
         assert!(serde_json::to_string_pretty(&schema).is_ok());
     }
+
+    #[test]
+    fn run_prints_without_error() {
+        // Exercises the print path; stdout is captured by the test harness.
+        assert!(run().is_ok());
+    }
 }

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -1,0 +1,172 @@
+//! `cxpak schema` — print the JSON Schema for the `auto_context` output contract.
+//!
+//! The schema is versioned by [`crate::auto_context::FORMAT_VERSION`] (ADR-0169):
+//! consumers can pin to a `format_version` and detect breaking changes. It documents
+//! the existing JSON output rather than introducing a new serialization format.
+
+use serde_json::json;
+
+/// Build the JSON Schema document for `AutoContextResult`, keyed to the current
+/// `FORMAT_VERSION`. Kept in one place so the advertised contract and the const
+/// never drift.
+pub fn auto_context_schema() -> serde_json::Value {
+    let version = crate::auto_context::FORMAT_VERSION;
+    json!({
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "title": "AutoContextResult",
+        "description": "Token-budgeted context bundle produced by cxpak auto_context.",
+        "type": "object",
+        "x-format-version": version,
+        "required": [
+            "format_version", "task", "budget", "sections", "filtered_out", "efficiency"
+        ],
+        "properties": {
+            "format_version": {
+                "type": "string",
+                "const": version,
+                "description": "Version of this output contract; bumped only on breaking changes."
+            },
+            "task": { "type": "string" },
+            "dna": { "type": "string", "description": "Convention-profile DNA section." },
+            "budget": {
+                "type": "object",
+                "required": ["total", "used", "remaining"],
+                "properties": {
+                    "total": { "type": "integer", "minimum": 0 },
+                    "used": { "type": "integer", "minimum": 0 },
+                    "remaining": { "type": "integer", "minimum": 0 }
+                }
+            },
+            "sections": {
+                "type": "object",
+                "description": "Packed context sections (target/test/schema files, API surface, blast radius).",
+                "properties": {
+                    "target_files": { "$ref": "#/$defs/packedFileSection" },
+                    "test_files": { "$ref": "#/$defs/packedFileSection" },
+                    "schema_context": { "$ref": "#/$defs/packedFileSection" }
+                }
+            },
+            "filtered_out": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["path", "reason", "tokens"],
+                    "properties": {
+                        "path": { "type": "string" },
+                        "reason": { "type": "string" },
+                        "tokens": { "type": "integer", "minimum": 0 }
+                    }
+                }
+            },
+            "efficiency": { "$ref": "#/$defs/efficiencyReport" },
+            "health": { "type": "object", "description": "Index health score." },
+            "risks": { "type": "array", "description": "Top risk entries." },
+            "architecture": { "type": "object", "description": "Architecture map." },
+            "co_changes": { "type": "array", "description": "Mined co-change edges." },
+            "recent_changes": { "type": "array" },
+            "predictions": {
+                "type": ["object", "null"],
+                "description": "Change-impact predictions when the task mentions file paths."
+            }
+        },
+        "$defs": {
+            "packedFileSection": {
+                "type": "object",
+                "required": ["count", "tokens", "files"],
+                "properties": {
+                    "count": { "type": "integer", "minimum": 0 },
+                    "tokens": { "type": "integer", "minimum": 0 },
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["path", "score", "tokens"],
+                            "properties": {
+                                "path": { "type": "string" },
+                                "score": { "type": "number" },
+                                "detail_level": { "type": "string" },
+                                "tokens": { "type": "integer", "minimum": 0 },
+                                "content": { "type": ["string", "null"] }
+                            }
+                        }
+                    }
+                }
+            },
+            "efficiencyReport": {
+                "type": "object",
+                "description": "Decision-support efficiency report (ADR-0168).",
+                "required": [
+                    "repo_tokens", "selected_tokens", "relevant_coverage",
+                    "relevant_total", "relevant_covered", "absolute_coverage",
+                    "budget_total", "budget_used", "budget_utilization",
+                    "tokens_saved_filtering", "advisory"
+                ],
+                "properties": {
+                    "repo_tokens": { "type": "integer", "minimum": 0 },
+                    "selected_tokens": { "type": "integer", "minimum": 0 },
+                    "relevant_coverage": {
+                        "type": "number", "minimum": 0, "maximum": 1,
+                        "description": "Headline: relevant candidates packed / relevant candidates."
+                    },
+                    "relevant_total": { "type": "integer", "minimum": 0 },
+                    "relevant_covered": { "type": "integer", "minimum": 0 },
+                    "absolute_coverage": {
+                        "type": "number", "minimum": 0, "maximum": 1,
+                        "description": "Demoted sanity field: selected/repo tokens."
+                    },
+                    "budget_total": { "type": "integer", "minimum": 0 },
+                    "budget_used": { "type": "integer", "minimum": 0 },
+                    "budget_utilization": { "type": "number", "minimum": 0, "maximum": 1 },
+                    "marginal_included_score": {
+                        "type": ["number", "null"],
+                        "description": "Lowest relevance score among included files."
+                    },
+                    "marginal_excluded_score": {
+                        "type": ["number", "null"],
+                        "description": "Highest relevance score among excluded relevant files."
+                    },
+                    "tokens_saved_filtering": { "type": "integer", "minimum": 0 },
+                    "cost_estimate": {
+                        "type": ["object", "null"],
+                        "properties": {
+                            "model": { "type": "string" },
+                            "input_usd": { "type": "number" },
+                            "rates_dated": { "type": "string" }
+                        }
+                    },
+                    "advisory": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Derived guidance; empty when the selection is healthy."
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Print the schema as pretty JSON to stdout.
+pub fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let schema = auto_context_schema();
+    println!("{}", serde_json::to_string_pretty(&schema)?);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_advertises_current_format_version() {
+        let schema = auto_context_schema();
+        assert_eq!(
+            schema["properties"]["format_version"]["const"],
+            json!(crate::auto_context::FORMAT_VERSION)
+        );
+        assert_eq!(schema["title"], json!("AutoContextResult"));
+        // efficiency block is part of the advertised contract
+        assert!(schema["$defs"]["efficiencyReport"].is_object());
+        // valid, serializable JSON
+        assert!(serde_json::to_string_pretty(&schema).is_ok());
+    }
+}

--- a/src/commands/schema.rs
+++ b/src/commands/schema.rs
@@ -39,11 +39,31 @@ pub fn auto_context_schema() -> serde_json::Value {
             },
             "sections": {
                 "type": "object",
-                "description": "Packed context sections (target/test/schema files, API surface, blast radius).",
+                "description": "Packed context sections.",
+                "required": [
+                    "target_files", "test_files", "schema_context",
+                    "api_surface", "blast_radius", "cross_language_tokens"
+                ],
                 "properties": {
                     "target_files": { "$ref": "#/$defs/packedFileSection" },
                     "test_files": { "$ref": "#/$defs/packedFileSection" },
-                    "schema_context": { "$ref": "#/$defs/packedFileSection" }
+                    "schema_context": { "$ref": "#/$defs/packedFileSection" },
+                    "api_surface": {
+                        "type": ["object", "array", "null"],
+                        "description": "Public API surface (present-but-null when absent)."
+                    },
+                    "blast_radius": {
+                        "type": ["object", "array", "null"],
+                        "description": "Blast-radius analysis of the top files (present-but-null when absent)."
+                    },
+                    "cross_language_edges": {
+                        "type": ["object", "array", "null"],
+                        "description": "Cross-language boundary edges. OMITTED from the JSON when absent (serde skip_serializing_if), unlike api_surface/blast_radius which serialize as null."
+                    },
+                    "cross_language_tokens": {
+                        "type": "integer", "minimum": 0,
+                        "description": "Token count consumed by the cross-language edges section."
+                    }
                 }
             },
             "filtered_out": {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -456,6 +456,8 @@ struct V1BriefingParams {
     task: String,
     tokens: Option<usize>,
     focus: Option<String>,
+    /// Opt-in: model name for a USD cost estimate in the efficiency report.
+    cost_model: Option<String>,
 }
 
 pub fn v1_error(
@@ -595,7 +597,7 @@ async fn v1_briefing_handler(
         guard.clone()
     };
     let opts = crate::auto_context::AutoContextOpts {
-        cost_model: None,
+        cost_model: params.cost_model,
         tokens: params.tokens.unwrap_or(50_000),
         focus: params.focus,
         include_tests: true,
@@ -1417,6 +1419,8 @@ struct AutoContextParams {
     include_tests: Option<bool>,
     include_blast_radius: Option<bool>,
     mode: Option<String>,
+    /// Opt-in: model name for a USD cost estimate in the efficiency report.
+    cost_model: Option<String>,
 }
 
 async fn auto_context_handler(
@@ -1442,7 +1446,7 @@ async fn auto_context_handler(
         .and_then(|t| crate::cli::parse_token_count(t).ok())
         .unwrap_or(50_000);
     let opts = crate::auto_context::AutoContextOpts {
-        cost_model: None,
+        cost_model: params.cost_model,
         tokens: token_budget,
         focus: params.focus,
         include_tests: params.include_tests.unwrap_or(true),
@@ -1979,7 +1983,8 @@ pub fn mcp_stdio_loop_with_io(
                                     "focus": { "type": "string", "description": "Path prefix to scope" },
                                     "include_tests": { "type": "boolean", "description": "Include mapped test files (default true)", "default": true },
                                     "include_blast_radius": { "type": "boolean", "description": "Include blast radius analysis (default true)", "default": true },
-                                    "mode": { "type": "string", "description": "Context mode: 'full' (default) or 'briefing'", "enum": ["full", "briefing"] }
+                                    "mode": { "type": "string", "description": "Context mode: 'full' (default) or 'briefing'", "enum": ["full", "briefing"] },
+                                    "cost_model": { "type": "string", "description": "Opt-in: model name (e.g. 'claude-opus-4-8') for a USD cost estimate in the efficiency report" }
                                 },
                                 "required": ["task"]
                             }
@@ -2188,7 +2193,8 @@ pub fn mcp_stdio_loop_with_io(
                                 "properties": {
                                     "task": { "type": "string", "description": "Natural language task description" },
                                     "tokens": { "type": "string", "description": "Token budget (default '50k')", "default": "50k" },
-                                    "focus": { "type": "string", "description": "Path prefix to scope" }
+                                    "focus": { "type": "string", "description": "Path prefix to scope" },
+                                    "cost_model": { "type": "string", "description": "Opt-in: model name (e.g. 'claude-opus-4-8') for a USD cost estimate in the efficiency report" }
                                 },
                                 "required": ["task"]
                             }
@@ -2401,8 +2407,12 @@ pub fn handle_tool_call(
                 .and_then(|v| v.as_str())
                 .unwrap_or("full")
                 .to_string();
+            let cost_model = args
+                .get("cost_model")
+                .and_then(|v| v.as_str())
+                .map(String::from);
             let opts = crate::auto_context::AutoContextOpts {
-                cost_model: None,
+                cost_model,
                 tokens: token_budget,
                 focus,
                 include_tests,
@@ -3182,8 +3192,12 @@ pub fn handle_tool_call(
                 .and_then(|t| crate::cli::parse_token_count(t).ok())
                 .unwrap_or(50_000);
             let focus = args.get("focus").and_then(|f| f.as_str()).map(String::from);
+            let cost_model = args
+                .get("cost_model")
+                .and_then(|v| v.as_str())
+                .map(String::from);
             let opts = crate::auto_context::AutoContextOpts {
-                cost_model: None,
+                cost_model,
                 tokens: token_budget,
                 focus,
                 include_tests: true,
@@ -4236,6 +4250,51 @@ mod tests {
         assert!(
             text.contains("required"),
             "missing symbol should error with 'required', got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_mcp_auto_context_cost_model_reaches_estimate() {
+        // Proves the cost_model param is wired end-to-end through the MCP entry
+        // point into the efficiency report (not just reachable in a unit test).
+        let index = make_test_index();
+        let snap = make_shared_snapshot();
+        let resp = handle_tool_call(
+            Some(json!(42)),
+            "cxpak_auto_context",
+            &json!({"task": "main", "cost_model": "claude-opus-4-8"}),
+            &index,
+            Path::new("/tmp"),
+            &snap,
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        let cost = &parsed["efficiency"]["cost_estimate"];
+        assert!(
+            cost.is_object(),
+            "cost_model param must produce a cost_estimate; got {cost}"
+        );
+        assert_eq!(cost["model"], json!("claude-opus-4-8"));
+        assert!(cost["input_usd"].as_f64().unwrap() >= 0.0);
+    }
+
+    #[test]
+    fn test_mcp_auto_context_no_cost_model_no_estimate() {
+        let index = make_test_index();
+        let snap = make_shared_snapshot();
+        let resp = handle_tool_call(
+            Some(json!(43)),
+            "cxpak_auto_context",
+            &json!({"task": "main"}),
+            &index,
+            Path::new("/tmp"),
+            &snap,
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert!(
+            parsed["efficiency"]["cost_estimate"].is_null(),
+            "no cost_model → no estimate"
         );
     }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -595,6 +595,7 @@ async fn v1_briefing_handler(
         guard.clone()
     };
     let opts = crate::auto_context::AutoContextOpts {
+        cost_model: None,
         tokens: params.tokens.unwrap_or(50_000),
         focus: params.focus,
         include_tests: true,
@@ -1441,6 +1442,7 @@ async fn auto_context_handler(
         .and_then(|t| crate::cli::parse_token_count(t).ok())
         .unwrap_or(50_000);
     let opts = crate::auto_context::AutoContextOpts {
+        cost_model: None,
         tokens: token_budget,
         focus: params.focus,
         include_tests: params.include_tests.unwrap_or(true),
@@ -2400,6 +2402,7 @@ pub fn handle_tool_call(
                 .unwrap_or("full")
                 .to_string();
             let opts = crate::auto_context::AutoContextOpts {
+                cost_model: None,
                 tokens: token_budget,
                 focus,
                 include_tests,
@@ -3180,6 +3183,7 @@ pub fn handle_tool_call(
                 .unwrap_or(50_000);
             let focus = args.get("focus").and_then(|f| f.as_str()).map(String::from);
             let opts = crate::auto_context::AutoContextOpts {
+                cost_model: None,
                 tokens: token_budget,
                 focus,
                 include_tests: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ fn main() {
 
     let result = match &cli.command {
         Commands::Clean { path } => commands::clean::run(path),
+        Commands::Schema => commands::schema::run(),
         #[cfg(feature = "daemon")]
         Commands::Serve {
             port,

--- a/tests/auto_context_v120.rs
+++ b/tests/auto_context_v120.rs
@@ -41,6 +41,7 @@ fn make_test_index() -> (CodebaseIndex, tempfile::TempDir) {
 fn test_v120_auto_context_result_has_all_fields() {
     let (index, _dir) = make_test_index();
     let opts = AutoContextOpts {
+        cost_model: None,
         tokens: 50_000,
         focus: None,
         include_tests: false,
@@ -106,6 +107,7 @@ fn test_v120_auto_context_result_has_all_fields() {
 fn test_v120_briefing_mode_content_is_none() {
     let (index, _dir) = make_test_index();
     let opts = AutoContextOpts {
+        cost_model: None,
         tokens: 50_000,
         focus: None,
         include_tests: false,
@@ -132,6 +134,7 @@ fn test_v120_briefing_mode_content_is_none() {
 fn test_v120_risks_sorted_descending() {
     let (index, _dir) = make_test_index();
     let opts = AutoContextOpts {
+        cost_model: None,
         tokens: 50_000,
         focus: None,
         include_tests: false,

--- a/tests/integration_cross_lang.rs
+++ b/tests/integration_cross_lang.rs
@@ -106,6 +106,7 @@ fn test_cross_lang_fixture_graph_edges() {
 fn test_cross_lang_fixture_auto_context_surfaces_edges() {
     let (index, _dir) = build_fixture();
     let opts = AutoContextOpts {
+        cost_model: None,
         tokens: 20_000,
         focus: None,
         include_tests: false,


### PR DESCRIPTION
Implements ADR-0168 (efficiency report) and ADR-0169 (versioned context-format schema). **Additive only** — default `auto_context` output is unchanged except for two new fields (`efficiency`, `format_version`).

## What's here

**Efficiency report — decision-support, not a dashboard** (`src/auto_context/efficiency.rs`, new):
- `relevant_coverage` (headline) = relevant candidates packed / relevant candidates (the post-noise `kept` set). Replaces the near-meaningless `selected/repo`, which is demoted to `absolute_coverage`.
- `marginal_included_score` / `marginal_excluded_score` — the budget boundary: a near-tie = healthy cut; a wide gap = starved context.
- `advisory: Vec<String>` — derived guidance, emitted only when actionable (starving → raise budget; headroom + filtering → lower threshold), silent when healthy.
- Computed at assembly from data already in scope (`kept` + packed sections); **no `briefing.rs` change**.
- `tokens_saved_filtering` enabled by one new field `FilteredFile.tokens` (populated at all 4 noise-filter sites).
- Opt-in `cost_estimate` via `AutoContextOpts.cost_model` (dated built-in rate table; never shown unless requested).

**Versioned schema** (ADR-0169): `FORMAT_VERSION = "2.3"` + `format_version` on the result; new `cxpak schema` subcommand prints the JSON Schema (documents the existing output incl. the efficiency block; keyed to the const so it can't drift).

## Verification (evidence)
- **Tests: 2676 passed / 0 failed / 3 ignored** (13 new tests). Verified via test-runner.
- New tests: 6 efficiency (incl. advisory starving/headroom/silent, zero-denominator), `filtered_file_carries_token_count`, `test_dedup_filtered_file_carries_tokens` (real dedup path), `opts_default_has_no_cost_model`, `auto_context_result_has_efficiency_block`, `result_advertises_format_version`, `schema_advertises_current_format_version`, `run_prints_without_error`.
- `cargo clippy --all-targets -- -D warnings`: clean. `cargo fmt --check`: clean.
- Coverage (tarpaulin --lib): **efficiency.rs 39/39 (100%)**, **schema.rs 105/105 (100%)**; noise.rs changed lines (incl. dedup-layer token propagation) covered by the new dedup test.
- Smoke: `cxpak schema` emits valid JSON Schema with `format_version: "2.3"`.

9 signed commits. Branched off the merged foundation (`adce3d6`). **Do not merge — awaiting human review.**

Note: the repo's `.git/hooks/pre-commit` (fmt/clippy/test) is shadowed by a global `core.hooksPath`; fmt/clippy/test were run manually as the gate (CI still enforces them).