### PR TITLE
fix(mcp): machine-readable retryable/terminal status discriminator (#19)

### DIFF
--- a/docs/adrs/0201-mcp-tool-call-status-discriminator.md
+++ b/docs/adrs/0201-mcp-tool-call-status-discriminator.md
@@ -19,19 +19,19 @@ only tell "retry soon" from "give up" by substring-matching the prose — a word
 change silently breaks retry logic (issue #19 documents a client pinning the exact
 string in a unit test for exactly this reason).
 
-REPRO.md corrects the issue's cited root cause and it was independently
-re-verified: Building/Failed do **not** flow through `mcp_tool_error`
-(serve.rs:4213). They flow through `mcp_tool_result` (serve.rs:2575) and carry
+Empirical reproduction corrects the issue's cited root cause; it was independently
+re-verified: Building/Failed do **not** flow through `mcp_tool_error`.
+They flow through `mcp_tool_result` and carry
 **no `isError`** — so they are indistinguishable not only from each other but from
 a genuine success result, except by prose. Parameter/capability errors *do* set
-`isError:true` (`mcp_tool_error`, serve.rs:4214). The current
-`snapshot_ready_index` collapses both not-ready states into a bare
-`Result<_, String>` (serve.rs:2427), discarding retryable/terminal at the type
+`isError:true` (via `mcp_tool_error`). Before this change,
+`snapshot_ready_index` collapsed both not-ready states into a bare
+`Result<_, String>`, discarding retryable/terminal at the type
 level before the caller can act on it.
 
 Crucially, `mcp_tool_error` is a **shared** helper for many terminal conditions —
 param validation *and* capability-execution failures, invalid regex, IO/render
-errors (serve.rs:2828/2839/3127/3475/3576/4143/4178). So a discriminator cannot be
+errors across many call sites. So a discriminator cannot be
 attached at that helper without mislabelling a disk-write failure as
 "invalid_params". The design must add a positive signal only where one is actually
 missing.
@@ -70,9 +70,11 @@ the cost of being wrong is low (additive field).
 
 Option C. Change `snapshot_ready_index` to `Result<Arc<CodebaseIndex>, NotReady>`
 with `NotReady { Indexing, Failed(String) }` (typed, with a `message()` accessor
-reproducing today's human prose **byte-for-byte**). At the tool-call site
-(serve.rs:2575): `Indexing` → non-error result + `{status:"indexing",
-retryable:true}`; `Failed` → `isError:true` + `{status:"failed",retryable:false}`
+reproducing today's human prose **byte-for-byte**). A single helper renders the
+not-ready envelope, deriving the `(status, retryable, isError)` triple from the
+`NotReady` variant so the two valid combinations are the only representable ones:
+`Indexing` → non-error result + `{status:"indexing", retryable:true}`; `Failed` →
+`isError:true` + `{status:"failed",retryable:false}`
 (an intentional, ADR'd envelope change — Failed is a terminal error state).
 Param/capability/IO errors are untouched. Success is untouched (no
 `structuredContent`). The readiness gate runs before param validation, so during
@@ -93,9 +95,9 @@ not left implicit).
 
 ### Negative
 - One intentional envelope change: Failed now sets `isError:true` (it previously
-  had none). No existing test asserts its absence (verified:
-  tests/mcp_nonblocking_startup.rs:166-181 checks `error==null`+text only), but a
-  client relying on Failed-as-normal-result must adapt. Documented in the PR.
+  had none), so a client relying on Failed-as-normal-result must adapt. Documented
+  in the PR; the end-to-end tests (`tests/mcp_nonblocking_startup.rs`) assert the
+  new `isError`/`structuredContent` envelope directly, not just the prose.
 - During Building, a permanently-malformed call is reported retryable until the
   build finishes; bounded by index build time, then terminal. Documented + tested.
 
@@ -109,3 +111,7 @@ not left implicit).
 - Param validation is hoisted before the readiness gate (a larger dispatch change)
   — then Building would no longer mask param errors and the "self-correcting" note
   is moot.
+- An older MCP client appears that reads only the `content` text block: the spec's
+  SHOULD is to also mirror `structuredContent` there as serialized JSON, but today
+  `text` stays human prose. Add a mirrored JSON content block if such a client needs
+  the marker.

--- a/docs/adrs/0201-mcp-tool-call-status-discriminator.md
+++ b/docs/adrs/0201-mcp-tool-call-status-discriminator.md
@@ -1,0 +1,111 @@
+---
+id: '0201'
+title: Machine-readable MCP tool-call status discriminator (retryable vs terminal)
+status: ACCEPTED
+date: 2026-07-16
+triggered_by: issue #19 (no machine-readable discriminator between retryable indexing and terminal errors)
+loop: planning
+---
+
+# ADR-0201: Machine-readable MCP tool-call status discriminator
+
+## Context
+
+On the MCP surface a `tools/call` that arrives before the background index is
+ready returns a human-readable message with **no machine-readable discriminator**
+distinguishing (a) retryable "indexing in progress", (b) terminal "indexing
+failed — restart", and (c) terminal parameter/capability errors. A client can
+only tell "retry soon" from "give up" by substring-matching the prose — a wording
+change silently breaks retry logic (issue #19 documents a client pinning the exact
+string in a unit test for exactly this reason).
+
+REPRO.md corrects the issue's cited root cause and it was independently
+re-verified: Building/Failed do **not** flow through `mcp_tool_error`
+(serve.rs:4213). They flow through `mcp_tool_result` (serve.rs:2575) and carry
+**no `isError`** — so they are indistinguishable not only from each other but from
+a genuine success result, except by prose. Parameter/capability errors *do* set
+`isError:true` (`mcp_tool_error`, serve.rs:4214). The current
+`snapshot_ready_index` collapses both not-ready states into a bare
+`Result<_, String>` (serve.rs:2427), discarding retryable/terminal at the type
+level before the caller can act on it.
+
+Crucially, `mcp_tool_error` is a **shared** helper for many terminal conditions —
+param validation *and* capability-execution failures, invalid regex, IO/render
+errors (serve.rs:2828/2839/3127/3475/3576/4143/4178). So a discriminator cannot be
+attached at that helper without mislabelling a disk-write failure as
+"invalid_params". The design must add a positive signal only where one is actually
+missing.
+
+Human decision: it picks the on-the-wire contract machine clients will depend on,
+and whether to change an existing envelope (Failed → `isError`).
+
+## Options considered
+
+- **Option A — Stable status strings in `text`, documented:** cheapest; clients
+  still parse prose. Rejected — prose parsing is exactly the fragility the issue is
+  about.
+- **Option B — Tag every result/error with `structuredContent{status,retryable}`,
+  including at the shared `mcp_tool_error` helper:** uniform, but tagging the shared
+  helper labels IO/render/capability failures as `invalid_params` — a factual lie,
+  and `retryable:false` isn't even universally right (a transient IO error could be
+  retryable). Rejected: it bakes a wrong contract into the exhaustive table test.
+- **Option C — Positive machine signal only where it's missing (chosen):** the
+  only state that is "neither an error nor a real answer" is **Building** — it
+  currently has no `isError` and no marker, so a machine client cannot detect it.
+  Give *Building* a positive marker: `mcp_tool_result` +
+  `structuredContent{"status":"indexing","retryable":true}`. Make *Failed* terminal
+  the standard way: `mcp_tool_error` (`isError:true`) +
+  `structuredContent{"status":"failed","retryable":false}`. Leave generic
+  param/capability/IO errors exactly as they are (`isError:true`, no
+  `structuredContent`) — already terminal via the standard flag, and not
+  mislabelled. Success stays a bare `mcp_tool_result` with **no** `structuredContent`.
+  Client rule becomes a clean three-way branch with no prose: `retryable === true`
+  → retry; else `isError === true` → terminal, don't retry; else → success.
+
+`structuredContent` (a first-class MCP `CallToolResult` field) is chosen over
+`_meta` (out-of-band/experimental) as the "the client should read this" channel;
+the cost of being wrong is low (additive field).
+
+## Decision
+
+Option C. Change `snapshot_ready_index` to `Result<Arc<CodebaseIndex>, NotReady>`
+with `NotReady { Indexing, Failed(String) }` (typed, with a `message()` accessor
+reproducing today's human prose **byte-for-byte**). At the tool-call site
+(serve.rs:2575): `Indexing` → non-error result + `{status:"indexing",
+retryable:true}`; `Failed` → `isError:true` + `{status:"failed",retryable:false}`
+(an intentional, ADR'd envelope change — Failed is a terminal error state).
+Param/capability/IO errors are untouched. Success is untouched (no
+`structuredContent`). The readiness gate runs before param validation, so during
+Building even a malformed call reports `retryable:true`; this is bounded and
+self-correcting — once `Ready`, the same call reaches validation and returns the
+terminal `isError:true`, so a conformant client stops retrying (documented + tested,
+not left implicit).
+
+## Consequences
+
+### Positive
+- A client distinguishes retry / restart / fix-your-call via a three-way branch on
+  `retryable`/`isError`, never on prose.
+- No mislabelling: generic terminal errors keep their honest `isError:true` and
+  gain no false `invalid_params` tag.
+- Typed `NotReady` makes the distinction unloseable at the call site; `message()`
+  keeps the Failed prose byte-identical.
+
+### Negative
+- One intentional envelope change: Failed now sets `isError:true` (it previously
+  had none). No existing test asserts its absence (verified:
+  tests/mcp_nonblocking_startup.rs:166-181 checks `error==null`+text only), but a
+  client relying on Failed-as-normal-result must adapt. Documented in the PR.
+- During Building, a permanently-malformed call is reported retryable until the
+  build finishes; bounded by index build time, then terminal. Documented + tested.
+
+### Neutral
+- No new dependency; JSON shape only. No effect on CLI/HTTP/LSP (MCP-specific).
+
+## Revisit if
+- The MCP spec deprecates/relocates `structuredContent` — move the marker.
+- Clients need more states (e.g. a distinct "enriching" while `ReadyEnriched`
+  builds) — extend `status`; `retryable` stays the primary branch key.
+- Param validation is hoisted before the readiness gate (a larger dispatch change)
+  — then Building would no longer mask param errors and the "self-correcting" note
+  is moot.

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -203,3 +203,4 @@
 | [0197](0197-hybrid-interaction-v1-diff.md) | Hybrid interaction model: bounded embed + opt-in Live serve; add /v1/diff | ACCEPTED | 2026-07-11 |
 | [0198](0198-risk-percentile-normalization.md) | Risk normalization = within-repo percentile; one-signal-per-channel encoding | ACCEPTED | 2026-07-11 |
 | [0199](0199-broaden-visual-roundtrip-conformance.md) | Broaden Visual round-trip conformance; no-dead-nav + provenance-completeness gates | ACCEPTED | 2026-07-11 |
+| [0201](0201-mcp-tool-call-status-discriminator.md) | Machine-readable MCP tool-call status discriminator — Building carries `structuredContent{status,retryable}`, Failed→`isError:true` | ACCEPTED | 2026-07-16 |

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -4970,6 +4970,87 @@ mod tests {
         );
     }
 
+    // --- N19.3 (ADR-0201): substring-independence + masked-during-Building ---
+
+    /// A client's retry decision must derive from `structuredContent.retryable`
+    /// alone, never from parsing `text` — swapping the prose out entirely (as a
+    /// reworded/localized message would) leaves the machine signal untouched.
+    #[test]
+    fn retryable_marker_is_independent_of_prose() {
+        let indexing = mcp_tool_status(
+            Some(json!(1)),
+            "some entirely different wording",
+            "indexing",
+            true,
+            false,
+        );
+        assert!(indexing["result"]["isError"].is_null());
+        assert_eq!(indexing["result"]["structuredContent"]["retryable"], true);
+
+        let failed = mcp_tool_status(
+            Some(json!(1)),
+            "yet another wording, still no substring in common",
+            "failed",
+            false,
+            true,
+        );
+        assert_eq!(failed["result"]["isError"], true);
+        assert_eq!(failed["result"]["structuredContent"]["retryable"], false);
+    }
+
+    /// Finding M4: the readiness gate (2571) runs *before* param validation,
+    /// so a permanently-malformed call is masked as retryable while
+    /// `Building`. This is bounded and self-correcting: once `Ready`, the
+    /// same call reaches validation and returns the terminal `isError` with
+    /// no marker, so a conformant client stops retrying.
+    #[test]
+    fn malformed_call_during_building_is_retryable_then_terminal_once_ready() {
+        let malformed = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"cxpak_context","arguments":{"op":"not_a_real_op"}}}"#,
+            "\n",
+        );
+
+        // Building masks the malformed call: retryable, no isError.
+        let building: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Building));
+        let snapshot = make_shared_snapshot();
+        let mut out: Vec<u8> = Vec::new();
+        mcp_stdio_loop_readiness(
+            std::path::Path::new("/tmp"),
+            &building,
+            &snapshot,
+            std::io::Cursor::new(malformed.as_bytes()),
+            &mut out,
+        )
+        .expect("loop");
+        let resp: Value = serde_json::from_slice(&out).unwrap();
+        assert!(
+            resp["result"]["isError"].is_null(),
+            "malformed call must be masked as retryable while Building"
+        );
+        assert_eq!(resp["result"]["structuredContent"]["retryable"], true);
+
+        // Once Ready, the same call reaches param validation: terminal, no marker.
+        let ready: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Ready(Arc::new(
+            make_test_index(),
+        ))));
+        let snapshot2 = make_shared_snapshot();
+        let mut out2: Vec<u8> = Vec::new();
+        mcp_stdio_loop_readiness(
+            std::path::Path::new("/tmp"),
+            &ready,
+            &snapshot2,
+            std::io::Cursor::new(malformed.as_bytes()),
+            &mut out2,
+        )
+        .expect("loop");
+        let resp2: Value = serde_json::from_slice(&out2).unwrap();
+        assert_eq!(resp2["result"]["isError"], true);
+        assert!(
+            resp2["result"]["structuredContent"].is_null(),
+            "once Ready the terminal param error carries no marker"
+        );
+    }
+
     // --- Health handler ---
 
     #[test]

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2601,12 +2601,7 @@ pub fn mcp_stdio_loop_readiness(
                     Ok(idx) => {
                         handle_tool_call(id, tool_name, &arguments, &idx, repo_path, snapshot)
                     }
-                    Err(NotReady::Indexing) => {
-                        mcp_tool_status(id, &NotReady::Indexing.message(), "indexing", true, false)
-                    }
-                    Err(status @ NotReady::Failed(_)) => {
-                        mcp_tool_status(id, &status.message(), "failed", false, true)
-                    }
+                    Err(not_ready) => mcp_tool_status(id, &not_ready),
                 }
             }
             _ => mcp_error_response(id, -32601, "Method not found"),
@@ -4265,15 +4260,20 @@ fn mcp_tool_error(id: Option<Value>, text: &str) -> Value {
 /// Generic param/capability/IO errors keep using `mcp_tool_error` and gain
 /// no `structuredContent` — see ADR-0201 on why the shared helper is not
 /// tagged.
-fn mcp_tool_status(
-    id: Option<Value>,
-    text: &str,
-    status: &str,
-    retryable: bool,
-    is_error: bool,
-) -> Value {
+/// Render a not-ready state as a `tools/call` result envelope (ADR-0201).
+///
+/// The `(status, retryable, is_error)` triple is derived from the typed
+/// [`NotReady`] variant, not passed in — so the only two representable
+/// envelopes are the two valid ones (retryable `indexing` / terminal
+/// `failed`); a caller cannot spell an invalid combination like
+/// `(retryable: true, is_error: true)`.
+fn mcp_tool_status(id: Option<Value>, not_ready: &NotReady) -> Value {
+    let (status, retryable, is_error) = match not_ready {
+        NotReady::Indexing => ("indexing", true, false),
+        NotReady::Failed(_) => ("failed", false, true),
+    };
     let mut result = json!({
-        "content": [{"type": "text", "text": text}],
+        "content": [{"type": "text", "text": not_ready.message()}],
         "structuredContent": {"status": status, "retryable": retryable}
     });
     if is_error {
@@ -4831,21 +4831,31 @@ mod tests {
     /// `structuredContent` names the state a client branches on.
     #[test]
     fn mcp_tool_status_indexing_marks_retryable_no_error() {
-        let resp = mcp_tool_status(Some(json!(1)), "still indexing", "indexing", true, false);
+        let resp = mcp_tool_status(Some(json!(1)), &NotReady::Indexing);
         assert!(resp["result"]["isError"].is_null());
         assert_eq!(resp["result"]["structuredContent"]["status"], "indexing");
         assert_eq!(resp["result"]["structuredContent"]["retryable"], true);
-        assert_eq!(resp["result"]["content"][0]["text"], "still indexing");
+        assert_eq!(
+            resp["result"]["content"][0]["text"],
+            INDEXING_IN_PROGRESS_MESSAGE
+        );
     }
 
     /// `mcp_tool_status` for the terminal case: `isError:true` plus
     /// `retryable:false` — a client stops retrying without parsing prose.
     #[test]
     fn mcp_tool_status_failed_marks_terminal_retryable_false() {
-        let resp = mcp_tool_status(Some(json!(1)), "build failed", "failed", false, true);
+        let resp = mcp_tool_status(
+            Some(json!(1)),
+            &NotReady::Failed("build failed".to_string()),
+        );
         assert_eq!(resp["result"]["isError"], true);
         assert_eq!(resp["result"]["structuredContent"]["status"], "failed");
         assert_eq!(resp["result"]["structuredContent"]["retryable"], false);
+        assert!(resp["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("build failed"));
     }
 
     /// Envelope table (ADR-0201): a `tools/call` while `Building` returns a
@@ -4973,32 +4983,32 @@ mod tests {
     // --- N19.3 (ADR-0201): substring-independence + masked-during-Building ---
 
     /// A client's retry decision must derive from `structuredContent.retryable`
-    /// alone, never from parsing `text` — swapping the prose out entirely (as a
-    /// reworded/localized message would) leaves the machine signal untouched.
+    /// alone, never from parsing `text`. The variant now fixes both the marker
+    /// and the prose, so the marker is independent of the *variable* part — the
+    /// `Failed` message: two failures with no substring in common both mark
+    /// terminal, and `Indexing` marks retryable.
     #[test]
     fn retryable_marker_is_independent_of_prose() {
-        let indexing = mcp_tool_status(
+        let failed_a = mcp_tool_status(
             Some(json!(1)),
-            "some entirely different wording",
-            "indexing",
-            true,
-            false,
+            &NotReady::Failed("some wording".to_string()),
         );
+        let failed_b = mcp_tool_status(
+            Some(json!(1)),
+            &NotReady::Failed("yet another, no substring in common".to_string()),
+        );
+        assert_eq!(failed_a["result"]["isError"], true);
+        assert_eq!(failed_a["result"]["structuredContent"]["retryable"], false);
+        assert_eq!(failed_b["result"]["isError"], true);
+        assert_eq!(failed_b["result"]["structuredContent"]["retryable"], false);
+
+        let indexing = mcp_tool_status(Some(json!(1)), &NotReady::Indexing);
         assert!(indexing["result"]["isError"].is_null());
         assert_eq!(indexing["result"]["structuredContent"]["retryable"], true);
-
-        let failed = mcp_tool_status(
-            Some(json!(1)),
-            "yet another wording, still no substring in common",
-            "failed",
-            false,
-            true,
-        );
-        assert_eq!(failed["result"]["isError"], true);
-        assert_eq!(failed["result"]["structuredContent"]["retryable"], false);
     }
 
-    /// Finding M4: the readiness gate (2571) runs *before* param validation,
+    /// Finding M4: the readiness gate (the `snapshot_ready_index` match in the
+    /// `tools/call` dispatch arm) runs *before* param validation,
     /// so a permanently-malformed call is masked as retryable while
     /// `Building`. This is bounded and self-correcting: once `Ready`, the
     /// same call reaches validation and returns the terminal `isError` with

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2416,15 +2416,44 @@ fn publish_ready_enriched(
     }
 }
 
+/// Typed not-ready state for a `tools/call` that arrives before the base
+/// index is available (ADR-0201). Distinguishes **retryable** (`Indexing`)
+/// from **terminal** (`Failed`) at the type level, so the tool-call site can
+/// attach the right machine-readable discriminator instead of re-deriving it
+/// from prose.
+#[derive(Debug)]
+enum NotReady {
+    /// Background base-index build in progress; the call is retryable.
+    Indexing,
+    /// The background build failed; not retryable without a server restart.
+    Failed(String),
+}
+
+impl NotReady {
+    /// Human-readable status text — byte-identical to the pre-ADR-0201
+    /// prose, so the `text` field of the tool-call envelope never changes
+    /// even though the caller now branches on `structuredContent` instead of
+    /// parsing this string.
+    fn message(&self) -> String {
+        match self {
+            NotReady::Indexing => INDEXING_IN_PROGRESS_MESSAGE.to_string(),
+            NotReady::Failed(msg) => format!(
+                "cxpak: indexing failed and no context is available: {msg}. \
+                 Check the cxpak server logs, then restart the MCP server to retry."
+            ),
+        }
+    }
+}
+
 /// Snapshot the base index if the background build has finished, else return the
-/// human-readable status to surface as a tool `result` (Task R0).
+/// typed not-ready state to surface as a tool `result` (Task R0, ADR-0201).
 ///
 /// Cloning the `Ready` `Arc` under a brief read lock is O(1); the lock is
 /// released before the (possibly long-running) tool handler runs, so tool calls
 /// never hold the readiness lock across a handler and never starve the
 /// background publish. A poisoned lock is recovered rather than propagated so a
 /// panicked reader cannot wedge the server.
-fn snapshot_ready_index(readiness: &SharedReadiness) -> Result<Arc<CodebaseIndex>, String> {
+fn snapshot_ready_index(readiness: &SharedReadiness) -> Result<Arc<CodebaseIndex>, NotReady> {
     let guard = match readiness.read() {
         Ok(g) => g,
         Err(poisoned) => poisoned.into_inner(),
@@ -2433,11 +2462,8 @@ fn snapshot_ready_index(readiness: &SharedReadiness) -> Result<Arc<CodebaseIndex
         // `ReadyEnriched` (R-E1) serves exactly like `Ready`; the attached
         // embedding index rides on the snapshotted `CodebaseIndex`.
         IndexReadiness::Ready(idx) | IndexReadiness::ReadyEnriched(idx) => Ok(Arc::clone(idx)),
-        IndexReadiness::Building => Err(INDEXING_IN_PROGRESS_MESSAGE.to_string()),
-        IndexReadiness::Failed(msg) => Err(format!(
-            "cxpak: indexing failed and no context is available: {msg}. \
-             Check the cxpak server logs, then restart the MCP server to retry."
-        )),
+        IndexReadiness::Building => Err(NotReady::Indexing),
+        IndexReadiness::Failed(msg) => Err(NotReady::Failed(msg.clone())),
     }
 }
 
@@ -2572,7 +2598,7 @@ pub fn mcp_stdio_loop_readiness(
                     Ok(idx) => {
                         handle_tool_call(id, tool_name, &arguments, &idx, repo_path, snapshot)
                     }
-                    Err(status) => mcp_tool_result(id, &status),
+                    Err(status) => mcp_tool_result(id, &status.message()),
                 }
             }
             _ => mcp_error_response(id, -32601, "Method not found"),
@@ -4609,8 +4635,9 @@ mod tests {
         let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Building));
         let status =
             snapshot_ready_index(&readiness).expect_err("building must not yield an index");
-        assert_eq!(status, INDEXING_IN_PROGRESS_MESSAGE);
-        assert!(status.contains("indexing in progress"));
+        assert!(matches!(status, NotReady::Indexing));
+        assert_eq!(status.message(), INDEXING_IN_PROGRESS_MESSAGE);
+        assert!(status.message().contains("indexing in progress"));
     }
 
     /// `Failed` surfaces the build error text as a clear status.
@@ -4619,8 +4646,53 @@ mod tests {
         let readiness: SharedReadiness =
             Arc::new(RwLock::new(IndexReadiness::Failed("boom".to_string())));
         let status = snapshot_ready_index(&readiness).expect_err("failed must not yield an index");
-        assert!(status.contains("indexing failed"));
-        assert!(status.contains("boom"));
+        assert!(matches!(status, NotReady::Failed(_)));
+        assert!(status.message().contains("indexing failed"));
+        assert!(status.message().contains("boom"));
+    }
+
+    /// N19.1 (ADR-0201): `snapshot_ready_index` returns a **typed** `NotReady`
+    /// — not a bare `String` — so retryable (`Indexing`) and terminal
+    /// (`Failed`) are distinguishable at the type level, before any caller
+    /// gets a chance to collapse them into indistinguishable prose.
+    #[test]
+    fn snapshot_ready_index_typed_states() {
+        let building: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Building));
+        assert!(matches!(
+            snapshot_ready_index(&building),
+            Err(NotReady::Indexing)
+        ));
+
+        let failed: SharedReadiness =
+            Arc::new(RwLock::new(IndexReadiness::Failed("boom".to_string())));
+        match snapshot_ready_index(&failed) {
+            Err(NotReady::Failed(msg)) => assert_eq!(msg, "boom"),
+            other => panic!("expected Err(NotReady::Failed(\"boom\")), got {other:?}"),
+        }
+
+        let ready: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Ready(Arc::new(
+            make_test_index(),
+        ))));
+        assert!(snapshot_ready_index(&ready).is_ok());
+
+        let ready_enriched: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::ReadyEnriched(
+            Arc::new(make_test_index()),
+        )));
+        assert!(snapshot_ready_index(&ready_enriched).is_ok());
+    }
+
+    /// N19.1 (ADR-0201, finding m9): `NotReady::message()` must reproduce
+    /// today's human prose byte-for-byte — including the `Failed` wrapper —
+    /// so existing prose-matching assertions/clients don't regress even
+    /// though the type now carries a machine-readable discriminator too.
+    #[test]
+    fn notready_message_byte_identical() {
+        assert_eq!(NotReady::Indexing.message(), INDEXING_IN_PROGRESS_MESSAGE);
+        assert_eq!(
+            NotReady::Failed("boom".to_string()).message(),
+            "cxpak: indexing failed and no context is available: boom. \
+             Check the cxpak server logs, then restart the MCP server to retry."
+        );
     }
 
     /// A tool call BEFORE the index is ready returns a JSON-RPC `result`

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2593,12 +2593,20 @@ pub fn mcp_stdio_loop_readiness(
                 let arguments = params.get("arguments").cloned().unwrap_or(json!({}));
                 // Gate on background-build readiness (Task R0): once ready, run
                 // against the base index exactly as before; before ready, return
-                // a graceful tool `result` (retry/failed status), never an error.
+                // a graceful tool result carrying a machine-readable status
+                // discriminator (ADR-0201) — retryable `Indexing`, terminal
+                // `Failed` — never a bare error indistinguishable from a
+                // param/capability failure.
                 match snapshot_ready_index(readiness) {
                     Ok(idx) => {
                         handle_tool_call(id, tool_name, &arguments, &idx, repo_path, snapshot)
                     }
-                    Err(status) => mcp_tool_result(id, &status.message()),
+                    Err(NotReady::Indexing) => {
+                        mcp_tool_status(id, &NotReady::Indexing.message(), "indexing", true, false)
+                    }
+                    Err(status @ NotReady::Failed(_)) => {
+                        mcp_tool_status(id, &status.message(), "failed", false, true)
+                    }
                 }
             }
             _ => mcp_error_response(id, -32601, "Method not found"),
@@ -4248,6 +4256,36 @@ fn mcp_tool_error(id: Option<Value>, text: &str) -> Value {
     })
 }
 
+/// Tool-call result carrying a machine-readable status discriminator
+/// (ADR-0201, Option C). Used only for the two states that need a positive
+/// signal beyond plain success/error: `Indexing` (retryable, no `isError`)
+/// and `Failed` (terminal, `isError: true`). `structuredContent` carries
+/// `{"status": status, "retryable": retryable}`; `text` stays the same
+/// human prose either helper would have produced, so display is unaffected.
+/// Generic param/capability/IO errors keep using `mcp_tool_error` and gain
+/// no `structuredContent` — see ADR-0201 on why the shared helper is not
+/// tagged.
+fn mcp_tool_status(
+    id: Option<Value>,
+    text: &str,
+    status: &str,
+    retryable: bool,
+    is_error: bool,
+) -> Value {
+    let mut result = json!({
+        "content": [{"type": "text", "text": text}],
+        "structuredContent": {"status": status, "retryable": retryable}
+    });
+    if is_error {
+        result["isError"] = json!(true);
+    }
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+}
+
 /// Process a batch of watcher changes, updating the shared index.
 ///
 /// Public so integration tests can drive the watcher invalidation contract
@@ -4785,6 +4823,151 @@ mod tests {
         // `stats` reports the two indexed files — proves it ran against the index.
         let parsed: Value = serde_json::from_str(text).expect("stats result is JSON");
         assert_eq!(parsed["files"], 2, "stats should reflect 2 indexed files");
+    }
+
+    // --- N19.2 (ADR-0201): machine-readable status discriminator ---
+
+    /// `mcp_tool_status` for the retryable case: no `isError`, and
+    /// `structuredContent` names the state a client branches on.
+    #[test]
+    fn mcp_tool_status_indexing_marks_retryable_no_error() {
+        let resp = mcp_tool_status(Some(json!(1)), "still indexing", "indexing", true, false);
+        assert!(resp["result"]["isError"].is_null());
+        assert_eq!(resp["result"]["structuredContent"]["status"], "indexing");
+        assert_eq!(resp["result"]["structuredContent"]["retryable"], true);
+        assert_eq!(resp["result"]["content"][0]["text"], "still indexing");
+    }
+
+    /// `mcp_tool_status` for the terminal case: `isError:true` plus
+    /// `retryable:false` — a client stops retrying without parsing prose.
+    #[test]
+    fn mcp_tool_status_failed_marks_terminal_retryable_false() {
+        let resp = mcp_tool_status(Some(json!(1)), "build failed", "failed", false, true);
+        assert_eq!(resp["result"]["isError"], true);
+        assert_eq!(resp["result"]["structuredContent"]["status"], "failed");
+        assert_eq!(resp["result"]["structuredContent"]["retryable"], false);
+    }
+
+    /// Envelope table (ADR-0201): a `tools/call` while `Building` returns a
+    /// non-error result carrying `{status:"indexing", retryable:true}`.
+    #[test]
+    fn tool_call_envelope_indexing_carries_retryable_marker() {
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Building));
+        let snapshot = make_shared_snapshot();
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"cxpak_context","arguments":{"op":"stats"}}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        mcp_stdio_loop_readiness(
+            std::path::Path::new("/tmp"),
+            &readiness,
+            &snapshot,
+            std::io::Cursor::new(input.as_bytes()),
+            &mut out,
+        )
+        .expect("loop");
+        let resp: Value = serde_json::from_slice(&out).unwrap();
+        assert!(resp["error"].is_null());
+        assert!(
+            resp["result"]["isError"].is_null(),
+            "Building must not be isError"
+        );
+        assert_eq!(resp["result"]["structuredContent"]["status"], "indexing");
+        assert_eq!(resp["result"]["structuredContent"]["retryable"], true);
+    }
+
+    /// Envelope table (ADR-0201): a `tools/call` while `Failed` returns
+    /// `isError:true` plus `{status:"failed", retryable:false}` — an
+    /// intentional envelope change from the prior no-marker/no-isError shape.
+    #[test]
+    fn tool_call_envelope_failed_carries_terminal_marker() {
+        let readiness: SharedReadiness =
+            Arc::new(RwLock::new(IndexReadiness::Failed("boom".to_string())));
+        let snapshot = make_shared_snapshot();
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"cxpak_context","arguments":{"op":"stats"}}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        mcp_stdio_loop_readiness(
+            std::path::Path::new("/tmp"),
+            &readiness,
+            &snapshot,
+            std::io::Cursor::new(input.as_bytes()),
+            &mut out,
+        )
+        .expect("loop");
+        let resp: Value = serde_json::from_slice(&out).unwrap();
+        assert!(
+            resp["error"].is_null(),
+            "must not be a protocol-level error"
+        );
+        assert_eq!(resp["result"]["isError"], true);
+        assert_eq!(resp["result"]["structuredContent"]["status"], "failed");
+        assert_eq!(resp["result"]["structuredContent"]["retryable"], false);
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(text.contains("boom"));
+    }
+
+    /// A generic param error (MAJOR-2/finding): `isError:true` via the shared
+    /// `mcp_tool_error` helper, with NO `structuredContent` — it must not be
+    /// mislabelled with the Building/Failed discriminator.
+    #[test]
+    fn tool_call_envelope_param_error_has_no_structured_content() {
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Ready(Arc::new(
+            make_test_index(),
+        ))));
+        let snapshot = make_shared_snapshot();
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"cxpak_context","arguments":{"op":"not_a_real_op"}}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        mcp_stdio_loop_readiness(
+            std::path::Path::new("/tmp"),
+            &readiness,
+            &snapshot,
+            std::io::Cursor::new(input.as_bytes()),
+            &mut out,
+        )
+        .expect("loop");
+        let resp: Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(resp["result"]["isError"], true);
+        assert!(
+            resp["result"]["structuredContent"].is_null(),
+            "generic param errors must not carry the Building/Failed marker"
+        );
+    }
+
+    /// Success stays a bare result — no `structuredContent` at all, so a
+    /// client's three-way branch (`retryable` / `isError` / else success)
+    /// never mistakes a real answer for a status marker.
+    #[test]
+    fn tool_call_envelope_success_has_no_structured_content() {
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Ready(Arc::new(
+            make_test_index(),
+        ))));
+        let snapshot = make_shared_snapshot();
+        let input = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"cxpak_context","arguments":{"op":"stats"}}}"#,
+            "\n",
+        );
+        let mut out: Vec<u8> = Vec::new();
+        mcp_stdio_loop_readiness(
+            std::path::Path::new("/tmp"),
+            &readiness,
+            &snapshot,
+            std::io::Cursor::new(input.as_bytes()),
+            &mut out,
+        )
+        .expect("loop");
+        let resp: Value = serde_json::from_slice(&out).unwrap();
+        assert!(resp["result"]["isError"].is_null());
+        assert!(
+            resp["result"]["structuredContent"].is_null(),
+            "success must carry no structuredContent"
+        );
     }
 
     // --- Health handler ---

--- a/tests/mcp_nonblocking_startup.rs
+++ b/tests/mcp_nonblocking_startup.rs
@@ -158,6 +158,20 @@ fn before_ready_tool_call_returns_graceful_status() {
         text.contains("indexing in progress"),
         "expected a retry status, got: {text}"
     );
+    // ADR-0201 envelope: Building is retryable and NOT an error — assert the
+    // machine-readable discriminator end-to-end, not just the prose.
+    assert!(
+        responses[2]["result"]["isError"].is_null(),
+        "Building must not be isError"
+    );
+    assert_eq!(
+        responses[2]["result"]["structuredContent"]["status"],
+        "indexing"
+    );
+    assert_eq!(
+        responses[2]["result"]["structuredContent"]["retryable"],
+        true
+    );
 }
 
 /// A failed background build surfaces a clear status on tool calls rather than
@@ -178,4 +192,15 @@ fn failed_build_surfaces_status_without_crashing() {
         .unwrap();
     assert!(text.contains("indexing failed"), "got: {text}");
     assert!(text.contains("scanner exploded"), "got: {text}");
+    // ADR-0201 envelope: Failed is terminal — isError:true and retryable:false,
+    // the intentional envelope change this PR introduces, asserted end-to-end.
+    assert_eq!(responses[0]["result"]["isError"], true);
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["status"],
+        "failed"
+    );
+    assert_eq!(
+        responses[0]["result"]["structuredContent"]["retryable"],
+        false
+    );
 }


### PR DESCRIPTION
Fixes #19.

## Problem (with a correction to the issue's root-cause trace)
On the MCP surface, a `tools/call` before the background index is ready returned a human-readable message with **no machine-readable discriminator** between retryable ("indexing in progress"), terminal ("indexing failed — restart"), and terminal param/capability errors. Clients could only branch by substring-matching prose.

**Reproduction corrected the issue's cited root cause.** The issue states Building/Failed return `isError:true` via `mcp_tool_error` (serve.rs:4213). They do **not** — they went through `mcp_tool_result` (serve.rs:2575) with **no `isError` at all**, indistinguishable even from a genuine success result except by prose. Param/capability errors *do* set `isError:true`. So the real defect was broader, and the fix targets a different location than the issue names.

| Condition | Before | After |
|---|---|---|
| Building (retryable) | `result` (no `isError`) | `result` + `structuredContent{status:"indexing",retryable:true}` |
| Failed (terminal) | `result` (no `isError`) | `isError:true` + `structuredContent{status:"failed",retryable:false}` |
| Param/capability error | `isError:true` | `isError:true` (unchanged, no marker) |
| Success | `result` | `result` (unchanged, no marker) |

Client rule now: `retryable===true` → retry; else `isError===true` → terminal; else success. No prose parsing.

## Design — ADR-0201 (in this PR)
Only **Building** lacked a machine signal, so only Building gains one. The shared `mcp_tool_error` helper is **deliberately not tagged** — it backs many terminal errors (param/capability/regex/IO/render), and a `status:"invalid_params"` tag there would mislabel a disk-write failure. `snapshot_ready_index` now returns a typed `Result<_, NotReady>` (`Indexing`/`Failed`), with `message()` reproducing the prior prose **byte-for-byte** (the `text` field never changes). One intentional envelope change: `Failed` now sets `isError:true` (it's a terminal error state) — breaks no existing test (verified).

## Tests (RED→GREEN, real behavioral)
Typed-state mapping; `message()` byte-parity; envelope table driven through the real `mcp_stdio_loop_readiness` (JSON in/out) asserting Indexing/Failed markers, **param-error has no `structuredContent`**, **success has no `structuredContent`**; substring-independence (client branches on `retryable` with prose swapped); masked-during-Building → retryable, then terminal once Ready.

- `cargo test --workspace --features daemon`: 3014 passed, 3 ignored, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `cargo fmt --check`: clean.
- Golden fixture `spa_output_matches_golden_fixture`: byte-identical.
- Independent pre-PR review: no blockers; every new branch covered by an explicit behavioral test.

## Manual QA (real MCP stdio path)
```
BUILDING envelope: {"isError":"<absent>","structuredContent":{"status":"indexing","retryable":true}}
```
Confirmed against a warm `serve --mcp` session; param-error stays `isError:true` with no marker.

https://claude.ai/code/session_019hJMLmPVoGS2FeUUX4w4Jz
