### PR TITLE
docs: add CONTRIBUTING guide + issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Something cxpak did wrong — a crash, a wrong result, or unexpected behavior.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. A minimal reproduction is the single most useful
+        thing you can provide — it turns hours of guessing into minutes of fixing.
+        For security vulnerabilities, do **not** file here — use a private
+        [security advisory](https://github.com/Barnett-Studios/cxpak/security/advisories/new).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you run, what did you expect, and what did you get instead?
+      placeholder: |
+        Ran `cxpak overview .` on my repo and it panicked / produced wrong output / ...
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Ideally a link to a minimal repo or a snippet that triggers it. Include
+        the exact command and any relevant file(s).
+      placeholder: |
+        1. Clone https://github.com/me/minimal-repro
+        2. Run `cxpak trace handle_request .`
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: cxpak version
+      description: Output of `cxpak --version`.
+      placeholder: "cxpak 3.1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: install
+    attributes:
+      label: How did you install cxpak?
+      options:
+        - Homebrew
+        - "cargo install"
+        - Prebuilt release binary
+        - Docker (ghcr.io image)
+        - Built from source
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS and architecture
+      placeholder: "macOS 15 arm64 / Ubuntu 24.04 x86_64 / Windows 11 x86_64"
+    validations:
+      required: true
+  - type: input
+    id: features
+    attributes:
+      label: Non-default features enabled (if any)
+      description: >
+        e.g. built with `--features data-introspect,lsp`. Leave blank for a
+        default build.
+      placeholder: "data-introspect"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant output or backtrace
+      description: >
+        Paste any error output. For a panic, re-run with `RUST_BACKTRACE=1`.
+        This is automatically formatted as code — no backticks needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/Barnett-Studios/cxpak/discussions
+    about: Usage questions, ideas, and open-ended discussion — not bug reports.
+  - name: Report a security vulnerability
+    url: https://github.com/Barnett-Studios/cxpak/security/advisories/new
+    about: Report privately so it can be fixed before disclosure. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,41 @@
+name: Feature request
+description: Suggest a capability, a surface addition, or an improvement.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check the [ADR index](https://github.com/Barnett-Studios/cxpak/blob/main/docs/adrs/INDEX.md) —
+        a decision may already record why something is (or isn't) the way it is.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do that cxpak makes hard or impossible today?
+      placeholder: >
+        When I run cxpak on a monorepo with X, I can't ... because ...
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        What would you like cxpak to do? If it touches a surface (CLI, MCP, HTTP,
+        LSP), say which and roughly how.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about, and why they fall short.
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: I'm willing to help implement this
+          required: false

--- a/.github/ISSUE_TEMPLATE/language_support.yml
+++ b/.github/ISSUE_TEMPLATE/language_support.yml
@@ -1,0 +1,45 @@
+name: Language support request
+description: Request (or offer to add) support for a programming language.
+labels: ["enhancement", "language-support"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        cxpak extracts symbols via tree-sitter, so a language needs a maintained
+        tree-sitter grammar. Adding one is a well-scoped contribution — see the
+        [recipe in CONTRIBUTING.md](https://github.com/Barnett-Studios/cxpak/blob/main/CONTRIBUTING.md#adding-a-language).
+  - type: input
+    id: language
+    attributes:
+      label: Language
+      placeholder: "Elm"
+    validations:
+      required: true
+  - type: input
+    id: grammar
+    attributes:
+      label: tree-sitter grammar crate
+      description: Link to the `tree-sitter-*` grammar (crates.io or repo). Required — cxpak can't parse without one.
+      placeholder: "https://crates.io/crates/tree-sitter-elm"
+    validations:
+      required: true
+  - type: dropdown
+    id: tier
+    attributes:
+      label: Extraction tier
+      description: >
+        Full = functions, classes/types, imports, exports (a real programming
+        language). Structural = selectors/keys/blocks (config, markup, data).
+      options:
+        - Full extraction (programming language)
+        - Structural extraction (config / markup / data)
+        - Not sure
+    validations:
+      required: true
+  - type: checkboxes
+    id: offer
+    attributes:
+      label: Contribution
+      options:
+        - label: I'm willing to implement this following the CONTRIBUTING recipe
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+Thanks for contributing to cxpak! Keep the PR focused and fill in the sections
+below. The checklist mirrors the CI gates — a box you can't tick is a signal to
+fix before requesting review, not to hide.
+-->
+
+## What & why
+
+<!-- What does this change do, and what problem does it solve? Link the issue. -->
+
+Closes #
+
+## How it was verified
+
+<!-- The commands you ran and what you observed. "Trust me" isn't verification. -->
+
+## Checklist
+
+- [ ] `cargo fmt -- --check` is clean
+- [ ] `cargo clippy --all-targets -- -D warnings` has zero warnings
+- [ ] `cargo test` passes, and new/changed code is covered (CI gate: ≥ 90%)
+- [ ] Feature-gated change? `bash scripts/feature-matrix.sh` is green
+- [ ] Docs updated in this PR if a documented surface changed (README, ADRs)
+- [ ] Architecturally significant? An ADR is added under `docs/adrs/` and indexed
+- [ ] Commits follow Conventional Commits and are logically scoped
+
+## Notes for reviewers
+
+<!-- Trade-offs, follow-ups, anything you're unsure about. Optional. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@barnett-studios.com**.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ to get set up, the quality bar every change has to clear, and the conventions
 that keep the project consistent.
 
 By contributing you agree that your contributions are licensed under the
-project's [MIT license](LICENSE) (inbound = outbound).
+project's [MIT license](LICENSE) (inbound = outbound). Participation is governed
+by our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Ways to contribute
 
@@ -135,8 +136,9 @@ the code that changes them).
 
 ## Reporting a security issue
 
-Please **don't** open a public issue for a security vulnerability. Report it
-privately via GitHub's [security advisory](https://github.com/Barnett-Studios/cxpak/security/advisories/new)
+Please **don't** open a public issue for a security vulnerability. See
+[SECURITY.md](SECURITY.md) — report it privately via GitHub's
+[security advisory](https://github.com/Barnett-Studios/cxpak/security/advisories/new)
 form so it can be fixed before disclosure.
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,146 @@
+# Contributing to cxpak
+
+Thanks for your interest in cxpak. It's a Rust CLI that indexes a codebase with
+tree-sitter and produces token-budgeted context for LLMs. This guide covers how
+to get set up, the quality bar every change has to clear, and the conventions
+that keep the project consistent.
+
+By contributing you agree that your contributions are licensed under the
+project's [MIT license](LICENSE) (inbound = outbound).
+
+## Ways to contribute
+
+- **Report a bug** — use the [bug report](.github/ISSUE_TEMPLATE/bug_report.yml) form.
+- **Request a feature** — use the [feature request](.github/ISSUE_TEMPLATE/feature_request.yml) form.
+- **Add a language** — cxpak supports 43 languages; adding one is a well-scoped
+  contribution with a [dedicated template](.github/ISSUE_TEMPLATE/language_support.yml)
+  and a recipe [below](#adding-a-language).
+- **Improve docs** — the README, the ADRs, or this guide.
+- **Fix a bug or land a feature** — open an issue first for anything non-trivial
+  so the approach can be agreed before you invest the time.
+
+## Development setup
+
+cxpak is a standard Cargo project. You need a Rust toolchain at or above the
+project's MSRV.
+
+```bash
+# Rust — MSRV is 1.91 (declared as rust-version in Cargo.toml)
+rustup toolchain install stable
+rustup component add rustfmt clippy
+
+# Clone and build
+git clone https://github.com/Barnett-Studios/cxpak
+cd cxpak
+cargo build
+
+# Install the pre-commit hook (runs fmt + clippy + tests before every commit)
+bash scripts/install-hooks.sh
+```
+
+`.mise.toml` pins a toolchain if you use [mise](https://mise.jdx.dev/); it's
+optional — plain `rustup` + `cargo` is fully supported.
+
+## The quality bar
+
+Every PR has to pass the same gates CI enforces. Run them locally before pushing —
+`scripts/install-hooks.sh` wires the first three into a pre-commit hook:
+
+| Gate | Command | Requirement |
+|---|---|---|
+| Format | `cargo fmt -- --check` | clean |
+| Lint | `cargo clippy --all-targets -- -D warnings` | zero warnings |
+| Tests | `cargo test` | all pass |
+| Coverage | tarpaulin (CI) | **≥ 90%** |
+| MSRV | build on 1.91 | compiles |
+| Bench gate | `cargo test --features bench --test bench_gate` | recall gate holds |
+
+Tests are authored **together with** the code they cover — a feature PR without
+tests won't pass the coverage gate, and a bug fix should come with a test that
+fails before the fix and passes after.
+
+### Feature flags
+
+cxpak has several optional features — `visual`, `lsp`, `daemon`, `embeddings`,
+`plugins`, `data-introspect` — on top of the per-language `lang-*` flags. A
+change that touches feature-gated code can compile under the default set and
+still break another combination. Verify the matrix before pushing:
+
+```bash
+bash scripts/feature-matrix.sh          # build + test every meaningful combo
+bash scripts/feature-matrix.sh build    # build only (faster)
+```
+
+If your change needs a live database (the `data-introspect` MySQL/Postgres
+path), its integration tests are `#[ignore]`d and read a DSN from
+`CXPAK_MYSQL_DSN` / `CXPAK_PG_DSN`; run them with `-- --ignored` against a local
+instance.
+
+## Commit conventions
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) with an
+optional scope. Keep the subject in the imperative and reference an ADR when one
+governs the change:
+
+```
+feat(visual): risk treemap colours by percentile, not collapsed score (ADR-0195)
+fix(schema): resolve item imports to file-level edges
+deps: bump mysql_async 0.34 -> 0.37 (security: lru advisory)
+docs: correct LSP method count in the README
+test(intelligence): RED — within-repo risk percentile
+```
+
+Common types: `feat`, `fix`, `docs`, `test`, `refactor`, `perf`, `deps`,
+`chore`. Keep commits logically scoped — the project preserves per-commit
+history on merge, so a clean series reviews far better than one giant commit.
+
+## Architecture Decision Records
+
+Any architecturally significant choice — a new edge type, a scoring-signal
+change, a surface (MCP/HTTP/LSP) addition, a distribution change — gets an ADR
+in [`docs/adrs/`](docs/adrs/). Copy [`docs/adrs/template.md`](docs/adrs/template.md),
+fill in Context / Options considered / Decision / Consequences / Revisit-if,
+take the next number, and add it to [`docs/adrs/INDEX.md`](docs/adrs/INDEX.md).
+Cite the ADR in the code comment and the commit that implements it.
+
+You don't need an ADR for a bug fix, a doc tweak, or a dependency bump.
+
+## Adding a language
+
+The most common structured contribution. To add `foo`:
+
+1. Add `tree-sitter-foo` to `Cargo.toml` as an **optional** dependency.
+2. Add a feature flag `lang-foo = ["dep:tree-sitter-foo"]` and include it in the
+   `default` feature set.
+3. Map the file extension in `src/scanner/mod.rs` → `detect_language()`.
+4. Create `src/parser/languages/foo.rs` implementing the `LanguageSupport` trait.
+5. Register it in `src/parser/languages/mod.rs` and `src/parser/mod.rs`.
+6. Add unit tests in the language file — cover functions, classes/types,
+   imports, and exports for a small real snippet.
+
+Then run `bash scripts/feature-matrix.sh` to confirm the flag composes cleanly.
+Update the language count and list in the README in the same PR (docs land with
+the code that changes them).
+
+## Pull requests
+
+1. Branch off `main` (fetch first — `main` moves).
+2. Keep the PR focused; a smaller diff reviews faster and lands sooner.
+3. Make sure `fmt`, `clippy`, `test`, and the feature matrix are green locally.
+4. Fill in the PR template — the checklist mirrors the CI gates.
+5. Update any documentation your change touches (README, ADRs) in the **same**
+   PR. Changes to a documented surface land with their doc update.
+6. Open the PR against `main`; CI runs the full gate set. A maintainer reviews
+   and merges (preserving history — we don't squash).
+
+## Reporting a security issue
+
+Please **don't** open a public issue for a security vulnerability. Report it
+privately via GitHub's [security advisory](https://github.com/Barnett-Studios/cxpak/security/advisories/new)
+form so it can be fixed before disclosure.
+
+---
+
+Questions that don't fit an issue? Open a
+[discussion](https://github.com/Barnett-Studios/cxpak/discussions). Thanks for
+contributing.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report them privately through GitHub's
+[security advisory form](https://github.com/Barnett-Studios/cxpak/security/advisories/new).
+This lets us investigate and ship a fix before the issue is public.
+
+Please include:
+
+- a description of the vulnerability and its impact,
+- the cxpak version (`cxpak --version`) and how it was built (which features),
+- steps to reproduce, ideally a minimal proof of concept.
+
+We aim to acknowledge a report within a few days and will keep you updated as we
+work on a fix. We follow coordinated disclosure: once a fix is available we'll
+publish an advisory and credit you, unless you'd prefer to remain anonymous.
+
+## Supported versions
+
+cxpak is pre-1.0 in spirit for security backports: fixes land on the **latest
+published release line** (currently `3.1.x`) and are shipped in a new patch
+release. We don't backport security fixes to older minor or major versions —
+upgrade to the latest release to stay covered.
+
+| Version | Supported |
+|---|---|
+| latest `3.1.x` | :white_check_mark: |
+| older releases | :x: (upgrade to latest) |
+
+## Security-relevant surfaces
+
+Most cxpak usage is local and read-only — it indexes files you point it at. The
+surfaces worth a security researcher's attention:
+
+- **HTTP server (`cxpak serve`)** — Bearer-token auth on all `/v1/*` routes when
+  `--token` is set; the token is compared in **constant time**
+  (`subtle::ConstantTimeEq`) to avoid timing side-channels. Binding to a
+  non-loopback address requires a token. `/health` is intentionally open as a
+  liveness probe.
+- **MCP / LSP servers** — stdio transports that index a single repository. They
+  read source and expose analysis; they do not execute project code.
+- **Live database introspection (`data-introspect`, off by default)** — connects
+  to a running Postgres/MySQL over rustls (no OpenSSL), issues a **read-only**
+  session, and **never logs or persists the DSN**. Off unless explicitly built
+  with the feature.
+- **WASM plugin SDK (`plugins`, off by default)** — plugins run in a wasmtime
+  sandbox with a SHA-256 checksum verified before compilation, plus memory and
+  CPU (epoch-interruption) caps. Only load plugins you trust; the checksum pins
+  what you approved, it does not vouch for the author.
+
+## What is not a vulnerability
+
+- Running an untrusted third-party WASM plugin and having it access repository
+  content — that's the plugin's declared capability; vet plugins before loading.
+- Pointing cxpak at a repository you don't control and disliking what it emits —
+  cxpak reports what it finds; it doesn't run the analyzed code.
+
+## Dependencies
+
+The dependency tree is OpenSSL-free (rustls throughout). Dependabot security
+updates are enabled so transitive advisories surface as PRs; where a transitive
+advisory is capped by a parent crate's constraint, we bump the parent.


### PR DESCRIPTION
## What

Adds the full set of contributor-facing community-health files — there were none (only `.github/workflows/`):

- **`CONTRIBUTING.md`** — setup, the quality bar (the exact CI gates: fmt / clippy `-D warnings` / test / **≥90% coverage** / MSRV 1.91 / bench), the feature-flag matrix (`scripts/feature-matrix.sh`), Conventional Commits with real examples from our history, the ADR process, and the **add-a-language recipe**.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — a checklist that mirrors the CI gates + ADR + docs-with-code.
- **`.github/ISSUE_TEMPLATE/`** — GitHub issue *forms* (structured YAML): `bug_report` (version, install method, OS/arch, non-default features, backtrace), `feature_request`, and a cxpak-specific `language_support` form. `config.yml` disables blank issues, routes questions to Discussions, and routes security to a private advisory.
- **`SECURITY.md`** — private-advisory reporting, a latest-release-line (`3.1.x`) support policy, and cxpak's *real* security-relevant surfaces: constant-time bearer auth (`subtle::ConstantTimeEq`), read-only `data-introspect` with DSN never logged, and the checksum-pinned + resource-capped WASM plugin sandbox.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, enforcement contact `conduct@barnett-studios.com`.

## Grounding, not boilerplate

Every claim is pulled from the repo: MSRV from `Cargo.toml`, gates from `ci.yml` + `install-hooks.sh`, features from `Cargo.toml`, commit style from `git log`, the add-a-language steps from internal dev notes (surfaced in-repo for the first time). SECURITY.md describes only surfaces/practices that actually exist — no invented `cargo-audit` gate, no fictional SLA.

## One action before/after merge

`conduct@barnett-studios.com` (the CoC contact) needs to exist / forward to a real inbox — it's published the moment this merges.

## Verification

- All four issue-form YAMLs parse cleanly.
- Docs-only; no code paths touched.