### PR TITLE
fix(graph): node enumeration op + subgraph seed validation + id-format docs (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Your AI tool gets five intent-parameterized tools; each selects a capability via
 | Intent tool | Capabilities (via `op`) |
 |----------|-------|
 | **`cxpak_context`** | `context`, `retrieval`, `search`, `overview`, `stats`, `briefing`, `pack_context`, `context_for_task` |
-| **`cxpak_graph`** | `graph` (`node`/`neighbors`/`path`/`subgraph`), `trace`, `blast_radius`, `call_graph`, `dead_code`, `api_surface`, `data_flow`, `cross_lang`, `predict` |
+| **`cxpak_graph`** | `graph` (`nodes`/`node`/`neighbors`/`path`/`subgraph`), `trace`, `blast_radius`, `call_graph`, `dead_code`, `api_surface`, `data_flow`, `cross_lang`, `predict` |
 | **`cxpak_data`** | `data` (indexed / live schema) |
 | **`cxpak_review`** | `review`, `diff`, `verify` |
 | **`cxpak_insight`** | `health`, `risks`, `architecture`, `conventions`, `security_surface`, `drift`, `visual`, `onboard` |
@@ -289,9 +289,10 @@ cxpak understands your data layer and uses it to build a richer dependency graph
 
 ## Graph query and export
 
-Query the typed dependency graph directly -- four primitives (`node`, `neighbors`, `path`, `subgraph`), identical across MCP, HTTP, LSP, and CLI. Edges carry a typed `edge_type` and a confidence marker; inferred (heuristic) edges are surfaced as such.
+Query the typed dependency graph directly -- five primitives (`nodes`, `node`, `neighbors`, `path`, `subgraph`), identical across MCP, HTTP, LSP, and CLI. Edges carry a typed `edge_type` and a confidence marker; inferred (heuristic) edges are surfaced as such. `nodes` enumerates every valid id with no arguments -- the way to discover ids (they're repo-relative file paths) before calling the others; `subgraph` reports any seed that isn't a real node in `unknown_seeds` rather than echoing it back as one.
 
 ```bash
+cxpak graph nodes .
 cxpak graph neighbors --id src/index/graph.rs .
 cxpak graph path --from src/main.rs --to src/output/mod.rs .
 cxpak graph subgraph --seeds src/scanner/mod.rs,src/parser/mod.rs --depth 2 .

--- a/docs/MIGRATION-3.0.md
+++ b/docs/MIGRATION-3.0.md
@@ -88,7 +88,7 @@ does not collide with the top-level `op` discriminator:
 
 | `op` | Sub-selector param | Values | Notes |
 |---|---|---|---|
-| `graph` (under `cxpak_graph`) | `graph_op` | `node`, `neighbors`, `path`, `subgraph` | The typed graph-query capability (ADR-0176). `neighbors`/`path`/`subgraph` output carries per-edge `edge_type` + `confidence` (`inferred`) — ADR-0175. |
+| `graph` (under `cxpak_graph`) | `graph_op` | `nodes`, `node`, `neighbors`, `path`, `subgraph` | The typed graph-query capability (ADR-0176). `neighbors`/`path`/`subgraph` output carries per-edge `edge_type` + `confidence` (`inferred`) — ADR-0175. `nodes` (added in 3.1.1, ADR-0202) takes no params and enumerates every node id; `subgraph` reports non-existent seeds in `unknown_seeds` rather than echoing them as real nodes. |
 | `retrieval` (under `cxpak_context`) | `retrieval_op` | `search`, `references`, `expand` | The iterative retrieval capability (ADR-0180). Distinct from the legacy `search` op. |
 
 The `data` op (under `cxpak_data`) returns the indexed data layer (`SchemaIndex`:

--- a/docs/adrs/0202-graph-node-enumeration-and-seed-validation.md
+++ b/docs/adrs/0202-graph-node-enumeration-and-seed-validation.md
@@ -13,7 +13,7 @@ loop: planning
 
 The deterministic graph-query surface (`intelligence::graph_query`, ADR-0176;
 projected to CLI `graph`, HTTP `/v1/graph`, LSP `cxpak/graph`, MCP `cxpak_graph`)
-cannot be bootstrapped by a fresh consumer (issue #20, reproduced in REPRO.md):
+cannot be bootstrapped by a fresh consumer (issue #20, reproduced empirically):
 
 1. **No enumerate op.** `execute` (graph_query.rs:398) offers only
    node|neighbors|path|subgraph; `node`/`neighbors` require an `--id`, `path`

--- a/docs/adrs/0202-graph-node-enumeration-and-seed-validation.md
+++ b/docs/adrs/0202-graph-node-enumeration-and-seed-validation.md
@@ -1,0 +1,102 @@
+---
+id: '0202'
+title: Graph query — node-enumeration op, subgraph seed validation, documented id format
+status: ACCEPTED
+date: 2026-07-16
+triggered_by: issue #20 (no node-id enumeration op; subgraph echoes non-existent seeds)
+loop: planning
+---
+
+# ADR-0202: Graph query — node enumeration, seed validation, id-format docs
+
+## Context
+
+The deterministic graph-query surface (`intelligence::graph_query`, ADR-0176;
+projected to CLI `graph`, HTTP `/v1/graph`, LSP `cxpak/graph`, MCP `cxpak_graph`)
+cannot be bootstrapped by a fresh consumer (issue #20, reproduced in REPRO.md):
+
+1. **No enumerate op.** `execute` (graph_query.rs:398) offers only
+   node|neighbors|path|subgraph; `node`/`neighbors` require an `--id`, `path`
+   requires `--from/--to`, and there is no op that lists valid ids. The id format
+   (repo-relative file path) is undocumented — `--help` says only "Node id".
+2. **`subgraph` doesn't validate seeds.** `subgraph` (graph_query.rs:323) inserts
+   every seed into the BFS frontier at distance 0 without `graph.contains_node`
+   (lines 331-333), so a non-existent seed is **echoed back as a node** with no
+   error — inconsistent with `node` (line 189, which reports `exists:false`), and
+   the one free-form-id op cannot be used to confirm ids because it accepts
+   garbage silently.
+
+Human decision: it adds a capability to a semver-relevant multi-surface core and
+picks a seed-validation contract (drop vs. error vs. annotate) that machine
+clients will code against.
+
+## Options considered
+
+### Enumerate op
+- **Option A — `subgraph` with no seeds dumps the whole graph:** no new op, but
+  overloads `subgraph`'s meaning and still returns edges/BFS structure when a
+  caller just wants a flat id list; awkward for "what ids exist?".
+- **Option B — new `nodes` op (chosen):** `pub fn nodes(graph) -> NodeList` — all
+  node ids, sorted (BTree order → deterministic), each with in/out degree. A
+  `"nodes"` arm in `execute`, projected to every surface (CLI `graph nodes`,
+  `/v1/graph`, `cxpak/graph`, MCP `graph_op:"nodes"`). One capability, four
+  projections, no new MCP tool (≤8 holds). Clear, discoverable, matches `node`'s
+  vocabulary. **No prefix/`focus` filter in 3.1.1** — the issue asked only for
+  enumeration; a filter would need a new CLI `--prefix` arg + a capability param
+  entry + a filtered cross-surface test to be reachable and advertised, none of
+  which the bare enumerate op requires (YAGNI; add later if a large-monorepo
+  consumer needs it, alongside paging).
+
+### Seed validation for `subgraph`
+- **Option A — error on any unknown seed:** strict; but a mixed real+bogus seed
+  set then yields nothing, and a client probing ids gets an error instead of data.
+- **Option B — silently drop unknown seeds:** clean output, but a caller can't
+  tell a typo from an empty region — the same silent-failure class the issue is
+  about, just inverted.
+- **Option C — partition: real seeds drive the BFS, unknown seeds returned in a
+  new `unknown_seeds:[id]` field, never emitted as `nodes` (chosen):** consistent
+  with `node --id` (`exists:false`), non-breaking (adds a field; real-seed
+  `nodes`/`edges` semantics unchanged), and still usable to probe ids (submit a
+  guess, read whether it landed in `unknown_seeds`). A strict client can treat a
+  non-empty `unknown_seeds` as an error; a lenient one ignores it. The new field is
+  `#[serde(default)]` so JSON produced by an older cxpak still deserializes. Note
+  the honest meaning: "unknown" = **not an edge-participating node** — a real file
+  with zero resolved edges (the ADR-0203 `main.rs` class) also lands here, exactly
+  as `node --id` reports `exists:false` for it; this is documented, not a
+  contradiction.
+
+### Id-format documentation
+- Update `graph --help` for `--id`/`--seeds`/`--from`/`--to` to "repo-relative
+  file path (enumerate with `graph nodes`)"; mirror in the MCP/HTTP schema
+  descriptions and the CLAUDE.md command list (docs-with-code, same commit).
+
+## Decision
+
+`nodes` enumerate op (Option B) + `subgraph` seed partition into `unknown_seeds`
+(Option C) + documented id format across `--help`, schema, and CLAUDE.md. All in
+the single graph core with the four projections; total order path-asc throughout.
+The `use <pkg>::` self-package resolution gap (why cxpak's own `main.rs` reports
+`exists:false`) is out of scope here — see ADR-0203.
+
+## Consequences
+
+### Positive
+- A fresh consumer can enumerate ids (`graph nodes`) and gets honest feedback on
+  unknown seeds — the surface is self-bootstrapping.
+- `subgraph` is now consistent with `node` on unknown ids.
+- Deterministic and cross-surface single-source by construction (ADR-0153/0176).
+
+### Negative
+- `Subgraph` gains a field (`unknown_seeds`) — additive, but every surface's
+  golden/round-trip expectations for `subgraph` update in lockstep.
+- Slightly more output for `nodes` on large repos; bounded by file count and
+  prefix-filterable.
+
+### Neutral
+- No new dependency. Graph path only — the visual golden fixture is unaffected.
+
+## Revisit if
+- The id scheme ever stops being the repo-relative path (e.g. symbol-level nodes)
+  — then `nodes`/`node`/`--help` id docs move together.
+- A consumer needs streaming enumeration for very large monorepos — add paging to
+  `nodes` rather than dumping.

--- a/docs/adrs/0203-self-package-import-resolution-deferred.md
+++ b/docs/adrs/0203-self-package-import-resolution-deferred.md
@@ -12,14 +12,14 @@ loop: planning
 ## Context
 
 Issue #20 flags (as "secondary") that cxpak's own `src/main.rs` reports
-`exists:false` from `graph node`. REPRO.md explains it: the dependency graph
+`exists:false` from `graph node`. The cause: the dependency graph
 stores only edge-participating nodes (`contains_node`, core_graph/graph.rs:240),
 and cxpak's `main.rs` imports only `clap::` (external) and `cxpak::cli` /
 `cxpak::commands` — via the **package name `cxpak::`**. The Rust import resolver
 (`src/index/graph.rs`) resolves `crate::`/`super::`/`self::` relative paths to
 local files but treats a `<package-name>::` path as an external crate, so
 `main.rs` gets zero resolved edges and is not a node. On a repo whose `main.rs`
-uses `use crate::foo` the same path resolves fine (REPRO.md tiny-repo: `main.rs`
+uses `use crate::foo` the same path resolves fine (a tiny repro's `main.rs`:
 exists:true, out:1). So this is a **narrow self-package (binary→library
 cross-crate) resolution gap**, not a graph-model bug.
 

--- a/docs/adrs/0203-self-package-import-resolution-deferred.md
+++ b/docs/adrs/0203-self-package-import-resolution-deferred.md
@@ -1,0 +1,72 @@
+---
+id: '0203'
+title: Self-package import resolution (use <own-crate>::) — deferred, limitation documented
+status: ACCEPTED
+date: 2026-07-16
+triggered_by: issue #20 (secondary — src/main.rs reports exists:false)
+loop: planning
+---
+
+# ADR-0203: Self-package import resolution — deferred
+
+## Context
+
+Issue #20 flags (as "secondary") that cxpak's own `src/main.rs` reports
+`exists:false` from `graph node`. REPRO.md explains it: the dependency graph
+stores only edge-participating nodes (`contains_node`, core_graph/graph.rs:240),
+and cxpak's `main.rs` imports only `clap::` (external) and `cxpak::cli` /
+`cxpak::commands` — via the **package name `cxpak::`**. The Rust import resolver
+(`src/index/graph.rs`) resolves `crate::`/`super::`/`self::` relative paths to
+local files but treats a `<package-name>::` path as an external crate, so
+`main.rs` gets zero resolved edges and is not a node. On a repo whose `main.rs`
+uses `use crate::foo` the same path resolves fine (REPRO.md tiny-repo: `main.rs`
+exists:true, out:1). So this is a **narrow self-package (binary→library
+cross-crate) resolution gap**, not a graph-model bug.
+
+Human decision: whether to change edge extraction — a high-blast-radius core —
+inside a patch release, for a cosmetic gain on entry-point files.
+
+## Options considered
+
+- **Option A — Resolve `use <own-crate>::path` to the local crate root in 3.1.1:**
+  makes `main.rs` a node. But import resolution feeds the dependency graph, which
+  feeds PageRank, blast radius, health, api_surface and the SPA — every consumer.
+  New edges shift PageRank on essentially every repo, and the determinism golden
+  fixture (`spa_golden.html`) plus the recall-regression gate (ADR-0172) would
+  both need re-baselining. High risk for a bugfix patch; a maintainer optimizing
+  for correctness-of-entry-points could still want it.
+- **Option B — Document the limitation, defer the fix (chosen):** record that
+  `use <package-name>::` from a binary crate is not resolved to local files
+  (only `crate::`/`super::`/`self::` are), keep 3.1.1 focused on the usability
+  fixes (ADR-0202), and carry the resolution work as its own change with its own
+  golden/recall re-baseline and tests. Honest and low-risk.
+- **Option C — Special-case only the crate-root entry files (main.rs/lib.rs):**
+  narrower than A but still perturbs the graph and still needs re-baselining, for
+  even less generality. Worst of both.
+
+## Decision
+
+Option B. Ship ADR-0202's usability fixes in 3.1.1; do **not** change import
+resolution. Document the `use <package-name>::` limitation (in the graph docs /
+`graph nodes` help note). The `nodes` enumerate op (ADR-0202) already removes the
+practical sting — a consumer lists real ids instead of guessing `main.rs`.
+
+## Consequences
+
+### Positive
+- 3.1.1 stays a low-risk patch; the golden fixture and recall gate are untouched.
+- The gap is documented, not silent; `graph nodes` makes it a non-issue in
+  practice.
+
+### Negative
+- `graph node --id src/main.rs` still reports `exists:false` on cxpak-like repos
+  until the deferred change lands — surprising for entry-point files.
+
+### Neutral
+- No code change in 3.1.1 for this item; docs-only.
+
+## Revisit if
+- A general Cargo package-name → crate-root resolution is implemented (with its
+  own golden + recall re-baseline and tests) — then this decision is superseded.
+- Entry-point node coverage becomes load-bearing for a downstream feature
+  (e.g. onboarding order, dead-code entry rules ADR-0131) rather than cosmetic.

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -203,3 +203,5 @@
 | [0197](0197-hybrid-interaction-v1-diff.md) | Hybrid interaction model: bounded embed + opt-in Live serve; add /v1/diff | ACCEPTED | 2026-07-11 |
 | [0198](0198-risk-percentile-normalization.md) | Risk normalization = within-repo percentile; one-signal-per-channel encoding | ACCEPTED | 2026-07-11 |
 | [0199](0199-broaden-visual-roundtrip-conformance.md) | Broaden Visual round-trip conformance; no-dead-nav + provenance-completeness gates | ACCEPTED | 2026-07-11 |
+| [0202](0202-graph-node-enumeration-and-seed-validation.md) | Graph query — `nodes` enumeration op + `subgraph` unknown-seed partition + documented id format | ACCEPTED | 2026-07-16 |
+| [0203](0203-self-package-import-resolution-deferred.md) | Self-package import resolution (`use <own-crate>::`) — deferred, limitation documented | ACCEPTED | 2026-07-16 |

--- a/src/capability/mod.rs
+++ b/src/capability/mod.rs
@@ -295,13 +295,16 @@ fn build_catalog() -> Vec<Capability> {
             s(true, false, false, true, false),
         ),
         // ---- Intent::Graph — query the dependency graph --------------------
-        // `graph` (B1, ADR-0176) — node/neighbors/path/subgraph over one core;
-        // CLI `cxpak graph`, HTTP `/v1/graph`, LSP `cxpak/graph`, MCP op. Its
+        // `graph` (B1, ADR-0176; `nodes` + `unknown_seeds` added by ADR-0202)
+        // — nodes/node/neighbors/path/subgraph over one core; CLI `cxpak
+        // graph`, HTTP `/v1/graph`, LSP `cxpak/graph`, MCP op. Its
         // neighbors/path/subgraph output carries per-edge `edge_type` +
         // `confidence` (`inferred`) — the A3 (ADR-0175) edge-confidence surface.
         cap(
             "graph",
-            "Query the typed dependency graph: node, neighbors, path, subgraph.",
+            "Query the typed dependency graph: nodes (enumerate all ids), \
+             node, neighbors, path, subgraph (unknown seeds reported in \
+             `unknown_seeds`, never echoed as nodes).",
             Intent::Graph,
             &[
                 "graph_op",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -169,23 +169,29 @@ pub enum Commands {
         #[command(subcommand)]
         subcommand: PluginSubcommand,
     },
-    /// Query the dependency graph: node, neighbors, path, subgraph
+    /// Query the dependency graph: nodes, node, neighbors, path, subgraph
     Graph {
-        /// Operation: node | neighbors | path | subgraph
+        /// Operation: nodes | node | neighbors | path | subgraph. `nodes`
+        /// takes no other params — it lists every valid id.
         op: String,
-        /// Node id (for `node` and `neighbors`)
+        /// Node id for `node`/`neighbors` — repo-relative file path
+        /// (enumerate with `graph nodes`)
         #[arg(long)]
         id: Option<String>,
-        /// Source node (for `path`)
+        /// Source node for `path` — repo-relative file path (enumerate with
+        /// `graph nodes`)
         #[arg(long)]
         from: Option<String>,
-        /// Target node (for `path`)
+        /// Target node for `path` — repo-relative file path (enumerate with
+        /// `graph nodes`)
         #[arg(long)]
         to: Option<String>,
         /// Neighbor direction: out | in | both
         #[arg(long, default_value = "both")]
         direction: String,
-        /// Seed nodes for `subgraph` (comma-separated)
+        /// Seed nodes for `subgraph` (comma-separated) — repo-relative file
+        /// paths (enumerate with `graph nodes`); unknown ids are reported in
+        /// `unknown_seeds`, not treated as real nodes
         #[arg(long, value_delimiter = ',')]
         seeds: Vec<String>,
         /// Hop depth for `subgraph`

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1113,12 +1113,16 @@ async fn v1_predict_handler(
     })?))
 }
 
-/// `POST /v1/graph` — deterministic graph-query (cxpak 3.0.0 Task B1).
+/// `POST /v1/graph` — deterministic graph-query (cxpak 3.0.0 Task B1; `nodes`
+/// added by ADR-0202).
 ///
-/// The request body is `{ "op": "node"|"neighbors"|"path"|"subgraph", ... }`;
-/// the remaining fields are the op's params. The body is passed straight to the
-/// single core [`crate::intelligence::graph_query::execute`] — this surface only
-/// adapts transport, it does not re-derive. Malformed requests (missing `op`,
+/// The request body is
+/// `{ "op": "nodes"|"node"|"neighbors"|"path"|"subgraph", ... }`; the
+/// remaining fields are the op's params (`nodes` takes none — it enumerates
+/// every node id, the way to discover valid ids for the other ops). The body
+/// is passed straight to the single core
+/// [`crate::intelligence::graph_query::execute`] — this surface only adapts
+/// transport, it does not re-derive. Malformed requests (missing `op`,
 /// missing a required param, bad direction, unknown op) map to `400`.
 async fn v1_graph_handler(
     axum::extract::State(index): axum::extract::State<SharedIndex>,
@@ -2814,10 +2818,11 @@ fn dispatch_capability_op(
     match op {
         // ---- Newly MCP-surfaced cores (B1 graph, C1 retrieval, C3 data) -----
         "graph" => {
-            // `graph_op` selects node/neighbors/path/subgraph — renamed so it
-            // does not collide with the intent-tool `op` discriminator. The
-            // neighbors/path/subgraph output carries per-edge `edge_type` +
-            // `confidence` (`inferred`) — A3 (ADR-0175) edge confidence.
+            // `graph_op` selects nodes/node/neighbors/path/subgraph (`nodes`
+            // added by ADR-0202) — renamed so it does not collide with the
+            // intent-tool `op` discriminator. The neighbors/path/subgraph
+            // output carries per-edge `edge_type` + `confidence` (`inferred`)
+            // — A3 (ADR-0175) edge confidence.
             let sub = args
                 .get("graph_op")
                 .or_else(|| args.get("query"))

--- a/src/intelligence/graph_query.rs
+++ b/src/intelligence/graph_query.rs
@@ -89,6 +89,13 @@ pub struct NodeInfo {
     pub in_degree: usize,
 }
 
+/// Result of [`nodes`]: every node id known to the graph.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NodeList {
+    /// Every node id, sorted, each with its existence and degree.
+    pub nodes: Vec<NodeInfo>,
+}
+
 /// One neighbour of a node, with the connecting edge described honestly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct NeighborEdge {
@@ -140,13 +147,19 @@ pub struct PathResult {
 /// Result of [`subgraph`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Subgraph {
-    /// The seed node ids, sorted and de-duplicated.
+    /// The real (edge-participating) seed node ids, sorted and de-duplicated.
+    /// Unknown seeds are excluded here — see `unknown_seeds`.
     pub seeds: Vec<String>,
     pub depth: usize,
-    /// All nodes within `depth` hops of any seed (both directions), sorted.
+    /// All nodes within `depth` hops of any real seed (both directions), sorted.
     pub nodes: Vec<String>,
     /// The induced edges among those nodes, sorted by `(from, to, edge_type)`.
     pub edges: Vec<GraphEdge>,
+    /// Seeds that are not edge-participating nodes (`graph.contains_node` is
+    /// false), sorted. Never emitted as `nodes` — consistent with `node --id`
+    /// reporting `exists:false` for the same id (ADR-0202).
+    #[serde(default)]
+    pub unknown_seeds: Vec<String>,
 }
 
 /// Error from [`execute`] when a request is malformed. Surfaces map these to
@@ -170,7 +183,7 @@ impl fmt::Display for GraphQueryError {
             GraphQueryError::InvalidParam(m) => write!(f, "invalid parameter: {m}"),
             GraphQueryError::UnknownOp(op) => write!(
                 f,
-                "unknown graph op `{op}`; expected one of node|neighbors|path|subgraph"
+                "unknown graph op `{op}`; expected one of node|neighbors|path|subgraph|nodes"
             ),
         }
     }
@@ -189,6 +202,20 @@ pub fn node(graph: &DependencyGraph, id: &str) -> NodeInfo {
         exists: graph.contains_node(id),
         out_degree: graph.dependencies(id).map(|s| s.len()).unwrap_or(0),
         in_degree: graph.dependents(id).len(),
+    }
+}
+
+/// `nodes()` — every node id known to the graph (the union of `edges` and
+/// `reverse_edges` keys), sorted with in/out degree. No prefix/focus filter
+/// (ADR-0202): the bare enumerate op is all issue #20 asked for.
+pub fn nodes(graph: &DependencyGraph) -> NodeList {
+    let ids: BTreeSet<&String> = graph
+        .edges
+        .keys()
+        .chain(graph.reverse_edges.keys())
+        .collect();
+    NodeList {
+        nodes: ids.into_iter().map(|id| node(graph, id)).collect(),
     }
 }
 
@@ -324,11 +351,18 @@ pub fn subgraph(graph: &DependencyGraph, seeds: &[&str], depth: usize) -> Subgra
     // De-duplicated, sorted seeds → deterministic regardless of caller order.
     let sorted_seeds: BTreeSet<String> = seeds.iter().map(|s| s.to_string()).collect();
 
+    // Partition into real (edge-participating) seeds, which drive the BFS,
+    // and unknown seeds, which are reported honestly rather than echoed back
+    // as a node — consistent with `node --id` (ADR-0202).
+    let (real_seeds, unknown_seeds): (BTreeSet<String>, BTreeSet<String>) = sorted_seeds
+        .into_iter()
+        .partition(|s| graph.contains_node(s));
+
     // Multi-source bounded BFS, both directions, visiting each node once at its
     // minimum hop distance. `dist` keys form the included node set.
     let mut dist: BTreeMap<String, usize> = BTreeMap::new();
     let mut queue: VecDeque<String> = VecDeque::new();
-    for s in &sorted_seeds {
+    for s in &real_seeds {
         dist.insert(s.clone(), 0);
         queue.push_back(s.clone());
     }
@@ -377,10 +411,11 @@ pub fn subgraph(graph: &DependencyGraph, seeds: &[&str], depth: usize) -> Subgra
     }
 
     Subgraph {
-        seeds: sorted_seeds.into_iter().collect(),
+        seeds: real_seeds.into_iter().collect(),
         depth,
         nodes,
         edges,
+        unknown_seeds: unknown_seeds.into_iter().collect(),
     }
 }
 
@@ -391,16 +426,23 @@ pub fn subgraph(graph: &DependencyGraph, seeds: &[&str], depth: usize) -> Subgra
 /// Execute a graph-query `op` with JSON `params` against `graph`, returning the
 /// deterministic JSON result. This is the one core all four surfaces invoke.
 ///
-/// * `node`      — params: `{ "id": string }`
+/// * `nodes` — params: none. Lists every node id (repo-relative file path)
+///   known to the graph, sorted, each with in/out degree — the way to
+///   discover valid ids for the other ops (ADR-0202).
+/// * `node` — params: `{ "id": string }` (id: repo-relative file path,
+///   enumerate with `nodes`)
 /// * `neighbors` — params: `{ "id": string, "direction"?: "out"|"in"|"both" }`
-/// * `path`      — params: `{ "from": string, "to": string }`
-/// * `subgraph`  — params: `{ "seeds": [string], "depth"?: number }`
+/// * `path` — params: `{ "from": string, "to": string }`
+/// * `subgraph` — params: `{ "seeds": [string], "depth"?: number }`; unknown
+///   seeds are partitioned into `unknown_seeds`, never emitted as `nodes`
+///   (ADR-0202)
 pub fn execute(
     graph: &DependencyGraph,
     op: &str,
     params: &Value,
 ) -> Result<Value, GraphQueryError> {
     match op {
+        "nodes" => Ok(to_json(&nodes(graph))),
         "node" => {
             let id = req_str(params, "id")?;
             Ok(to_json(&node(graph, id)))
@@ -635,6 +677,93 @@ mod tests {
     }
 
     #[test]
+    fn nodes_enumerates_all_ids_sorted_with_degree() {
+        let g = linear(); // a -> b -> c
+        let list = nodes(&g);
+        let ids: Vec<&str> = list.nodes.iter().map(|n| n.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["a", "b", "c"],
+            "sorted, every edge-participating id"
+        );
+        for n in &list.nodes {
+            assert!(n.exists, "every enumerated node exists by construction");
+        }
+        let a = list.nodes.iter().find(|n| n.id == "a").unwrap();
+        assert_eq!(a.out_degree, 1);
+        assert_eq!(a.in_degree, 0);
+        let b = list.nodes.iter().find(|n| n.id == "b").unwrap();
+        assert_eq!(b.out_degree, 1);
+        assert_eq!(b.in_degree, 1);
+        let c = list.nodes.iter().find(|n| n.id == "c").unwrap();
+        assert_eq!(c.out_degree, 0);
+        assert_eq!(c.in_degree, 1);
+    }
+
+    #[test]
+    fn nodes_diamond_union_of_edges_and_reverse_edges() {
+        let g = diamond(); // a->b, a->c, b->d, c->d
+        let list = nodes(&g);
+        let ids: Vec<&str> = list.nodes.iter().map(|n| n.id.as_str()).collect();
+        assert_eq!(ids, vec!["a", "b", "c", "d"]);
+        let d = list.nodes.iter().find(|n| n.id == "d").unwrap();
+        assert_eq!(d.out_degree, 0);
+        assert_eq!(d.in_degree, 2);
+    }
+
+    #[test]
+    fn nodes_empty_graph_is_empty() {
+        let g = DependencyGraph::new();
+        let list = nodes(&g);
+        assert!(list.nodes.is_empty());
+    }
+
+    #[test]
+    fn subgraph_partitions_unknown_seeds() {
+        let g = linear(); // a -> b -> c
+        let sg = subgraph(&g, &["a", "bogus"], 1);
+        assert_eq!(sg.seeds, vec!["a"], "unknown seed excluded from seeds too");
+        assert_eq!(sg.unknown_seeds, vec!["bogus"]);
+        assert_eq!(
+            sg.nodes,
+            vec!["a", "b"],
+            "bogus seed never emitted as a node"
+        );
+    }
+
+    #[test]
+    fn subgraph_all_unknown_empty_nodes() {
+        let g = linear();
+        let sg = subgraph(&g, &["totally", "bogus"], 1);
+        assert_eq!(sg.seeds, Vec::<String>::new());
+        assert_eq!(sg.unknown_seeds, vec!["bogus", "totally"], "sorted");
+        assert!(sg.nodes.is_empty());
+        assert!(sg.edges.is_empty());
+    }
+
+    #[test]
+    fn subgraph_mixed_seeds() {
+        let g = diamond(); // a->b, a->c, b->d, c->d
+        let sg = subgraph(&g, &["a", "nope", "d"], 1);
+        assert_eq!(sg.seeds, vec!["a", "d"]);
+        assert_eq!(sg.unknown_seeds, vec!["nope"]);
+        // depth 1 from a (out: b,c) and d (in: b,c) both real seeds.
+        assert_eq!(sg.nodes, vec!["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn subgraph_real_but_edgeless_seed() {
+        // A file with zero resolved edges is not a node (contains_node is
+        // false), matching `node --id` exists:false for the same case
+        // (ADR-0203 main.rs class) — it lands in unknown_seeds too.
+        let g = linear();
+        let sg = subgraph(&g, &["a", "src/main.rs"], 1);
+        assert_eq!(sg.seeds, vec!["a"]);
+        assert_eq!(sg.unknown_seeds, vec!["src/main.rs"]);
+        assert_eq!(sg.nodes, vec!["a", "b"]);
+    }
+
+    #[test]
     fn execute_node_roundtrips() {
         let g = linear();
         let v = execute(&g, "node", &json!({"id": "b"})).unwrap();
@@ -656,6 +785,29 @@ mod tests {
         assert_eq!(p["nodes"], json!(["a", "b", "d"]));
         let s = execute(&g, "subgraph", &json!({"seeds": ["a"], "depth": 1})).unwrap();
         assert_eq!(s["depth"], json!(1));
+    }
+
+    #[test]
+    fn execute_nodes_op_returns_sorted_list() {
+        let g = linear();
+        let v = execute(&g, "nodes", &json!({})).unwrap();
+        let ids: Vec<&str> = v["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|n| n["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn execute_unknown_op_lists_nodes() {
+        let g = linear();
+        let err = execute(&g, "frobnicate", &json!({})).unwrap_err();
+        assert!(
+            err.to_string().contains("nodes"),
+            "UnknownOp message must name `nodes` as a valid op: {err}"
+        );
     }
 
     #[test]

--- a/src/intelligence/graph_query.rs
+++ b/src/intelligence/graph_query.rs
@@ -1,6 +1,6 @@
 //! Deterministic graph-query core (cxpak 3.0.0 Task B1).
 //!
-//! Four primitives — [`node`], [`neighbors`], [`path`], [`subgraph`] — answer
+//! Five primitives — [`node`], [`nodes`], [`neighbors`], [`path`], [`subgraph`] — answer
 //! structural questions over the typed [`DependencyGraph`]. This is the SINGLE
 //! source of truth for graph-query: every surface (MCP `cxpak_graph`, LSP
 //! `cxpak/graph`, CLI `graph`, HTTP `/v1/graph`) calls [`execute`] and reshapes

--- a/src/intelligence/graph_query.rs
+++ b/src/intelligence/graph_query.rs
@@ -183,7 +183,7 @@ impl fmt::Display for GraphQueryError {
             GraphQueryError::InvalidParam(m) => write!(f, "invalid parameter: {m}"),
             GraphQueryError::UnknownOp(op) => write!(
                 f,
-                "unknown graph op `{op}`; expected one of node|neighbors|path|subgraph|nodes"
+                "unknown graph op `{op}`; expected one of nodes|node|neighbors|path|subgraph"
             ),
         }
     }
@@ -853,6 +853,7 @@ mod tests {
     fn outputs_are_byte_deterministic() {
         let g = diamond();
         let ops = [
+            ("nodes", json!({})),
             ("node", json!({"id": "a"})),
             ("neighbors", json!({"id": "a", "direction": "both"})),
             ("path", json!({"from": "a", "to": "d"})),

--- a/src/lsp/methods.rs
+++ b/src/lsp/methods.rs
@@ -639,18 +639,21 @@ pub fn handle_custom_method(
             "edges": index.call_graph.edges,
             "total": index.call_graph.edges.len(),
         }))),
-        // Deterministic graph-query (cxpak 3.0.0 Task B1). `params` is
-        // `{ "op": "node"|"neighbors"|"path"|"subgraph", ... }`; it is passed
-        // straight to the single core `graph_query::execute`. A missing/invalid
-        // op or required param maps to JSON-RPC InternalError (-32603), matching
-        // the other required-param methods (trace/search/predict/dataFlow).
+        // Deterministic graph-query (cxpak 3.0.0 Task B1; `nodes` added by
+        // ADR-0202). `params` is
+        // `{ "op": "nodes"|"node"|"neighbors"|"path"|"subgraph", ... }`; it is
+        // passed straight to the single core `graph_query::execute`. A
+        // missing/invalid op or required param maps to JSON-RPC InternalError
+        // (-32603), matching the other required-param methods
+        // (trace/search/predict/dataFlow).
         "cxpak/graph" => {
             let op = params
                 .get("op")
                 .and_then(|v| v.as_str())
                 .ok_or_else(|| {
                     LspMethodError::Internal(
-                        "cxpak/graph requires 'op' (node|neighbors|path|subgraph) param".into(),
+                        "cxpak/graph requires 'op' (nodes|node|neighbors|path|subgraph) param"
+                            .into(),
                     )
                 })?
                 .to_string();

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -821,3 +821,97 @@ fn test_diff_invalid_since_fails() {
         .assert()
         .failure();
 }
+
+/// A repo with a real cross-file edge (`src/main.rs` `use crate::`-imports
+/// `src/helper_mod.rs`), so `graph nodes`/`subgraph` have something to
+/// enumerate. `make_test_repo`'s `main.rs` has no imports at all.
+fn make_graph_test_repo() -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+    let sig = git2::Signature::now("Test", "t@t.com").unwrap();
+
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(
+        dir.path().join("src/main.rs"),
+        "mod helper_mod;\nuse crate::helper_mod::helper;\nfn main() { helper(); }\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("src/helper_mod.rs"), "pub fn helper() {}\n").unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let mut index = repo.index().unwrap();
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+
+    dir
+}
+
+/// Issue #20 (ADR-0202): `graph nodes` enumerates every node id with no
+/// `--id`/`--seeds`/`--from`/`--to` required — the bootstrap op for a fresh
+/// consumer who doesn't yet know a valid id.
+#[test]
+fn graph_cli_nodes_op() {
+    let repo = make_graph_test_repo();
+    Command::new(assert_cmd::cargo_bin!("cxpak"))
+        .args(["graph", "nodes", repo.path().to_str().unwrap()])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("src/main.rs"))
+        .stdout(predicate::str::contains("src/helper_mod.rs"));
+}
+
+/// Negative-path regression: `node` must still require `--id` after the
+/// `nodes` op is added (op stays a free-form positional; only `nodes` skips
+/// the id requirement).
+#[test]
+fn graph_cli_node_still_requires_id() {
+    let repo = make_test_repo();
+    Command::new(assert_cmd::cargo_bin!("cxpak"))
+        .args(["graph", "node", repo.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("id"));
+}
+
+/// Negative-path regression: same as above for `neighbors`.
+#[test]
+fn graph_cli_neighbors_still_requires_id() {
+    let repo = make_test_repo();
+    Command::new(assert_cmd::cargo_bin!("cxpak"))
+        .args(["graph", "neighbors", repo.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("id"));
+}
+
+/// Issue #20 (ADR-0202): `subgraph` partitions a non-existent seed into
+/// `unknown_seeds` instead of echoing it back as a node.
+#[test]
+fn graph_cli_subgraph_reports_unknown_seed() {
+    let repo = make_graph_test_repo();
+    Command::new(assert_cmd::cargo_bin!("cxpak"))
+        .args([
+            "graph",
+            "subgraph",
+            "--seeds",
+            "totally/bogus.xyz",
+            repo.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"unknown_seeds\""))
+        .stdout(predicate::str::contains("totally/bogus.xyz"))
+        .stdout(
+            predicate::str::contains("\"nodes\": []").or(predicate::str::contains("\"nodes\":[]")),
+        );
+}

--- a/tests/graph_query_surfaces.rs
+++ b/tests/graph_query_surfaces.rs
@@ -6,11 +6,14 @@
 //! (`/v1/graph`) surfaces call the same `execute`, so identical output is a
 //! structural consequence; `tests/surface_conformance.rs` covers the projection
 //! framework for all four declared surfaces.
-#![cfg(feature = "lsp")]
+#![cfg(all(feature = "daemon", feature = "lsp"))]
 
+use axum::body::Body;
+use axum::http::Request;
 use cxpak::index::CodebaseIndex;
 use cxpak::intelligence::graph_query;
 use serde_json::json;
+use tower::ServiceExt;
 
 /// A tiny two-file Rust index where `main.rs` imports `lib.rs`, so the graph has
 /// a real edge to query.
@@ -91,4 +94,197 @@ fn core_is_byte_deterministic_over_real_index() {
             "subgraph output must be byte-identical every run"
         );
     }
+}
+
+// ---------------------------------------------------------------------------
+// N20.5 — cross-surface parity for `nodes` and `subgraph.unknown_seeds`
+// (ADR-0202, issue #20). CLI, HTTP `/v1/graph`, LSP `cxpak/graph`, and MCP
+// `cxpak_graph` all route through the single `graph_query::execute` core, so
+// this is a structural consequence, not independent logic — the test proves
+// it holds rather than re-deriving it. Compared on PARSED `serde_json::Value`
+// (never raw bytes): HTTP returns compact JSON, CLI/MCP pretty-print, so a
+// byte comparison would fail on whitespace alone despite identical content.
+
+/// A real on-disk git repo with a genuine cross-file `use crate::` edge (the
+/// CLI leg re-scans from disk; the ADR-0203 `main.rs` self-package gap means
+/// a bare `mod` declaration resolves no edges, so the import must be
+/// `crate::`-qualified for `main.rs` to be a node at all).
+fn fixture_repo() -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().unwrap();
+    let repo = git2::Repository::init(dir.path()).unwrap();
+    let sig = git2::Signature::now("Test", "t@t.com").unwrap();
+
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(
+        dir.path().join("src/main.rs"),
+        "mod helper_mod;\nuse crate::helper_mod::helper;\nfn main() { helper(); }\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("src/helper_mod.rs"), "pub fn helper() {}\n").unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[package]\nname = \"test\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let mut index = repo.index().unwrap();
+    index
+        .add_all(["*"].iter(), git2::IndexAddOption::DEFAULT, None)
+        .unwrap();
+    index.write().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .unwrap();
+
+    dir
+}
+
+/// Run `cxpak graph <op> [args...] <path>` as a real subprocess and parse
+/// stdout as JSON.
+fn cli_graph(path: &std::path::Path, extra_args: &[&str]) -> serde_json::Value {
+    let mut args: Vec<&str> = vec!["graph"];
+    args.extend_from_slice(extra_args);
+    let path_str = path.to_str().unwrap();
+    args.push(path_str);
+    let output = std::process::Command::new(assert_cmd::cargo_bin!("cxpak"))
+        .args(&args)
+        .output()
+        .expect("cxpak graph subprocess must run");
+    assert!(
+        output.status.success(),
+        "cxpak graph {extra_args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|e| panic!("cxpak graph {extra_args:?} stdout not JSON ({e})"))
+}
+
+/// Drive the MCP `tools/call` channel and parse the embedded JSON payload out
+/// of the JSON-RPC envelope (`result.content[0].text`, per MCP spec).
+fn call_mcp_graph(idx: &CodebaseIndex, args: serde_json::Value) -> serde_json::Value {
+    let snapshot: cxpak::commands::serve::SharedSnapshot =
+        std::sync::Arc::new(std::sync::RwLock::new(None));
+    let envelope = cxpak::commands::serve::handle_tool_call(
+        Some(json!(1)),
+        "cxpak_graph",
+        &args,
+        idx,
+        std::path::Path::new("/tmp"),
+        &snapshot,
+    );
+    let text = envelope["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| {
+            panic!("MCP cxpak_graph envelope missing result.content[0].text: {envelope}")
+        });
+    serde_json::from_str(text)
+        .unwrap_or_else(|e| panic!("MCP cxpak_graph content text not JSON ({e}): {text}"))
+}
+
+async fn call_http_graph(idx: CodebaseIndex, body: serde_json::Value) -> serde_json::Value {
+    let shared = std::sync::Arc::new(std::sync::RwLock::new(std::sync::Arc::new(idx)));
+    let path = std::sync::Arc::new(std::path::PathBuf::from("/tmp"));
+    let app = cxpak::commands::serve::build_router_for_test(shared, path);
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/graph")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn nodes_op_is_identical_across_cli_http_lsp_mcp() {
+    let repo = fixture_repo();
+    let idx = cxpak::commands::serve::build_index(repo.path()).expect("index builds");
+
+    let cli = cli_graph(repo.path(), &["nodes"]);
+    let http = call_http_graph(idx.clone(), json!({"op": "nodes"})).await;
+    let lsp = cxpak::lsp::methods::handle_custom_method(
+        "cxpak/graph",
+        json!({"op": "nodes"}),
+        &idx,
+        std::path::Path::new("/tmp"),
+    )
+    .unwrap()
+    .expect("Some");
+    let mcp = call_mcp_graph(&idx, json!({"op": "graph", "graph_op": "nodes"}));
+
+    assert_eq!(cli, http, "CLI vs HTTP `nodes` parity");
+    assert_eq!(http, lsp, "HTTP vs LSP `nodes` parity");
+    assert_eq!(lsp, mcp, "LSP vs MCP `nodes` parity");
+    // Sanity: this isn't an accidental all-empty pass.
+    assert!(
+        !cli["nodes"].as_array().unwrap().is_empty(),
+        "fixture must have at least one node"
+    );
+}
+
+#[tokio::test]
+async fn subgraph_unknown_seeds_is_identical_across_cli_http_lsp_mcp() {
+    let repo = fixture_repo();
+    let idx = cxpak::commands::serve::build_index(repo.path()).expect("index builds");
+
+    let cli = cli_graph(
+        repo.path(),
+        &["subgraph", "--seeds", "totally/bogus.xyz,src/main.rs"],
+    );
+    let http = call_http_graph(
+        idx.clone(),
+        json!({"op": "subgraph", "seeds": ["totally/bogus.xyz", "src/main.rs"], "depth": 1}),
+    )
+    .await;
+    let lsp = cxpak::lsp::methods::handle_custom_method(
+        "cxpak/graph",
+        json!({"op": "subgraph", "seeds": ["totally/bogus.xyz", "src/main.rs"], "depth": 1}),
+        &idx,
+        std::path::Path::new("/tmp"),
+    )
+    .unwrap()
+    .expect("Some");
+    let mcp = call_mcp_graph(
+        &idx,
+        json!({"op": "graph", "graph_op": "subgraph", "seeds": ["totally/bogus.xyz", "src/main.rs"], "depth": 1}),
+    );
+
+    assert_eq!(cli, http, "CLI vs HTTP `subgraph` parity");
+    assert_eq!(http, lsp, "HTTP vs LSP `subgraph` parity");
+    assert_eq!(lsp, mcp, "LSP vs MCP `subgraph` parity");
+    assert_eq!(
+        cli["unknown_seeds"],
+        json!(["totally/bogus.xyz"]),
+        "bogus seed must land in unknown_seeds on every surface"
+    );
+    assert!(
+        !cli["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|n| n == "totally/bogus.xyz"),
+        "the bogus seed must never be emitted as a node"
+    );
+}
+
+#[test]
+fn graph_capability_description_mentions_nodes_and_unknown_seeds() {
+    let graph_cap = cxpak::capability::catalog()
+        .iter()
+        .find(|c| c.id == "graph")
+        .expect("graph capability is registered");
+    assert!(
+        graph_cap.summary.contains("nodes"),
+        "graph capability description must mention the `nodes` op: {}",
+        graph_cap.summary
+    );
+    assert!(
+        graph_cap.summary.contains("unknown_seeds"),
+        "graph capability description must mention `unknown_seeds`: {}",
+        graph_cap.summary
+    );
 }


### PR DESCRIPTION
Fixes #20.

## Problem
The graph-query surface (`cxpak graph` / `/v1/graph` / MCP `cxpak_graph` / LSP) couldn't be bootstrapped: no op enumerated valid node ids, the id format (repo-relative path) was undocumented, and `subgraph` **echoed non-existent seeds back as nodes** with no error — inconsistent with `node --id`, which reports `exists:false`.

## Fix — ADR-0202 (in this PR)
- **`nodes` enumerate op** — `graph_query::nodes()` lists every node id (union of forward+reverse edge keys, sorted, with in/out degree). One core, projected to all four surfaces (CLI/HTTP/LSP/MCP) via the shared `execute` dispatch. No prefix filter (the issue asked only for enumeration).
- **`subgraph` seed partition** — real (edge-participating) seeds drive the BFS; unknown seeds go to a new `#[serde(default)] unknown_seeds` field, never emitted as `nodes`. Consistent with `node --id exists:false`. "Unknown" honestly means "not an edge-participating node" (a real but edge-less file lands here too — same as `node`).
- **Id-format docs** — `graph --help`, the capability schema description, the LSP error text, README, and MIGRATION-3.0.md all document "repo-relative file path (enumerate with `graph nodes`)" and list the new op.
- **`main.rs exists:false` (issue's secondary)** — explained and deliberately deferred as ADR-0203: it's a narrow `use <own-crate>::` self-package resolution gap (high blast radius to change — perturbs pagerank/health + the determinism golden fixture), not a graph-model bug. `graph nodes` removes the practical sting.

## Before / after (manual QA, real binary, issue's exact case)
```
# before:  subgraph --seeds totally/bogus.xyz  →  nodes:["totally/bogus.xyz"]   (echoed!)
# after:   subgraph --seeds totally/bogus.xyz  →  nodes:[], unknown_seeds:["totally/bogus.xyz"]
# new:     graph nodes .  →  enumerates every id with degree
```

## Tests (RED→GREEN, real)
Core: `nodes` enumeration completeness/order/degree (linear, diamond, empty); `subgraph` partition (bogus, all-unknown, mixed, **real-but-edgeless→unknown_seeds**); `nodes` added to the byte-determinism stress loop. CLI: `graph nodes` op, negative-path regression (`node`/`neighbors` still reject a missing id). Cross-surface: `nodes` and `unknown_seeds` **identical across CLI (real subprocess) / HTTP / LSP / MCP**, compared on parsed `Value`.

- `cargo test --workspace`: 3020 passed, 3 ignored, 0 failed. `clippy --all-targets --all-features -D warnings`: clean. `fmt --check`: clean.
- Golden fixture `spa_output_matches_golden_fixture`: byte-identical (graph path, not visual).
- Independent pre-PR review: correctness/determinism/single-source/cross-surface all verified; no blockers.

https://claude.ai/code/session_019hJMLmPVoGS2FeUUX4w4Jz
