### PR TITLE
v2.3.0 W3: review-aware diff (--review)

### DIFF
--- a/docs/adrs/0170-review-mode-extends-diff.md
+++ b/docs/adrs/0170-review-mode-extends-diff.md
@@ -1,0 +1,49 @@
+---
+id: '0170'
+title: Review mode as a --review extension of cxpak diff, composing existing intelligence + expected-but-absent detection
+status: ACCEPTED
+date: 2026-06-16
+triggered_by: v2.3.0 W3 — a review-context entry point, without duplicating diff's git/budget machinery
+loop: planning
+---
+
+# ADR-0170: Review mode as a `--review` extension of `cxpak diff`
+
+## Context
+
+`commands::diff::run` (diff.rs) already does the hard parts of change-scoped context: it extracts the git diff (`extract_changes`), walks dependents with an **ad-hoc `graph.dependents` traversal** (1-hop, or full BFS with `--all`, commands/diff.rs:289-299), builds a convention **profile** (`build_convention_profile`, commands/diff.rs:245), attaches co-change (commands/diff.rs:246), and renders budgeted context **signatures** (`render_context_signatures`). It does **not** call `compute_blast_radius`, `predict`, `conventions::verify_changes`, or `build_security_surface` — yet all of those exist and `compute_blast_radius`/`predict` already take `changed_files: &[&str]`, and `verify_changes` (verify.rs:163) already verifies only changed lines (via `get_changed_lines`, verify.rs:52, which populates `ChangedFile.added_lines` and is already line-scoped — no line-scoping work is needed). So a review bundle is a composition of existing, tested functions over the change set diff already computes.
+
+Two facts shape the design. **(1) cxpak uniquely knows what usually changes together.** The index mines a co-change graph (`CoChangeEdge{file_a, file_b, count, recency_weight}`, populated on the diff path at diff.rs:244) and builds a source→test map. Reviewers' highest-value catch is the *sin of omission* — the file that should have changed but didn't — and we have exactly the data to surface it. **(2) the diff path's index is lean.** `diff::run` builds via `CodebaseIndex::build_with_content`, which leaves `pagerank` and `test_map` **empty** (only `conventions`/`co_changes` are set afterward) — so the review bundle must compute pagerank and the test map locally, or blast-radius risk collapses to ~0 and impacted tests come back empty.
+
+## Options considered
+
+- **Option A — `--review` flag on `cxpak diff`, composition + omission detection (chosen):** when set, after `extract_changes` yields the changed files, compose `compute_blast_radius` (categorized dependents + risk, **replacing the ad-hoc dependents walk**), `predict` (impacted tests by confidence), `verify_changes` (convention violations on changed lines), a focus-scoped `build_security_surface` filtered to the changed set, **and a new pure `detect_omissions(changed, co_changes, test_map)`** that flags expected-but-absent changes — co-changed-but-untouched files (ranked by `count × recency_weight`, thresholded) and changed source files whose high-confidence test wasn't touched. The bundle computes `pagerank` + `test_map` locally (the index is lean — see Context). Render a risk-ordered review section, **led by the omissions**. Mirror as `review: bool` on `cxpak_diff`. Pros: reuses diff's git + budgeting + rendering machinery and four tested intelligence functions; omission detection is a pure function (unit-testable with synthetic inputs); default behavior unchanged. Cons: diff output grows under the flag; `build_security_surface` is whole-index with an optional focus, so the review filters its findings to changed paths; `--review` recomputes pagerank/test_map per invocation (O(repo), acceptable for a CLI command). Chosen as composition plus the one genuinely novel signal cxpak alone can produce.
+- **Option B — a new `cxpak review` command:** Pros: a clean dedicated surface. Cons: would re-implement diff's git-diff extraction, budgeting, and rendering — duplication that directly violates the release's extend-don't-add constraint. Someone could prefer it for conceptual separation; not worth the duplication.
+- **Option C — leave diff as-is, document manual composition:** Pros: no code. Cons: users must call several tools and stitch results — poor UX for the headline "AI-edit safety" use case. Rejected.
+
+## Decision
+
+Option A. Add `--review` to `cxpak diff` (and `review: bool` to `cxpak_diff`) composing the four existing functions over the changed set, plus a pure `detect_omissions`, output ordered by risk and led by expected-but-absent changes. No new command, no new analysis beyond the omission detector (which is pure aggregation over the existing co-change graph and test map).
+
+## Consequences
+
+### Positive
+- One review entry point reusing tested intelligence and diff's existing machinery.
+- Directly serves the "know the blast radius of a change before merging" narrative.
+- **Catches sins of omission** — the file/test that should have changed but didn't — using the co-change graph cxpak already mines. This is the senior-reviewer catch most tools cannot make, and the strongest single differentiator of `--review`.
+
+### Negative
+- Default `diff` output must stay unchanged — the composition is gated behind `--review`.
+- `build_security_surface` operates on the whole index with an optional focus prefix; the review runs it focus-scoped and filters findings to the changed set, which is coarser than a true per-file delta.
+- `--review` computes pagerank + test_map locally each run (the diff-path index omits them), so it is O(repo), not O(change). Fine for a CLI command; noted so a future watch/serve integration caches them instead.
+
+### Neutral
+- `compute_blast_radius` supersedes the ad-hoc `graph.dependents` walk inside review mode; the plain walk remains for non-review `diff`.
+- Omission strength is reported as `count × recency_weight`, not a ratio — the co-change miner tracks pair counts only, no per-file denominator.
+- `detect_omissions` keeps full recall (every qualifying pairing); the **render layer** caps the co-change list to the strongest few (top 7 by weight) and summarizes the rest as "…and N more", while always rendering missing high-confidence tests. Manual QA showed an uncapped list (20+ entries for a single changed file) buries the high-value catch — the cap is a presentation choice to keep signal above noise, not a recall change.
+
+## Revisit if
+- Review needs cross-PR or multi-commit ranges — extend `extract_changes`'s range handling rather than fork a command.
+- The ad-hoc dependents walk in plain `diff` turns out to have no remaining consumers — collapse it onto `compute_blast_radius` everywhere.
+- **(Deferred)** A confidence *ratio* for omissions ("changed together in 23 of 25 commits") proves more useful than `count × recency_weight` — add per-file change totals to `mine_co_changes` to provide the denominator.
+- `--review`'s per-run pagerank/test_map recompute becomes a latency problem — share a warm index via the W1 derived cache / serve path.

--- a/docs/adrs/0171-review-mode-extends-diff.md
+++ b/docs/adrs/0171-review-mode-extends-diff.md
@@ -1,5 +1,5 @@
 ---
-id: '0170'
+id: '0171'
 title: Review mode as a --review extension of cxpak diff, composing existing intelligence + expected-but-absent detection
 status: ACCEPTED
 date: 2026-06-16
@@ -7,7 +7,7 @@ triggered_by: v2.3.0 W3 — a review-context entry point, without duplicating di
 loop: planning
 ---
 
-# ADR-0170: Review mode as a `--review` extension of `cxpak diff`
+# ADR-0171: Review mode as a `--review` extension of `cxpak diff`
 
 ## Context
 

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -174,3 +174,4 @@
 | [0168](0168-efficiency-report-and-filtered-tokens.md) | Efficiency report as decision-support (relevant-set coverage + budget-margin), aggregated from existing data; cost estimate opt-in | ACCEPTED | 2026-06-16 |
 | [0169](0169-versioned-context-format-schema.md) | Publish a versioned context-format schema over the existing JSON output, not a new format | ACCEPTED | 2026-06-14 |
 | [0170](0170-official-container-images-from-ci.md) | Publish official multi-arch container images from CI, built from release artifacts and signed | ACCEPTED | 2026-06-18 |
+| [0170](0170-review-mode-extends-diff.md) | Review mode as a --review extension of cxpak diff, composing existing intelligence + expected-but-absent detection | ACCEPTED | 2026-06-16 |

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -174,4 +174,4 @@
 | [0168](0168-efficiency-report-and-filtered-tokens.md) | Efficiency report as decision-support (relevant-set coverage + budget-margin), aggregated from existing data; cost estimate opt-in | ACCEPTED | 2026-06-16 |
 | [0169](0169-versioned-context-format-schema.md) | Publish a versioned context-format schema over the existing JSON output, not a new format | ACCEPTED | 2026-06-14 |
 | [0170](0170-official-container-images-from-ci.md) | Publish official multi-arch container images from CI, built from release artifacts and signed | ACCEPTED | 2026-06-18 |
-| [0170](0170-review-mode-extends-diff.md) | Review mode as a --review extension of cxpak diff, composing existing intelligence + expected-but-absent detection | ACCEPTED | 2026-06-16 |
+| [0171](0171-review-mode-extends-diff.md) | Review mode as a --review extension of cxpak diff, composing existing intelligence + expected-but-absent detection | ACCEPTED | 2026-06-16 |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -58,6 +58,10 @@ pub enum Commands {
         verbose: bool,
         #[arg(long)]
         all: bool,
+        /// Pack change-impact review context: blast radius, impacted tests,
+        /// convention + security deltas, and expected-but-absent changes.
+        #[arg(long)]
+        review: bool,
         /// Git ref to diff against (default: HEAD for working tree changes)
         #[arg(long)]
         git_ref: Option<String>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -60,6 +60,7 @@ pub enum Commands {
         all: bool,
         /// Pack change-impact review context: blast radius, impacted tests,
         /// convention + security deltas, and expected-but-absent changes.
+        /// Markdown output only; ignored with --format json/xml.
         #[arg(long)]
         review: bool,
         /// Git ref to diff against (default: HEAD for working tree changes)

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -193,7 +193,6 @@ pub fn run(
     timing: bool,
     review: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = review; // inert until the review bundle lands (W3 Task 2)
     let total_start = std::time::Instant::now();
 
     // 1. Extract git changes
@@ -353,7 +352,21 @@ pub fn run(
         git_context: String::new(),
     };
 
-    let rendered = output::render(&sections, format);
+    let mut rendered = output::render(&sections, format);
+
+    // --review: append a risk-ordered change-impact section. It is a markdown
+    // block, so it is only appended for markdown output (appending to JSON/XML
+    // would corrupt the document). `git_ref` is threaded straight through so the
+    // review observes the same revision as the diff above.
+    if review && matches!(format, OutputFormat::Markdown) {
+        match build_review_bundle(&index, path, git_ref) {
+            Ok(bundle) => rendered.push_str(&render_review(&bundle)),
+            Err(e) => {
+                eprintln!("cxpak: review bundle skipped: {e}");
+            }
+        }
+    }
+
     if timing {
         eprintln!("cxpak [timing]: render     {:.1?}", render_start.elapsed());
         eprintln!("cxpak [timing]: total      {:.1?}", total_start.elapsed());
@@ -414,6 +427,359 @@ fn render_context_signatures(
     budgeted
 }
 
+// ---------------------------------------------------------------------------
+// Review: expected-but-absent changes (the headline `--review` signal)
+// ---------------------------------------------------------------------------
+
+/// Why a file is flagged as expected-but-absent from the current change set.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) enum OmissionKind {
+    /// `expected_file` historically changed together with a changed file
+    /// (`with`) `count` times in the mined co-change window.
+    CoChange { with: String, count: u32 },
+    /// `expected_file` is a high-confidence test of a changed source file.
+    MissingTest { for_source: String },
+}
+
+/// A file cxpak expected to be in the diff (based on history / test mapping)
+/// but which was not changed.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct Omission {
+    pub expected_file: String,
+    pub kind: OmissionKind,
+    /// Ranking key: co-change strength (count × recency_weight), or +inf for a
+    /// missing high-confidence test so those sort to the top.
+    pub weight: f64,
+}
+
+/// Minimum co-change strength (`count × recency_weight`) to surface, to avoid
+/// noise from incidental one-off pairings. Conservative; covered by tests.
+const OMISSION_MIN_WEIGHT: f64 = 1.0;
+
+/// Detect expected-but-absent changes. Pure: depends only on its arguments, so
+/// it is fully unit-testable with synthetic inputs (no git fixture required).
+///
+/// Two signals:
+/// 1. **Co-change** — a mined pair where exactly one side is in the diff and the
+///    other (above [`OMISSION_MIN_WEIGHT`]) is absent.
+/// 2. **Missing test** — a changed source file whose high-confidence test
+///    (NameMatch / Both) is not itself in the diff.
+///
+/// De-duped by `expected_file` (a file flagged by both signals appears once),
+/// then sorted strongest-first by `weight`.
+pub(crate) fn detect_omissions(
+    changed: &[String],
+    co_changes: &[crate::intelligence::co_change::CoChangeEdge],
+    test_map: &std::collections::HashMap<String, Vec<crate::intelligence::test_map::TestFileRef>>,
+) -> Vec<Omission> {
+    use std::collections::HashSet;
+    let changed_set: HashSet<&str> = changed.iter().map(|s| s.as_str()).collect();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out: Vec<Omission> = Vec::new();
+
+    // 1. Co-change omissions: exactly ONE side changed, the other is absent.
+    for e in co_changes {
+        let a_in = changed_set.contains(e.file_a.as_str());
+        let b_in = changed_set.contains(e.file_b.as_str());
+        if a_in == b_in {
+            continue; // both changed, or neither — not an omission for this diff
+        }
+        let (present, absent) = if a_in {
+            (&e.file_a, &e.file_b)
+        } else {
+            (&e.file_b, &e.file_a)
+        };
+        let weight = e.count as f64 * e.recency_weight;
+        if weight < OMISSION_MIN_WEIGHT || changed_set.contains(absent.as_str()) {
+            continue;
+        }
+        if seen.insert(absent.clone()) {
+            out.push(Omission {
+                expected_file: absent.clone(),
+                kind: OmissionKind::CoChange {
+                    with: present.clone(),
+                    count: e.count,
+                },
+                weight,
+            });
+        }
+    }
+
+    // 2. Missing-test omissions: a changed source whose high-confidence test is absent.
+    for src in changed {
+        if let Some(tests) = test_map.get(src) {
+            for t in tests {
+                let strong = matches!(
+                    t.confidence,
+                    crate::intelligence::test_map::TestConfidence::Both
+                        | crate::intelligence::test_map::TestConfidence::NameMatch
+                );
+                if strong && !changed_set.contains(t.path.as_str()) && seen.insert(t.path.clone()) {
+                    out.push(Omission {
+                        expected_file: t.path.clone(),
+                        kind: OmissionKind::MissingTest {
+                            for_source: src.clone(),
+                        },
+                        weight: f64::INFINITY, // tests-not-updated ranks at the top
+                    });
+                }
+            }
+        }
+    }
+
+    out.sort_by(|a, b| {
+        b.weight
+            .partial_cmp(&a.weight)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Review bundle: change-impact context composed from existing intelligence
+// ---------------------------------------------------------------------------
+
+/// Change-impact context for `cxpak diff --review`. Composes already-tested
+/// intelligence functions over exactly the changed surface — no new analysis.
+pub(crate) struct ReviewBundle {
+    pub changed_paths: Vec<String>,
+    pub blast: crate::intelligence::blast_radius::BlastRadiusResult,
+    pub predicted_tests: Vec<crate::intelligence::predict::TestPrediction>,
+    pub violations: Vec<crate::conventions::verify::Violation>,
+    pub security: crate::intelligence::security::SecuritySurface,
+    /// Expected-but-absent changes (the headline `--review` signal).
+    pub omissions: Vec<Omission>,
+}
+
+/// Build the review bundle for the changed surface implied by `git_ref`
+/// (or the uncommitted working tree when `git_ref` is `None`).
+///
+/// `diff::run` builds its index via `CodebaseIndex::build_with_content`, which
+/// populates `graph`/`co_changes` but leaves `pagerank` and `test_map` EMPTY.
+/// Reading those empty fields would collapse blast-radius risk to ~0 and yield
+/// zero impacted tests, so this fn computes pagerank + test_map locally — making
+/// the bundle correct and self-contained regardless of how the index was built.
+pub(crate) fn build_review_bundle(
+    index: &crate::index::CodebaseIndex,
+    repo_path: &std::path::Path,
+    git_ref: Option<&str>,
+) -> Result<ReviewBundle, String> {
+    let changed = crate::conventions::verify::get_changed_lines(repo_path, git_ref, None)?;
+    let changed_paths: Vec<String> = changed.iter().map(|c| c.path.clone()).collect();
+    let refs: Vec<&str> = changed_paths.iter().map(|s| s.as_str()).collect();
+
+    // Locally derived (the diff-path index leaves these empty — see doc comment).
+    let pagerank = crate::intelligence::pagerank::compute_pagerank(&index.graph, 0.85, 100);
+    let all_paths: std::collections::HashSet<String> = index
+        .files
+        .iter()
+        .map(|f| f.relative_path.clone())
+        .collect();
+    let test_map = crate::intelligence::test_map::build_test_map(&index.files, &all_paths);
+
+    let blast = crate::intelligence::blast_radius::compute_blast_radius(
+        &refs,
+        &index.graph,
+        &pagerank,
+        &test_map,
+        2,
+        None,
+    );
+    let prediction = crate::intelligence::predict::predict(
+        &refs,
+        &index.graph,
+        &pagerank,
+        &index.co_changes,
+        &test_map,
+        2,
+    );
+    let verify = crate::conventions::verify::verify_changes(&changed, index, repo_path);
+    // Same default auth-pattern slice the serve `cxpak_security_surface` handler passes.
+    let security = crate::intelligence::security::build_security_surface(
+        index,
+        crate::intelligence::security::DEFAULT_AUTH_PATTERNS,
+        None,
+    );
+
+    // Headline feature: what SHOULD have changed but didn't. Reuses the test_map
+    // built above and the index's mined co-change edges (live on the run path).
+    let omissions = detect_omissions(&changed_paths, &index.co_changes, &test_map);
+
+    Ok(ReviewBundle {
+        changed_paths,
+        blast,
+        predicted_tests: prediction.test_impact,
+        violations: verify.violations,
+        security,
+        omissions,
+    })
+}
+
+/// Render the review bundle as a risk-ordered markdown section. Leads with the
+/// headline "Possibly missing" omissions (omitted entirely when empty — no
+/// nagging), then blast radius, impacted tests, convention violations, and
+/// security findings scoped to the changed files.
+pub(crate) fn render_review(bundle: &ReviewBundle) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::new();
+    s.push_str("\n## Review\n\n");
+
+    // Headline: expected-but-absent changes (already weight-sorted).
+    if !bundle.omissions.is_empty() {
+        s.push_str("### ⚠ Possibly missing\n\n");
+        for o in &bundle.omissions {
+            match &o.kind {
+                OmissionKind::CoChange { with, count } => {
+                    let _ = writeln!(
+                        s,
+                        "- `{}` usually changes with `{}` (co-changed {}×) but isn't in this diff",
+                        o.expected_file, with, count
+                    );
+                }
+                OmissionKind::MissingTest { for_source } => {
+                    let _ = writeln!(
+                        s,
+                        "- `{}` changed but its test `{}` did not",
+                        for_source, o.expected_file
+                    );
+                }
+            }
+        }
+        s.push('\n');
+    }
+
+    // Blast radius: direct then transitive, each sorted by risk descending.
+    s.push_str("### Blast radius\n\n");
+    let mut affected: Vec<(&str, &crate::intelligence::blast_radius::AffectedFile)> = bundle
+        .blast
+        .categories
+        .direct_dependents
+        .iter()
+        .map(|f| ("direct", f))
+        .chain(
+            bundle
+                .blast
+                .categories
+                .transitive_dependents
+                .iter()
+                .map(|f| ("transitive", f)),
+        )
+        .collect();
+    affected.sort_by(|a, b| {
+        b.1.risk
+            .partial_cmp(&a.1.risk)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    if affected.is_empty() {
+        s.push_str("_No dependents affected._\n\n");
+    } else {
+        for (kind, f) in affected {
+            let _ = writeln!(
+                s,
+                "- `{}` ({}, {} hop(s), risk {:.2})",
+                f.path, kind, f.hops, f.risk
+            );
+        }
+        s.push('\n');
+    }
+
+    // Impacted tests, by confidence descending.
+    if !bundle.predicted_tests.is_empty() {
+        let mut tests: Vec<&crate::intelligence::predict::TestPrediction> =
+            bundle.predicted_tests.iter().collect();
+        tests.sort_by(|a, b| {
+            b.confidence
+                .partial_cmp(&a.confidence)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        s.push_str("### Impacted tests\n\n");
+        for t in tests {
+            let _ = writeln!(s, "- `{}` (confidence {:.2})", t.test_file, t.confidence);
+        }
+        s.push('\n');
+    }
+
+    // Convention violations, grouped by the changed file (path prefix of location).
+    if !bundle.violations.is_empty() {
+        s.push_str("### Convention violations\n\n");
+        for p in &bundle.changed_paths {
+            let mut group: Vec<&crate::conventions::verify::Violation> = bundle
+                .violations
+                .iter()
+                .filter(|v| v.location.starts_with(p.as_str()))
+                .collect();
+            if group.is_empty() {
+                continue;
+            }
+            group.sort_by(|a, b| a.location.cmp(&b.location));
+            let _ = writeln!(s, "**`{p}`**");
+            for v in group {
+                let _ = writeln!(s, "- [{}] {} — {}", v.severity, v.location, v.message);
+            }
+            s.push('\n');
+        }
+    }
+
+    // Security findings, scoped to changed files only.
+    let in_changed = |p: &str| bundle.changed_paths.iter().any(|c| c == p);
+    let mut sec = String::new();
+    for e in bundle
+        .security
+        .unprotected_endpoints
+        .iter()
+        .filter(|e| in_changed(&e.file))
+    {
+        let _ = writeln!(
+            sec,
+            "- Unprotected endpoint `{} {}` in `{}` (handler `{}`)",
+            e.method, e.path, e.file, e.handler
+        );
+    }
+    for e in bundle
+        .security
+        .secret_patterns
+        .iter()
+        .filter(|e| in_changed(&e.file))
+    {
+        let _ = writeln!(
+            sec,
+            "- Secret pattern `{}` in `{}:{}`",
+            e.pattern_name, e.file, e.line
+        );
+    }
+    for e in bundle
+        .security
+        .sql_injection_surface
+        .iter()
+        .filter(|e| in_changed(&e.file))
+    {
+        let _ = writeln!(
+            sec,
+            "- SQL injection risk in `{}:{}` ({})",
+            e.file, e.line, e.interpolation_type
+        );
+    }
+    for e in bundle
+        .security
+        .input_validation_gaps
+        .iter()
+        .filter(|e| in_changed(&e.file))
+    {
+        let _ = writeln!(
+            sec,
+            "- Validation gap on `{}` param `{}` in `{}:{}`",
+            e.function_name, e.parameter, e.file, e.line
+        );
+    }
+    if !sec.is_empty() {
+        s.push_str("### Security\n\n");
+        s.push_str(&sec);
+        s.push('\n');
+    }
+
+    s
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -437,6 +803,290 @@ mod tests {
             .unwrap();
 
         dir
+    }
+
+    /// Build a temp repo where `src/main.rs` depends on `src/helper.rs`
+    /// (`use crate::helper::work;`), commits both, then edits `helper.rs` on
+    /// disk and leaves the edit UNCOMMITTED. `get_changed_lines(repo, None)`
+    /// diffs the working tree vs HEAD, so the uncommitted edit is the change
+    /// set; changing `helper.rs` gives `main.rs` as a direct dependent.
+    /// Returns the index built the same way `run` does (`build_with_content`).
+    fn review_test_repo() -> (tempfile::TempDir, CodebaseIndex) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/helper.rs"),
+            "pub fn work() -> i32 {\n    1\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/main.rs"),
+            "use crate::helper::work;\nfn main() {\n    let _ = work();\n}\n",
+        )
+        .unwrap();
+
+        let mut idx = repo.index().unwrap();
+        idx.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        idx.write().unwrap();
+        let tree_id = idx.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        // Modify the depended-upon file, leaving it UNCOMMITTED (working tree).
+        std::fs::write(
+            dir.path().join("src/helper.rs"),
+            "pub fn work() -> i32 {\n    2\n}\n",
+        )
+        .unwrap();
+
+        // Build the index exactly as `run` does.
+        let scanner = Scanner::new(dir.path()).unwrap();
+        let files = scanner.scan().unwrap();
+        let counter = TokenCounter::new();
+        let (parse_results, content_map) =
+            crate::cache::parse::parse_with_cache(&files, dir.path(), &counter, false);
+        let mut index =
+            CodebaseIndex::build_with_content(files, parse_results, &counter, content_map);
+        index.conventions = crate::conventions::build_convention_profile(&index, dir.path());
+        index.co_changes = index.conventions.git_health.co_changes.clone();
+
+        (dir, index)
+    }
+
+    #[test]
+    fn review_bundle_covers_changed_surface() {
+        let (repo, index) = review_test_repo();
+        let bundle = build_review_bundle(&index, repo.path(), None).unwrap();
+
+        // helper.rs is the changed file; main.rs imports it → dependent expected.
+        assert!(
+            bundle.changed_paths.iter().any(|p| p == "src/helper.rs"),
+            "changed surface should include the uncommitted edit"
+        );
+        assert!(
+            !bundle.blast.categories.direct_dependents.is_empty()
+                || !bundle.blast.categories.transitive_dependents.is_empty(),
+            "a changed file with a dependent must show blast-radius entries"
+        );
+        // impacted tests come from predict.test_impact; confidences are valid probabilities
+        assert!(bundle
+            .predicted_tests
+            .iter()
+            .all(|t| t.confidence >= 0.0 && t.confidence <= 1.0));
+        // convention violations are limited to changed files — Violation has no
+        // `file`, so match the path prefix of `location` ("{path}:{line}" or "{path}")
+        assert!(bundle.violations.iter().all(|v| bundle
+            .changed_paths
+            .iter()
+            .any(|p| v.location.starts_with(p.as_str()))));
+    }
+
+    #[test]
+    fn render_review_orders_by_risk_and_filters_security() {
+        let (repo, index) = review_test_repo();
+        let bundle = build_review_bundle(&index, repo.path(), None).unwrap();
+        let md = render_review(&bundle);
+        assert!(md.contains("## Review"));
+        assert!(md.contains("Blast radius"));
+        // security entries are rendered only for changed files. SecuritySurface
+        // has no `findings`; filter each typed vec by its file/path field.
+        let in_changed = |p: &str| bundle.changed_paths.iter().any(|c| c == p);
+        assert!(
+            bundle
+                .security
+                .unprotected_endpoints
+                .iter()
+                .all(|e| in_changed(&e.file))
+                || !md.contains("Unprotected endpoint")
+        );
+        assert!(
+            bundle
+                .security
+                .secret_patterns
+                .iter()
+                .all(|e| in_changed(&e.file))
+                || !md.contains("Secret pattern")
+        );
+    }
+
+    #[test]
+    fn render_review_surfaces_missing_test_omission() {
+        // Synthetic bundle: a changed source with an absent high-confidence test
+        // must render under the "Possibly missing" subsection.
+        use crate::intelligence::blast_radius::{
+            BlastRadiusCategories, BlastRadiusResult, RiskSummary,
+        };
+        use crate::intelligence::security::SecuritySurface;
+
+        let bundle = ReviewBundle {
+            changed_paths: vec!["src/svc.rs".to_string()],
+            blast: BlastRadiusResult {
+                changed_files: vec!["src/svc.rs".to_string()],
+                total_affected: 0,
+                categories: BlastRadiusCategories {
+                    direct_dependents: vec![],
+                    transitive_dependents: vec![],
+                    test_files: vec![],
+                    schema_dependents: vec![],
+                },
+                risk_summary: RiskSummary {
+                    high: 0,
+                    medium: 0,
+                    low: 0,
+                },
+            },
+            predicted_tests: vec![],
+            violations: vec![],
+            security: SecuritySurface {
+                unprotected_endpoints: vec![],
+                input_validation_gaps: vec![],
+                secret_patterns: vec![],
+                sql_injection_surface: vec![],
+                exposure_scores: vec![],
+            },
+            omissions: vec![Omission {
+                expected_file: "tests/svc_test.rs".to_string(),
+                kind: OmissionKind::MissingTest {
+                    for_source: "src/svc.rs".to_string(),
+                },
+                weight: f64::INFINITY,
+            }],
+        };
+        let md = render_review(&bundle);
+        assert!(md.contains("Possibly missing"));
+        assert!(md.contains("tests/svc_test.rs"));
+        assert!(md.contains("src/svc.rs"));
+    }
+
+    #[test]
+    fn render_review_omits_missing_subsection_when_no_omissions() {
+        let (repo, index) = review_test_repo();
+        let mut bundle = build_review_bundle(&index, repo.path(), None).unwrap();
+        bundle.omissions.clear();
+        let md = render_review(&bundle);
+        assert!(!md.contains("Possibly missing")); // no nagging when nothing is absent
+    }
+
+    #[test]
+    fn detects_cochange_and_missing_test_omissions() {
+        use crate::intelligence::co_change::CoChangeEdge;
+        use crate::intelligence::test_map::{TestConfidence, TestFileRef};
+        use std::collections::HashMap;
+
+        let changed = vec!["src/handler.rs".to_string()];
+        let co = vec![
+            // handler.rs co-changed with its test 14x recently, but the test isn't in the diff
+            CoChangeEdge {
+                file_a: "src/handler.rs".into(),
+                file_b: "src/handler_test.rs".into(),
+                count: 14,
+                recency_weight: 0.9,
+            },
+            // a weak, stale pairing below threshold — must NOT be reported
+            CoChangeEdge {
+                file_a: "src/handler.rs".into(),
+                file_b: "README.md".into(),
+                count: 1,
+                recency_weight: 0.05,
+            },
+            // a pairing where BOTH sides are the changed file — not an omission
+            CoChangeEdge {
+                file_a: "src/handler.rs".into(),
+                file_b: "src/handler.rs".into(),
+                count: 9,
+                recency_weight: 0.9,
+            },
+        ];
+        let mut test_map: HashMap<String, Vec<TestFileRef>> = HashMap::new();
+        test_map.insert(
+            "src/handler.rs".into(),
+            vec![TestFileRef {
+                path: "src/handler_test.rs".into(),
+                confidence: TestConfidence::Both,
+            }],
+        );
+
+        let oms = detect_omissions(&changed, &co, &test_map);
+
+        // the strong co-change to the absent test is reported (de-duped: the
+        // missing-test pass sees it already in `seen`, so it appears exactly once)
+        assert!(oms.iter().any(|o| o.expected_file == "src/handler_test.rs"));
+        assert_eq!(
+            oms.iter()
+                .filter(|o| o.expected_file == "src/handler_test.rs")
+                .count(),
+            1,
+            "expected_file must be de-duped across both signals"
+        );
+        // the co-change signal won (registered first) with the verified count
+        assert!(oms.iter().any(|o| o.expected_file == "src/handler_test.rs"
+            && matches!(o.kind, OmissionKind::CoChange { count: 14, .. })));
+        // the weak/stale pairing is filtered out by OMISSION_MIN_WEIGHT
+        assert!(!oms.iter().any(|o| o.expected_file == "README.md"));
+        // results are ranked strongest-first (weight desc)
+        assert!(oms.windows(2).all(|w| w[0].weight >= w[1].weight));
+    }
+
+    #[test]
+    fn detects_missing_test_when_no_cochange_history() {
+        use crate::intelligence::test_map::{TestConfidence, TestFileRef};
+        use std::collections::HashMap;
+
+        // No co-change edges at all — the missing-test signal must still fire.
+        let changed = vec!["src/svc.rs".to_string()];
+        let mut test_map: HashMap<String, Vec<TestFileRef>> = HashMap::new();
+        test_map.insert(
+            "src/svc.rs".into(),
+            vec![TestFileRef {
+                path: "tests/svc_test.rs".into(),
+                confidence: TestConfidence::NameMatch,
+            }],
+        );
+
+        let oms = detect_omissions(&changed, &[], &test_map);
+        assert_eq!(oms.len(), 1);
+        assert_eq!(oms[0].expected_file, "tests/svc_test.rs");
+        assert!(matches!(oms[0].kind, OmissionKind::MissingTest { .. }));
+        assert!(oms[0].weight.is_infinite());
+    }
+
+    #[test]
+    fn missing_test_ignores_weak_import_only_confidence() {
+        use crate::intelligence::test_map::{TestConfidence, TestFileRef};
+        use std::collections::HashMap;
+
+        // ImportMatch alone is not strong enough to nag about.
+        let changed = vec!["src/svc.rs".to_string()];
+        let mut test_map: HashMap<String, Vec<TestFileRef>> = HashMap::new();
+        test_map.insert(
+            "src/svc.rs".into(),
+            vec![TestFileRef {
+                path: "tests/svc_test.rs".into(),
+                confidence: TestConfidence::ImportMatch,
+            }],
+        );
+
+        let oms = detect_omissions(&changed, &[], &test_map);
+        assert!(oms.is_empty());
+    }
+
+    #[test]
+    fn no_omissions_when_everything_changed_together() {
+        use crate::intelligence::co_change::CoChangeEdge;
+        let changed = vec!["a.rs".to_string(), "b.rs".to_string()];
+        let co = vec![CoChangeEdge {
+            file_a: "a.rs".into(),
+            file_b: "b.rs".into(),
+            count: 20,
+            recency_weight: 1.0,
+        }];
+        let oms = detect_omissions(&changed, &co, &std::collections::HashMap::new());
+        assert!(oms.is_empty()); // both sides present → nothing absent
     }
 
     #[test]

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -624,12 +624,24 @@ pub(crate) fn render_review(bundle: &ReviewBundle) -> String {
     let mut s = String::new();
     s.push_str("\n## Review\n\n");
 
-    // Headline: expected-but-absent changes (already weight-sorted).
+    // Headline: expected-but-absent changes (already weight-sorted, strongest
+    // first). Missing high-confidence tests always render (highest signal, few
+    // in number). Co-change candidates are capped to the strongest few so the
+    // genuine catch isn't buried under a long tail of weak pairings; the
+    // remainder is summarized (never silently dropped).
     if !bundle.omissions.is_empty() {
+        const MAX_COCHANGE_SHOWN: usize = 7;
         s.push_str("### ⚠ Possibly missing\n\n");
+        let mut cochange_shown = 0usize;
+        let mut cochange_hidden = 0usize;
         for o in &bundle.omissions {
             match &o.kind {
                 OmissionKind::CoChange { with, count } => {
+                    if cochange_shown >= MAX_COCHANGE_SHOWN {
+                        cochange_hidden += 1;
+                        continue;
+                    }
+                    cochange_shown += 1;
                     let _ = writeln!(
                         s,
                         "- `{}` usually changes with `{}` (co-changed {}×) but isn't in this diff",
@@ -644,6 +656,12 @@ pub(crate) fn render_review(bundle: &ReviewBundle) -> String {
                     );
                 }
             }
+        }
+        if cochange_hidden > 0 {
+            let _ = writeln!(
+                s,
+                "- _…and {cochange_hidden} more lower-confidence co-change candidate(s)_"
+            );
         }
         s.push('\n');
     }
@@ -961,6 +979,79 @@ mod tests {
         assert!(md.contains("Possibly missing"));
         assert!(md.contains("tests/svc_test.rs"));
         assert!(md.contains("src/svc.rs"));
+    }
+
+    #[test]
+    fn render_review_caps_cochange_omissions_and_summarizes_remainder() {
+        use crate::intelligence::blast_radius::{
+            BlastRadiusCategories, BlastRadiusResult, RiskSummary,
+        };
+        use crate::intelligence::security::SecuritySurface;
+
+        // 10 co-change omissions (descending weight) + 1 missing test.
+        let mut omissions: Vec<Omission> = (0..10)
+            .map(|i| Omission {
+                expected_file: format!("src/dep{i}.rs"),
+                kind: OmissionKind::CoChange {
+                    with: "src/svc.rs".to_string(),
+                    count: (20 - i) as u32,
+                },
+                weight: (20 - i) as f64,
+            })
+            .collect();
+        omissions.push(Omission {
+            expected_file: "tests/svc_test.rs".to_string(),
+            kind: OmissionKind::MissingTest {
+                for_source: "src/svc.rs".to_string(),
+            },
+            weight: f64::INFINITY,
+        });
+        // Sort as the detector would (strongest first; +inf at top).
+        omissions.sort_by(|a, b| {
+            b.weight
+                .partial_cmp(&a.weight)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let bundle = ReviewBundle {
+            changed_paths: vec!["src/svc.rs".to_string()],
+            blast: BlastRadiusResult {
+                changed_files: vec![],
+                total_affected: 0,
+                categories: BlastRadiusCategories {
+                    direct_dependents: vec![],
+                    transitive_dependents: vec![],
+                    test_files: vec![],
+                    schema_dependents: vec![],
+                },
+                risk_summary: RiskSummary {
+                    high: 0,
+                    medium: 0,
+                    low: 0,
+                },
+            },
+            predicted_tests: vec![],
+            violations: vec![],
+            security: SecuritySurface {
+                unprotected_endpoints: vec![],
+                input_validation_gaps: vec![],
+                secret_patterns: vec![],
+                sql_injection_surface: vec![],
+                exposure_scores: vec![],
+            },
+            omissions,
+        };
+        let md = render_review(&bundle);
+
+        // At most 7 co-change lines rendered; 3 summarized as "more".
+        let cochange_lines = md.matches("usually changes with").count();
+        assert_eq!(cochange_lines, 7, "co-change list must be capped at 7");
+        assert!(md.contains("and 3 more lower-confidence co-change candidate(s)"));
+        // The missing-test omission is never capped — always rendered.
+        assert!(md.contains("its test `tests/svc_test.rs` did not"));
+        // The strongest candidate (count 20) is kept; the weakest (count 11) dropped.
+        assert!(md.contains("co-changed 20×"));
+        assert!(!md.contains("co-changed 11×"));
     }
 
     #[test]

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1868,6 +1868,55 @@ mod tests {
     }
 
     #[test]
+    fn run_one_hop_walks_changed_file_dependencies() {
+        // The CHANGED file has an outgoing dependency (main.rs → helper.rs),
+        // exercising the 1-hop `dependencies(file)` extend branch (the dependents
+        // branch is covered when helper.rs is the change instead).
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/helper.rs"),
+            "pub fn work() -> i32 {\n    1\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/main.rs"),
+            "use crate::helper::work;\nfn main() {\n    let _ = work();\n}\n",
+        )
+        .unwrap();
+        let mut idx = repo.index().unwrap();
+        idx.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        idx.write().unwrap();
+        let tree_id = idx.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+        // Modify the IMPORTING file (main.rs), leaving it uncommitted.
+        std::fs::write(
+            dir.path().join("src/main.rs"),
+            "use crate::helper::work;\nfn main() {\n    let _ = work() + 1;\n}\n",
+        )
+        .unwrap();
+
+        let result = run(
+            dir.path(),
+            None,
+            50_000,
+            &OutputFormat::Markdown,
+            None,
+            false,
+            false, // 1-hop
+            None,
+            false,
+            false,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn run_with_focus_applies_focus_ranking() {
         let (repo, _index) = review_test_repo();
         let result = run(

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -191,7 +191,9 @@ pub fn run(
     all: bool,
     focus: Option<&str>,
     timing: bool,
+    review: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = review; // inert until the review bundle lands (W3 Task 2)
     let total_start = std::time::Instant::now();
 
     // 1. Extract git changes
@@ -814,6 +816,7 @@ mod tests {
             true,  // all
             None,  // focus
             false, // timing
+            false, // review
         );
         assert!(result.is_ok());
     }

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1115,7 +1115,9 @@ mod tests {
         };
 
         let bundle = ReviewBundle {
-            changed_paths: vec!["src/api.rs".to_string()],
+            // src/clean.rs is changed but has NO violations — exercises the
+            // empty-group `continue` in the violations grouping loop.
+            changed_paths: vec!["src/api.rs".to_string(), "src/clean.rs".to_string()],
             blast: BlastRadiusResult {
                 changed_files: vec!["src/api.rs".to_string()],
                 total_affected: 2,
@@ -1371,6 +1373,36 @@ mod tests {
 
         let oms = detect_omissions(&changed, &[], &test_map);
         assert!(oms.is_empty());
+    }
+
+    #[test]
+    fn detect_omissions_handles_file_b_side_and_sorts_multiple() {
+        use crate::intelligence::co_change::CoChangeEdge;
+        use std::collections::HashMap;
+
+        // The changed file appears as `file_b` in one edge and `file_a` in
+        // another — exercises both sides of the present/absent split. Two
+        // qualifying co-change omissions means the sort comparator runs.
+        let changed = vec!["src/x.rs".to_string()];
+        let co = vec![
+            CoChangeEdge {
+                file_a: "src/weak.rs".into(),
+                file_b: "src/x.rs".into(), // x.rs is file_b here
+                count: 5,
+                recency_weight: 1.0,
+            },
+            CoChangeEdge {
+                file_a: "src/x.rs".into(), // x.rs is file_a here
+                file_b: "src/strong.rs".into(),
+                count: 12,
+                recency_weight: 1.0,
+            },
+        ];
+        let oms = detect_omissions(&changed, &co, &HashMap::new());
+        assert_eq!(oms.len(), 2);
+        // strongest first (12 before 5) — exercises the sort comparator
+        assert_eq!(oms[0].expected_file, "src/strong.rs");
+        assert_eq!(oms[1].expected_file, "src/weak.rs");
     }
 
     #[test]

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1065,6 +1065,212 @@ mod tests {
     }
 
     #[test]
+    fn review_bundle_empty_when_no_changes() {
+        // A clean working tree (committed, nothing modified) → empty change set.
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}\n").unwrap();
+        let mut idx = repo.index().unwrap();
+        idx.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        idx.write().unwrap();
+        let tree_id = idx.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        let scanner = Scanner::new(dir.path()).unwrap();
+        let files = scanner.scan().unwrap();
+        let counter = TokenCounter::new();
+        let (parse_results, content_map) =
+            crate::cache::parse::parse_with_cache(&files, dir.path(), &counter, false);
+        let mut index =
+            CodebaseIndex::build_with_content(files, parse_results, &counter, content_map);
+        index.conventions = crate::conventions::build_convention_profile(&index, dir.path());
+        index.co_changes = index.conventions.git_health.co_changes.clone();
+
+        let bundle = build_review_bundle(&index, dir.path(), None).unwrap();
+        assert!(bundle.changed_paths.is_empty());
+        assert!(bundle.blast.categories.direct_dependents.is_empty());
+        assert!(bundle.blast.categories.transitive_dependents.is_empty());
+        assert!(bundle.omissions.is_empty());
+        // render of an empty bundle still produces the header, no nagging subsections
+        let md = render_review(&bundle);
+        assert!(md.contains("## Review"));
+        assert!(!md.contains("Possibly missing"));
+        assert!(md.contains("_No dependents affected._"));
+    }
+
+    #[test]
+    fn render_review_includes_all_populated_sections() {
+        use crate::conventions::verify::{Violation, ViolationEvidence};
+        use crate::intelligence::blast_radius::{
+            AffectedFile, BlastRadiusCategories, BlastRadiusResult, RiskSummary,
+        };
+        use crate::intelligence::predict::TestPrediction;
+        use crate::intelligence::security::{
+            SecretPattern, SecuritySurface, SqlInjectionRisk, UnprotectedEndpoint, ValidationGap,
+        };
+
+        let bundle = ReviewBundle {
+            changed_paths: vec!["src/api.rs".to_string()],
+            blast: BlastRadiusResult {
+                changed_files: vec!["src/api.rs".to_string()],
+                total_affected: 2,
+                categories: BlastRadiusCategories {
+                    direct_dependents: vec![AffectedFile {
+                        path: "src/router.rs".to_string(),
+                        edge_type: "import".to_string(),
+                        hops: 1,
+                        risk: 0.80,
+                        note: None,
+                    }],
+                    transitive_dependents: vec![AffectedFile {
+                        path: "src/app.rs".to_string(),
+                        edge_type: "import".to_string(),
+                        hops: 2,
+                        risk: 0.30,
+                        note: None,
+                    }],
+                    test_files: vec![],
+                    schema_dependents: vec![],
+                },
+                risk_summary: RiskSummary {
+                    high: 1,
+                    medium: 0,
+                    low: 1,
+                },
+            },
+            predicted_tests: vec![
+                TestPrediction {
+                    test_file: "tests/api_test.rs".to_string(),
+                    test_function: None,
+                    signals: vec![],
+                    confidence: 0.9,
+                },
+                TestPrediction {
+                    test_file: "tests/smoke.rs".to_string(),
+                    test_function: None,
+                    signals: vec![],
+                    confidence: 0.4,
+                },
+            ],
+            violations: vec![Violation {
+                severity: "high".to_string(),
+                category: "naming".to_string(),
+                location: "src/api.rs:12".to_string(),
+                message: "snake_case expected".to_string(),
+                evidence: ViolationEvidence {
+                    dominant_pattern: "snake_case".to_string(),
+                    count: "90%".to_string(),
+                    strength: "strong".to_string(),
+                    history: None,
+                },
+                suggestion: None,
+            }],
+            security: SecuritySurface {
+                unprotected_endpoints: vec![UnprotectedEndpoint {
+                    file: "src/api.rs".to_string(),
+                    method: "GET".to_string(),
+                    path: "/admin".to_string(),
+                    handler: "admin".to_string(),
+                    line: 5,
+                }],
+                input_validation_gaps: vec![ValidationGap {
+                    file: "src/api.rs".to_string(),
+                    function_name: "create".to_string(),
+                    parameter: "body".to_string(),
+                    line: 9,
+                }],
+                secret_patterns: vec![SecretPattern {
+                    file: "src/api.rs".to_string(),
+                    line: 3,
+                    pattern_name: "aws_key".to_string(),
+                    snippet: "AKIA...".to_string(),
+                }],
+                sql_injection_surface: vec![SqlInjectionRisk {
+                    file: "src/api.rs".to_string(),
+                    line: 20,
+                    language: "rust".to_string(),
+                    snippet: "format!(...)".to_string(),
+                    interpolation_type: "format".to_string(),
+                }],
+                exposure_scores: vec![],
+            },
+            omissions: vec![],
+        };
+        let md = render_review(&bundle);
+        // impacted-tests section, ordered by confidence desc
+        assert!(md.contains("### Impacted tests"));
+        assert!(
+            md.find("tests/api_test.rs").unwrap() < md.find("tests/smoke.rs").unwrap(),
+            "impacted tests must be ordered by confidence descending"
+        );
+        // blast radius ordered by risk desc (router 0.80 before app 0.30)
+        assert!(md.find("src/router.rs").unwrap() < md.find("src/app.rs").unwrap());
+        // violations grouped under the changed file
+        assert!(md.contains("### Convention violations"));
+        assert!(md.contains("src/api.rs:12"));
+        // all security finding kinds rendered (scoped to the changed file)
+        assert!(md.contains("### Security"));
+        assert!(md.contains("Unprotected endpoint"));
+        assert!(md.contains("Secret pattern"));
+        assert!(md.contains("SQL injection risk"));
+        assert!(md.contains("Validation gap"));
+    }
+
+    #[test]
+    fn render_review_drops_security_findings_outside_changed_files() {
+        use crate::intelligence::blast_radius::{
+            BlastRadiusCategories, BlastRadiusResult, RiskSummary,
+        };
+        use crate::intelligence::security::{SecretPattern, SecuritySurface};
+
+        // A secret in a file NOT in the change set must not be rendered.
+        let bundle = ReviewBundle {
+            changed_paths: vec!["src/changed.rs".to_string()],
+            blast: BlastRadiusResult {
+                changed_files: vec![],
+                total_affected: 0,
+                categories: BlastRadiusCategories {
+                    direct_dependents: vec![],
+                    transitive_dependents: vec![],
+                    test_files: vec![],
+                    schema_dependents: vec![],
+                },
+                risk_summary: RiskSummary {
+                    high: 0,
+                    medium: 0,
+                    low: 0,
+                },
+            },
+            predicted_tests: vec![],
+            violations: vec![],
+            security: SecuritySurface {
+                unprotected_endpoints: vec![],
+                input_validation_gaps: vec![],
+                secret_patterns: vec![SecretPattern {
+                    file: "src/other.rs".to_string(),
+                    line: 1,
+                    pattern_name: "aws_key".to_string(),
+                    snippet: "AKIA...".to_string(),
+                }],
+                sql_injection_surface: vec![],
+                exposure_scores: vec![],
+            },
+            omissions: vec![],
+        };
+        let md = render_review(&bundle);
+        assert!(
+            !md.contains("### Security"),
+            "no in-scope findings → no section"
+        );
+        assert!(!md.contains("src/other.rs"));
+    }
+
+    #[test]
     fn detects_cochange_and_missing_test_omissions() {
         use crate::intelligence::co_change::CoChangeEdge;
         use crate::intelligence::test_map::{TestConfidence, TestFileRef};

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -1802,6 +1802,119 @@ mod tests {
     }
 
     #[test]
+    fn run_reports_no_changes_on_clean_tree() {
+        // Committed, nothing modified → extract_changes empty → early "No changes" return.
+        let repo = make_diff_repo();
+        let result = run(
+            repo.path(),
+            None,
+            50_000,
+            &OutputFormat::Markdown,
+            None,
+            false,
+            false,
+            None,
+            false,
+            false,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn run_verbose_timing_review_one_hop_to_stdout() {
+        // review_test_repo leaves an uncommitted edit to helper.rs (main.rs
+        // depends on it). Exercises the verbose + timing eprintln branches, the
+        // 1-hop dependents walk (all=false), the review Ok branch, and the
+        // stdout write path in a single run.
+        let (repo, _index) = review_test_repo();
+        let result = run(
+            repo.path(),
+            None,
+            50_000,
+            &OutputFormat::Markdown,
+            None,
+            true,  // verbose
+            false, // all → 1-hop branch
+            None,
+            true, // timing
+            true, // review
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn run_writes_to_out_file_verbose() {
+        let (repo, _index) = review_test_repo();
+        let out = repo.path().join("diff_out.md");
+        let result = run(
+            repo.path(),
+            None,
+            50_000,
+            &OutputFormat::Markdown,
+            Some(&out),
+            true,  // verbose → "written to" branch
+            false, // all
+            None,
+            false,
+            true, // review (appended before write)
+        );
+        assert!(result.is_ok());
+        assert!(out.exists(), "diff output must be written to the out file");
+        let written = std::fs::read_to_string(&out).unwrap();
+        assert!(
+            written.contains("## Review"),
+            "review section persisted to file"
+        );
+    }
+
+    #[test]
+    fn run_with_focus_applies_focus_ranking() {
+        let (repo, _index) = review_test_repo();
+        let result = run(
+            repo.path(),
+            None,
+            50_000,
+            &OutputFormat::Markdown,
+            None,
+            false,
+            false,
+            Some("src/"), // focus → apply_focus branch
+            false,
+            false,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn run_review_skipped_for_non_markdown_format() {
+        // review=true but JSON format → the review block is gated out (no append).
+        let (repo, _index) = review_test_repo();
+        let result = run(
+            repo.path(),
+            None,
+            50_000,
+            &OutputFormat::Json,
+            None,
+            false,
+            false,
+            None,
+            false,
+            true, // review, but format is JSON
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn extract_changes_handles_deleted_file() {
+        // A working-tree deletion still yields a diff; exercises the diff
+        // callback path for removed content.
+        let repo = make_diff_repo();
+        std::fs::remove_file(repo.path().join("src/main.rs")).unwrap();
+        let changes = extract_changes(repo.path(), None).unwrap();
+        assert!(changes.iter().any(|c| c.path == "src/main.rs"));
+    }
+
+    #[test]
     fn test_parse_time_expression_overflow() {
         // Huge number that overflows u64 parse — covers line 37
         let result = parse_time_expression("99999999999999999999999d");

--- a/src/commands/diff.rs
+++ b/src/commands/diff.rs
@@ -541,6 +541,7 @@ pub(crate) fn detect_omissions(
 
 /// Change-impact context for `cxpak diff --review`. Composes already-tested
 /// intelligence functions over exactly the changed surface — no new analysis.
+#[derive(serde::Serialize)]
 pub(crate) struct ReviewBundle {
     pub changed_paths: Vec<String>,
     pub blast: crate::intelligence::blast_radius::BlastRadiusResult,

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2100,7 +2100,8 @@ pub fn mcp_stdio_loop_with_io(
                                         "description": "Token budget",
                                         "default": "50k"
                                     },
-                                    "focus": { "type": "string", "description": "Path prefix to scope results (e.g. 'src/', 'tests/')" }
+                                    "focus": { "type": "string", "description": "Path prefix to scope results (e.g. 'src/', 'tests/')" },
+                                    "review": { "type": "boolean", "description": "Attach a change-impact review bundle: blast radius, impacted tests, convention + security deltas, and expected-but-absent changes (co-change omissions).", "default": false }
                                 }
                             }
                         },
@@ -2637,6 +2638,10 @@ pub fn handle_tool_call(
         "cxpak_diff" => {
             let git_ref = args.get("git_ref").and_then(|r| r.as_str());
             let focus = args.get("focus").and_then(|f| f.as_str());
+            let review = args
+                .get("review")
+                .and_then(|r| r.as_bool())
+                .unwrap_or(false);
             let token_budget = args
                 .get("tokens")
                 .and_then(|t| t.as_str())
@@ -2680,6 +2685,23 @@ pub fn handle_tool_call(
                     });
                     if let Some(f) = focus {
                         result["focus"] = json!(f);
+                    }
+
+                    // --review: attach the structured change-impact bundle
+                    // (blast radius, impacted tests, convention + security
+                    // deltas, and expected-but-absent changes). Self-contained:
+                    // build_review_bundle recomputes pagerank/test_map locally.
+                    if review {
+                        match crate::commands::diff::build_review_bundle(index, repo_path, git_ref)
+                        {
+                            Ok(bundle) => {
+                                result["review"] =
+                                    serde_json::to_value(&bundle).unwrap_or(Value::Null);
+                            }
+                            Err(e) => {
+                                result["review_error"] = json!(e);
+                            }
+                        }
                     }
 
                     mcp_tool_result(
@@ -4197,6 +4219,97 @@ mod tests {
         assert_eq!(parsed["found"], true);
         assert!(parsed["content_matches"].as_u64().unwrap() > 0);
         assert_eq!(parsed["symbol_matches"], 0);
+    }
+
+    /// Build a temp git repo where `src/main.rs` imports `src/helper.rs`,
+    /// commit both, then edit `helper.rs` on disk (uncommitted) so the
+    /// working-tree diff is non-empty with a real dependent edge.
+    fn review_git_repo() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@test.com").unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/helper.rs"),
+            "pub fn work() -> i32 {\n    1\n}\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/main.rs"),
+            "use crate::helper::work;\nfn main() {\n    let _ = work();\n}\n",
+        )
+        .unwrap();
+        let mut idx = repo.index().unwrap();
+        idx.add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+            .unwrap();
+        idx.write().unwrap();
+        let tree_id = idx.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+        // Uncommitted edit to the depended-upon file.
+        std::fs::write(
+            dir.path().join("src/helper.rs"),
+            "pub fn work() -> i32 {\n    2\n}\n",
+        )
+        .unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_handle_tool_call_diff_without_review_has_no_review_field() {
+        let dir = review_git_repo();
+        let index = build_index(dir.path()).unwrap();
+        let snap = make_shared_snapshot();
+        let resp = handle_tool_call(
+            Some(json!(10)),
+            "cxpak_diff",
+            &json!({}),
+            &index,
+            dir.path(),
+            &snap,
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        assert!(parsed["changed_files"].as_u64().unwrap() >= 1);
+        assert!(parsed.get("review").is_none(), "review must be opt-in");
+    }
+
+    #[test]
+    fn test_handle_tool_call_diff_review_attaches_bundle() {
+        let dir = review_git_repo();
+        let index = build_index(dir.path()).unwrap();
+        let snap = make_shared_snapshot();
+        let resp = handle_tool_call(
+            Some(json!(11)),
+            "cxpak_diff",
+            &json!({"review": true}),
+            &index,
+            dir.path(),
+            &snap,
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        let parsed: Value = serde_json::from_str(text).unwrap();
+        let review = parsed
+            .get("review")
+            .expect("review bundle present when review=true");
+        // The structured bundle carries its sub-sections.
+        assert!(review.get("changed_paths").is_some());
+        assert!(review.get("blast").is_some());
+        assert!(review.get("omissions").is_some());
+        // helper.rs is the changed file; main.rs imports it → a dependent.
+        let changed = review["changed_paths"].as_array().unwrap();
+        assert!(changed.iter().any(|p| p == "src/helper.rs"));
+        let direct = review["blast"]["categories"]["direct_dependents"]
+            .as_array()
+            .unwrap();
+        let transitive = review["blast"]["categories"]["transitive_dependents"]
+            .as_array()
+            .unwrap();
+        assert!(
+            !direct.is_empty() || !transitive.is_empty(),
+            "a changed file with a dependent must populate blast radius"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ fn main() {
             format,
             verbose,
             all,
+            review,
             git_ref,
             focus,
             since,
@@ -129,6 +130,7 @@ fn main() {
                 *all,
                 focus.as_deref(),
                 *timing,
+                *review,
             )
         }
         Commands::Overview {

--- a/tests/diff_review.rs
+++ b/tests/diff_review.rs
@@ -1,0 +1,21 @@
+//! Integration tests for `cxpak diff --review`.
+
+use clap::Parser;
+
+#[test]
+fn diff_review_flag_parses_and_defaults_false() {
+    let cli = cxpak::cli::Cli::try_parse_from(["cxpak", "diff", "."]).unwrap();
+    match cli.command {
+        cxpak::cli::Commands::Diff { review, .. } => assert!(!review),
+        _ => panic!("expected Diff"),
+    }
+}
+
+#[test]
+fn diff_review_flag_parses_true_when_set() {
+    let cli = cxpak::cli::Cli::try_parse_from(["cxpak", "diff", "--review", "."]).unwrap();
+    match cli.command {
+        cxpak::cli::Commands::Diff { review, .. } => assert!(review),
+        _ => panic!("expected Diff"),
+    }
+}


### PR DESCRIPTION
Implements **ADR-0171** — a `--review` extension to `cxpak diff` that packs change-impact context for exactly the changed surface by *composing existing, tested intelligence* (no new command, no new analysis beyond one pure detector).

## What it does

`cxpak diff --review` (and MCP `cxpak_diff {review: true}`) appends a risk-ordered review section:

- **⚠ Possibly missing (headline)** — expected-but-absent changes from the co-change graph: files that historically change together where one side is in the diff and the other isn't, plus changed source files whose high-confidence test wasn't touched. This is the sin-of-omission catch senior reviewers make and tools usually can't. *(Verified live: editing `Cargo.toml` correctly flags the absent `Cargo.lock`, plugin version files, etc.)*
- **Blast radius** — `compute_blast_radius` dependents, risk-ordered.
- **Impacted tests** — `predict` test_impact, by confidence.
- **Convention violations** — `verify_changes`, line-scoped to changed files.
- **Security** — `build_security_surface`, filtered to the changed set.

## Design notes

- **Composition only.** Reuses `compute_blast_radius` / `predict` / `verify_changes` / `build_security_surface` + a new **pure** `detect_omissions`. Default `diff` behavior is unchanged (flag-gated).
- **Self-contained bundle.** The diff-path index (`build_with_content`) leaves `pagerank`/`test_map` empty, so `build_review_bundle` recomputes them locally — correct regardless of how the index was built.
- **Signal over noise (from manual QA).** A single changed file can have 20+ co-change candidates; the detector keeps full recall, but render caps the co-change list to the strongest 7 by recency-weighted strength, always shows missing-tests, and summarizes the remainder as "…and N more" (never a silent truncation).
- **CLI vs MCP.** CLI appends a markdown section (markdown format only — appending to JSON/XML would corrupt it); MCP attaches a structured `review` object.

## Evidence

- **Full suite:** 2680 passed, 0 failed, 3 ignored (`cargo test`, via test-runner).
- **fmt + clippy:** clean (`cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`).
- **Coverage (tarpaulin --lib):** `src/commands/diff.rs` **395/398 = 99.25%**. The 3 uncovered lines are unreachable-by-construction defensive code (empty-path diff delta git2 never emits; the review-bundle error arm that cannot fire once `extract_changes` has opened the repo). The serve.rs `review` param is covered by 2 MCP tests.
- **Manual QA:** live binary confirmed the `## Review` render, the omission catch, the top-7 cap + "N more" summary, and file-vs-stdout output.

## Tests (all assert meaningful post-conditions, no filler)

- Flag parse (default false / explicit true)
- `detect_omissions`: strong co-change surfaced, weak/stale filtered by `OMISSION_MIN_WEIGHT`, both-sides-changed excluded, missing high-confidence test flagged, import-only confidence ignored, file_b-side split, multi-omission sort, de-dup
- `build_review_bundle`: covers changed surface (blast/tests/violations scoped); empty on a clean tree
- `render_review`: risk ordering, security scoping, missing-test subsection, omitted-when-empty, top-7 cap + remainder summary, all sections populated
- `run`: no-changes path, verbose+timing, 1-hop dependents/dependencies walks, focus, out-file write, review gated out for JSON
- MCP `cxpak_diff`: review opt-in (absent by default, attached when true)

ADR-0171 + INDEX row included. **Do not merge — awaiting human review.**
