### PR TITLE
chore(release): v2.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "cxpak",
       "source": "./plugin",
       "description": "Structured codebase context for Claude. Auto-context on every prompt plus an on-demand single-page dashboard with Cmd+K command palette: architecture explorer, risk heatmap, flow diagram, timeline, and diff view. 26 MCP tools, 12 HTTP endpoints, 14 LSP custom methods — all wired to real intelligence: health scoring, blast radius, change prediction, drift detection, security surface, data flow tracing, cross-language resolution. tree-sitter across 43 languages. Cross-process deterministic output.",
-      "version": "2.2.1"
+      "version": "2.3.0"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "cxpak"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cxpak"
-version = "2.2.1"
+version = "2.3.0"
 edition = "2021"
 rust-version = "1.91"
 description = "Spends CPU cycles so you don't spend tokens. The LLM gets a briefing packet instead of a flashlight in a dark room."

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cxpak",
   "description": "Structured codebase context for Claude. Auto-context on every prompt plus an on-demand single-page dashboard with Cmd+K command palette: architecture explorer, risk heatmap, flow diagram, timeline, and diff view. 26 MCP tools, 12 HTTP endpoints, 14 LSP custom methods — all wired to real intelligence: health scoring, blast radius, change prediction, drift detection, security surface, data flow tracing, cross-language resolution. tree-sitter across 43 languages. Cross-process deterministic output.",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "author": {
     "name": "Barnett Studios"
   },

--- a/plugin/lib/ensure-cxpak
+++ b/plugin/lib/ensure-cxpak
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REQUIRED_VERSION="2.2.1"
+REQUIRED_VERSION="2.3.0"
 
 version_matches() {
     local installed


### PR DESCRIPTION
## Release v2.3.0

Bumps all four version sync points `2.2.1 → 2.3.0` and regenerates `Cargo.lock`. This is the release-cut PR for the v2.3.0 feature set, which is already merged into `main`:

- **W1 — scale / live-update speed** (#11): warm-started PageRank, edge-delta graph rebuild, persistent content-addressed derived cache; live watcher path wired to the delta. ADRs 0164–0167.
- **W2 — token-efficiency reporting** (#9): decision-support efficiency report + opt-in cost estimate; versioned context-format schema (`cxpak schema`, `format_version 2.3`). ADRs 0168–0169.
- **W3 — review-aware diff** (#10): `cxpak diff --review` + MCP `cxpak_diff {review:true}` — blast radius, impacted tests, convention/security deltas, and co-change/missing-test omissions. ADR 0171.

### Files bumped
- `Cargo.toml`
- `plugin/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `plugin/lib/ensure-cxpak` (`REQUIRED_VERSION`)
- `Cargo.lock` (regenerated via `cargo check`)

### Pre-release verification (on integrated `main`)
- **Full suite: 2723 passed / 0 failed / 3 ignored** — W1 parity, W2 efficiency, W3 review tests all pass together.
- `cargo fmt -- --check` clean; `cargo check` clean (Cargo.lock regenerated).
- **Manual QA on the built binary** (no regressions):
  - Core: `overview`, `trace`, `diff` — exit 0.
  - W2: `schema` → `format_version 2.3`; MCP `auto_context` → efficiency (14 fields) + cost estimate $0.73.
  - W3: CLI `diff --review` + MCP `cxpak_diff {review:true}` → omissions/blast/impacted-tests render; `--format json` correctly skips the review block.
  - W1: `watch` → derived cache written, content edit → incremental `updated 1 file(s)` (tokens 41→50).
  - MCP: 26 tools advertised; co-change mining 20122 edges.

After merge, tag `v2.3.0` on the merged commit to trigger CI cross-compile + crates.io publish.

HITL — do not merge/tag without review.
