### PR TITLE
fix(mcp): keep serve --mcp index fresh via an owned file watcher (#18)

### DIFF
--- a/docs/adrs/0200-mcp-index-freshness-via-watcher.md
+++ b/docs/adrs/0200-mcp-index-freshness-via-watcher.md
@@ -12,18 +12,18 @@ loop: planning
 ## Context
 
 `cxpak serve --mcp` builds its index **once** at startup (`run_mcp` →
-`spawn_mcp_index_build`, `src/commands/serve.rs:2238/2318`, ADR-0185) and never
-refreshes it. Its own doc comment admits it (serve.rs:2448-2449: "a long-lived
+`spawn_mcp_index_build`, ADR-0185) and never
+refreshes it. Its own doc comment admits it (`snapshot_ready_index`: "a long-lived
 session would keep the first ready index (no periodic rebuild)"). Reproduced
-(REPRO.md): a warm MCP session returns `out_degree 0` for a symbol after an edit
+empirically: a warm MCP session returns `out_degree 0` for a symbol after an edit
 that a fresh index shows as `out_degree 1` — silently, no staleness signal.
 
-The HTTP path (`run`, serve.rs:1351) does **not** have this bug: it spawns a
+The HTTP path (`run`) does **not** have this bug: it spawns a
 `daemon::watcher::FileWatcher` and drives `process_watcher_changes`
-(serve.rs:4231, takes `&SharedIndex`) — snapshot-then-swap, edge-delta graph
+(takes `&SharedIndex`) — snapshot-then-swap, edge-delta graph
 rebuild + warm PageRank (ADR-0165/0166), fresh derived caches — on every
 debounced change batch, atomically swapping a `SharedIndex`. The delta==full
-parity is already tested (serve.rs:6169). So the freshness *primitives* exist and
+parity is already tested. So the freshness *primitives* exist and
 are proven; they are simply not wired into `run_mcp`.
 
 The reuse is **not** verbatim, though: the HTTP watcher loop is an infinite

--- a/docs/adrs/0200-mcp-index-freshness-via-watcher.md
+++ b/docs/adrs/0200-mcp-index-freshness-via-watcher.md
@@ -1,0 +1,140 @@
+---
+id: '0200'
+title: MCP index freshness — wire the file watcher into serve --mcp
+status: ACCEPTED
+date: 2026-07-16
+triggered_by: issue #18 (serve --mcp serves a stale index after file edits)
+loop: planning
+---
+
+# ADR-0200: MCP index freshness — wire the file watcher into `serve --mcp`
+
+## Context
+
+`cxpak serve --mcp` builds its index **once** at startup (`run_mcp` →
+`spawn_mcp_index_build`, `src/commands/serve.rs:2238/2318`, ADR-0185) and never
+refreshes it. Its own doc comment admits it (serve.rs:2448-2449: "a long-lived
+session would keep the first ready index (no periodic rebuild)"). Reproduced
+(REPRO.md): a warm MCP session returns `out_degree 0` for a symbol after an edit
+that a fresh index shows as `out_degree 1` — silently, no staleness signal.
+
+The HTTP path (`run`, serve.rs:1351) does **not** have this bug: it spawns a
+`daemon::watcher::FileWatcher` and drives `process_watcher_changes`
+(serve.rs:4231, takes `&SharedIndex`) — snapshot-then-swap, edge-delta graph
+rebuild + warm PageRank (ADR-0165/0166), fresh derived caches — on every
+debounced change batch, atomically swapping a `SharedIndex`. The delta==full
+parity is already tested (serve.rs:6169). So the freshness *primitives* exist and
+are proven; they are simply not wired into `run_mcp`.
+
+The reuse is **not** verbatim, though: the HTTP watcher loop is an infinite
+`loop {}` (serve.rs:1392-1399) that is detached and only dies on process exit.
+That is fine for a server whose lifetime *is* the process, but the MCP stdio loop
+returns on stdin EOF and is driven in-process by tests — a detached infinite
+thread would leak into every test and cannot be joined on shutdown
+(resource-cleanup). So this decision must also own the watcher's lifecycle.
+
+There is also a **pre-existing second writer** of the readiness cell on the MCP
+path: the opt-in embedding-enrichment phase (`enrich_ready_with_embeddings` →
+`publish_ready_enriched`, serve.rs:2405-2417, ADR-0186) runs on the *same*
+background build thread and, seconds after `Ready`, blind-swaps `ReadyEnriched`
+built from the **startup** index. A watcher that republishes `Ready(edited)` in
+that window would be silently clobbered by the late enrichment (stale, but
+embedding-adorned) — reintroducing exactly the staleness #18 is about. So this
+decision must *coordinate* the watcher with that existing writer, not merely add
+one. (The default no-embeddings path returns early at serve.rs:2375 — the race is
+config-gated and window-bounded, but a correctness defect nonetheless.)
+
+Human decision: it re-opens the ADR-0185 trade-off (that ADR accepted "no
+periodic rebuild" for a short-lived one-task-one-connection model) now that a
+long-lived warm MCP session is a real usage pattern (a persistent commit-gate
+reusing one session across edits), and it decides the thread-lifecycle and
+embedding-staleness contracts.
+
+## Options considered
+
+- **Option A — Document "restart to refresh", change nothing:** honest, zero
+  code. But it forfeits the warm-session value (cold-spawn-per-query pays the full
+  10-14s index every call) and leaves MCP and HTTP with asymmetric freshness for
+  the same command — a latent trap for every machine consumer.
+- **Option B — Mirrored `SharedIndex` + republish into the readiness cell, with an
+  owned, terminable watcher thread (chosen):** after the background build
+  publishes `Ready`, a watcher thread seeds a `SharedIndex` from it, runs the
+  existing `process_watcher_changes` on each debounced change batch, then
+  republishes `Ready(new_index)` into the `SharedReadiness` cell.
+  `mcp_stdio_loop` already snapshots readiness per `tools/call`, so it picks up
+  the swap with no protocol change. The thread waits for `Ready` **or**
+  `ReadyEnriched` (both mean ready-to-mirror; seed from whichever), and that
+  pre-Ready wait itself checks the shutdown signal (`Arc<AtomicBool>`, polling
+  with a sleep — not a busy-spin) so an EOF during the 13-34s initial build joins
+  promptly; it aborts if the build resolves `Failed` (nothing to watch over).
+  Once looping, it checks the same shutdown signal at each `recv_timeout(1s)` poll.
+  The one-shot enrichment publish is made a **compare-and-swap** so it can never
+  clobber a watcher republish (see Decision).
+- **Option C — Extract a transport-agnostic `recompute_index(snapshot,changes)`
+  core shared by HTTP and MCP:** cleaner single-source, but a larger refactor of a
+  load-bearing, determinism-sensitive function for no behavioral gain over B;
+  higher risk for a patch release. Deferred.
+- **Explicit `refresh`/`reindex` op (DEFERRED):** a `tools/call` to force a
+  synchronous rebuild deterministically (the issue's stated *nice-to-have*).
+  Rejected for 3.1.1 because it introduces a **second writer** of the readiness
+  cell racing the watcher (last-write-wins can republish an older index) and
+  leaves the watcher's mirror stale (the next batch rebuilds from the stale mirror
+  and clobbers the refresh). Making it coherent means routing refresh *through*
+  the watcher (signal-to-drain-and-rebuild) — a real design, but scope beyond the
+  core bug, which the debounced watcher already fixes. Deferred to a follow-up.
+
+## Decision
+
+Option B: reuse `FileWatcher` + `process_watcher_changes`, but own the watcher
+thread's lifecycle (shutdown `AtomicBool` checked in both the pre-Ready wait and
+the poll loop; wait predicate accepts `Ready | ReadyEnriched`; abort on a `Failed`
+build) and republish base `Ready`. A watcher swap **actively clears**
+`embedding_index` on the republished index (a delta-rebuilt clone would otherwise
+carry the *stale* enrichment and score against an out-of-date 7th signal — see
+Negative), dropping to the documented 6-signal fallback with a one-line log.
+
+To coordinate with the pre-existing enrichment second writer (Context), make
+`publish_ready_enriched` a **compare-and-swap**: it swaps in `ReadyEnriched` only
+if the cell still holds the exact base `Arc` it enriched (`Arc::ptr_eq` on the
+inner `Arc<CodebaseIndex>`); otherwise it skips and logs "index changed during
+enrichment — serving fresh 6-signal". So a watcher republish is never overwritten
+by a late enrichment (the enriched base and the current cell differ by identity).
+
+The explicit `refresh` op is **deferred** — it would add a *third*, uncoordinated
+writer. Watcher-start failure logs and leaves the one-shot index serving
+(fail-open — never wedges the session).
+
+## Consequences
+
+### Positive
+- MCP and HTTP have symmetric freshness; warm sessions are correct.
+- Reuses proven, determinism-safe primitives; delta==full parity already tested.
+- The watcher thread is owned and terminable — no leak into the stdio loop or
+  in-process tests.
+
+### Negative
+- A watcher swap drops embedding enrichment (7→6 signal) for the rest of the
+  session; the republished index must *actively clear* `embedding_index` (not just
+  rely on the variant being discarded) so no *stale* embedding is ever served.
+  Logged; a regression test asserts the 6-signal fallback and no stale embedding.
+  Re-enrichment after a swap is a follow-up.
+- A mirrored `SharedIndex` holds one extra `Arc` alongside the readiness cell
+  (cheap; shared backing). The readiness cell has **two coordinated writers** — the
+  watcher and the one-shot embedding enrichment — made coherent by the enrichment
+  publish being a compare-and-swap (`Arc::ptr_eq` against the base it enriched), so
+  a watcher republish is never overwritten by a late enrichment. `refresh` stays
+  deferred because it would add a *third*, uncoordinated writer. (An earlier draft
+  wrongly claimed the watcher was the sole writer — the enrichment phase, ADR-0186,
+  is a pre-existing second writer; the CAS is what makes the pair safe.)
+
+### Neutral
+- No new dependency; `std::thread` + notify, same as HTTP serve. No golden-fixture
+  impact (visual path untouched).
+
+## Revisit if
+- A transport-agnostic recompute core is extracted for other reasons — fold B into
+  it (Option C) to drop the mirrored cell.
+- A coherence-safe `refresh` design lands (routed through the watcher) — ship it
+  then; the commit-gate use case still wants it.
+- Embedding enrichment (ADR-0186) becomes common enough that dropping it on every
+  edit is a measured regression — then re-enrich after each watcher swap.

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -203,3 +203,4 @@
 | [0197](0197-hybrid-interaction-v1-diff.md) | Hybrid interaction model: bounded embed + opt-in Live serve; add /v1/diff | ACCEPTED | 2026-07-11 |
 | [0198](0198-risk-percentile-normalization.md) | Risk normalization = within-repo percentile; one-signal-per-channel encoding | ACCEPTED | 2026-07-11 |
 | [0199](0199-broaden-visual-roundtrip-conformance.md) | Broaden Visual round-trip conformance; no-dead-nav + provenance-completeness gates | ACCEPTED | 2026-07-11 |
+| [0200](0200-mcp-index-freshness-via-watcher.md) | MCP index freshness — wire the file watcher into `serve --mcp` (mirror + republish `Ready`); `refresh` op deferred | ACCEPTED | 2026-07-16 |

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2533,8 +2533,20 @@ pub fn spawn_mcp_watcher(
         // can be `strip_prefix`-ed against `path` without mismatch inside
         // `classify_changes`; same fix `commands::watch::run` applies before
         // its own watcher. Fail-open: if canonicalization fails (path already
-        // gone), fall back to the original rather than aborting the watcher.
-        let path = path.canonicalize().unwrap_or(path);
+        // gone), fall back to the original rather than aborting the watcher --
+        // but log it, because an uncanonical root makes every `notify` event's
+        // `strip_prefix` miss, silently dropping all edits (issue #18's mode).
+        let path = match path.canonicalize() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!(
+                    "cxpak: MCP watcher canonicalize failed for {}: {e} — \
+                     file-change matching may silently miss edits under this root",
+                    path.display()
+                );
+                path
+            }
+        };
 
         let seed = loop {
             if shutdown.load(Ordering::Relaxed) {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -4967,15 +4967,15 @@ mod tests {
         let shutdown = Arc::new(AtomicBool::new(false));
         let handle = spawn_mcp_watcher(dir.path(), Arc::clone(&readiness), Arc::clone(&shutdown));
 
-        // Let the watcher install its FileWatcher before the edit below --
-        // a real (if generous) startup allowance, not a substitute for the
-        // bounded poll that follows.
-        std::thread::sleep(Duration::from_millis(300));
-        std::fs::write(dir.path().join("src/new_file.rs"), "fn brand_new() {}").unwrap();
-
         let deadline = std::time::Instant::now() + Duration::from_secs(10);
         let mut observed = 2;
         while std::time::Instant::now() < deadline {
+            // Re-assert the edit each iteration rather than sleeping a guessed
+            // interval then writing once: an edit that lands before the watcher
+            // installs its FileWatcher produces no event and is missed with no
+            // retry. Re-writing keeps producing modify events until the watcher
+            // is live and catches one — no fixed-sleep race.
+            let _ = std::fs::write(dir.path().join("src/new_file.rs"), "fn brand_new() {}");
             if let Ok(g) = readiness.read() {
                 if let IndexReadiness::Ready(idx) = &*g {
                     observed = idx.total_files;
@@ -5086,21 +5086,20 @@ mod tests {
         assert_eq!(before["exists"], true, "before edit: {before}");
         assert_eq!(before["out_degree"], 0, "before edit: {before}");
 
-        // Give the watcher's FileWatcher a moment to be installed, then make
-        // the edit the #18 repro exercises: a.rs gains an out-edge.
-        std::thread::sleep(Duration::from_millis(300));
-        std::fs::write(path.join("src/c.rs"), "pub fn cee() {}\n").unwrap();
-        std::fs::write(
-            path.join("src/a.rs"),
-            "use crate::c::cee;\npub fn helper() { cee(); }\n",
-        )
-        .unwrap();
-
         // AFTER the edit: bounded poll (not a fixed sleep) on the warm
         // session's own tool call -- the same call the client would replay.
+        // Re-assert the edit (a.rs gains an out-edge to a new c.rs) each
+        // iteration rather than sleeping-then-editing-once: an edit that lands
+        // before the watcher installs its FileWatcher is missed with no retry,
+        // so re-writing keeps producing modify events until the watcher is live.
         let edit_deadline = std::time::Instant::now() + Duration::from_secs(10);
         let mut after = before.clone();
         while std::time::Instant::now() < edit_deadline {
+            let _ = std::fs::write(path.join("src/c.rs"), "pub fn cee() {}\n");
+            let _ = std::fs::write(
+                path.join("src/a.rs"),
+                "use crate::c::cee;\npub fn helper() { cee(); }\n",
+            );
             after = drive(call_node_a);
             if after["out_degree"] == 1 {
                 break;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use subtle::ConstantTimeEq;
@@ -2249,12 +2250,25 @@ pub fn run_mcp(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
     );
     let build_handle = spawn_mcp_index_build(path, Arc::clone(&readiness));
 
+    // Freshness (Task #18, ADR-0200): a long-lived MCP session otherwise keeps
+    // the first-ready index forever (no periodic rebuild). The watcher mirrors
+    // the base once it lands, then republishes `Ready` into the same cell on
+    // every debounced edit — symmetric with HTTP `run`'s watcher (serve.rs
+    // above). `shutdown` gives it an owned, terminable lifecycle so it never
+    // leaks past this function's return (resource-cleanup on every path,
+    // including error).
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let watcher_handle = spawn_mcp_watcher(path, Arc::clone(&readiness), Arc::clone(&shutdown));
+
     let snapshot: SharedSnapshot = Arc::new(RwLock::new(None));
     let result = mcp_stdio_loop(path, &readiness, &snapshot);
 
-    // Reclaim the background thread before returning (stdin closed / EOF).
-    // Best-effort: a panicked build thread must not turn a clean shutdown into
-    // an error, so the join result is intentionally discarded.
+    // Reclaim both background threads before returning (stdin closed / EOF).
+    // Signal the watcher first so it stops promptly instead of riding out its
+    // next `recv_timeout` poll. Best-effort: a panicked thread must not turn a
+    // clean shutdown into an error, so both join results are discarded.
+    shutdown.store(true, Ordering::Relaxed);
+    let _ = watcher_handle.join();
     let _ = build_handle.join();
     result
 }
@@ -2396,11 +2410,19 @@ fn enrich_ready_with_embeddings(
 /// cell as [`IndexReadiness::ReadyEnriched`] (R-E1).
 ///
 /// The enriched index is built into a local *before* the lock is taken, so the
-/// write lock is held only for the O(1) `Arc` swap — no lock is held across the
-/// clone/build. A `tools/call` racing this swap snapshots either the pre-swap
-/// `Ready` (6-signal) or the `ReadyEnriched` (7-signal), never a torn state.
-/// Poison recovery matches R0's discipline: a panicked reader cannot wedge the
-/// publish.
+/// write lock is held only for the O(1) compare-and-swap — no lock is held
+/// across the clone/build. A `tools/call` racing this swap snapshots either
+/// the pre-swap `Ready` (6-signal) or the `ReadyEnriched` (7-signal), never a
+/// torn state. Poison recovery matches R0's discipline: a panicked reader
+/// cannot wedge the publish.
+///
+/// Compare-and-swap (Task #18, ADR-0200): this enrichment runs on the
+/// background build thread, seconds after `Ready` — the same window a
+/// long-lived MCP session's freshness watcher (N18.2) may republish a fresh
+/// `Ready(Arc)` into this same cell. The swap lands ONLY if the cell still
+/// holds the exact base `Arc` this enrichment was built from (`Arc::ptr_eq`);
+/// otherwise it is a stale enrichment racing a fresher republish, so it is
+/// skipped rather than clobbering the watcher's edit with pre-edit content.
 #[cfg(feature = "embeddings")]
 fn publish_ready_enriched(
     readiness: &SharedReadiness,
@@ -2410,10 +2432,157 @@ fn publish_ready_enriched(
     let mut enriched = (**base).clone();
     enriched.embedding_index = Some(emb);
     let next = IndexReadiness::ReadyEnriched(Arc::new(enriched));
-    match readiness.write() {
-        Ok(mut g) => *g = next,
-        Err(poisoned) => *poisoned.into_inner() = next,
+
+    let mut guard = match readiness.write() {
+        Ok(g) => g,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    match &*guard {
+        IndexReadiness::Ready(cur) if Arc::ptr_eq(cur, base) => *guard = next,
+        _ => {
+            eprintln!("cxpak: index changed during enrichment — serving fresh 6-signal");
+        }
     }
+}
+
+/// Outcome of checking the readiness cell during the watcher's pre-`Ready`
+/// wait (Task #18, ADR-0200): `Seed` once a queryable base exists — `Ready`
+/// and `ReadyEnriched` both qualify, and the watcher mirrors whichever landed
+/// first — `Pending` while still `Building` (keep polling), and `Abort` on
+/// `Failed` (the one-shot build never became queryable; nothing to watch
+/// over).
+///
+/// Extracted as a pure function over `&IndexReadiness` so the classification
+/// is unit-testable without spawning a thread or a real `FileWatcher`.
+enum WatcherWait {
+    Seed(Arc<CodebaseIndex>),
+    Pending,
+    Abort,
+}
+
+fn classify_watcher_wait(state: &IndexReadiness) -> WatcherWait {
+    match state {
+        IndexReadiness::Ready(idx) | IndexReadiness::ReadyEnriched(idx) => {
+            WatcherWait::Seed(Arc::clone(idx))
+        }
+        IndexReadiness::Building => WatcherWait::Pending,
+        IndexReadiness::Failed(_) => WatcherWait::Abort,
+    }
+}
+
+/// Poll interval for the watcher's pre-`Ready` wait (Task #18). A sleep, not a
+/// busy-spin — `shutdown` is checked on every iteration, so a stdin EOF during
+/// the 13–34s initial build joins within one interval instead of blocking on
+/// the full build.
+const WATCHER_WAIT_POLL: Duration = Duration::from_millis(100);
+
+/// Build the `Ready(..)` payload for a watcher republish: snapshot the
+/// mirrored `SharedIndex` and actively clear `embedding_index`.
+///
+/// A delta-rebuilt clone otherwise carries the *stale* enrichment forward —
+/// scoring the 7th signal against pre-edit embedded text would be worse than
+/// not having it (ADR-0200 Consequences). Extracted so the clearing behavior
+/// is unit-testable without a real edit + `FileWatcher` cycle.
+fn republish_watcher_index(shared: &SharedIndex) -> Arc<CodebaseIndex> {
+    let mut idx = match shared.read() {
+        Ok(g) => (**g).clone(),
+        Err(poisoned) => (**poisoned.into_inner()).clone(),
+    };
+    #[cfg(feature = "embeddings")]
+    {
+        idx.embedding_index = None;
+    }
+    Arc::new(idx)
+}
+
+/// Spawn the MCP freshness watcher (Task #18, ADR-0200).
+///
+/// Owns its lifecycle end to end — it is NOT a verbatim reuse of HTTP `run`'s
+/// detached, infinite watcher thread (serve.rs above), which is fine for a
+/// server whose lifetime *is* the process but would leak into every in-process
+/// MCP test and could never be joined on shutdown:
+///
+/// 1. Waits for the one-shot background build to become queryable (`Ready` or
+///    `ReadyEnriched`; see [`classify_watcher_wait`]), checking `shutdown` on
+///    every poll so a stdin EOF during the initial build joins promptly
+///    rather than riding out the full 13–34s build. Aborts without installing
+///    a watcher if the build resolves `Failed`.
+/// 2. Seeds a `SharedIndex` mirror from that base and runs the same debounced
+///    `FileWatcher` + `process_watcher_changes` loop HTTP `run` uses — but
+///    terminable: `shutdown` is checked at each `recv_timeout(1s)` poll, not
+///    just at process exit.
+/// 3. Each republish clears `embedding_index` on the rebuilt index (see
+///    [`republish_watcher_index`]) and swaps a fresh `Ready(..)` into
+///    `readiness` — never `ReadyEnriched`; a swap downgrades to the
+///    documented 6-signal fallback until a future re-enrich lands.
+///
+/// `#[doc(hidden)] pub` (not private) so integration tests can drive the real
+/// `FileWatcher` end-to-end without spawning a subprocess, matching the
+/// existing convention for testable internals in this module
+/// (`spawn_mcp_index_build`, `process_watcher_changes`).
+#[doc(hidden)]
+pub fn spawn_mcp_watcher(
+    path: &Path,
+    readiness: SharedReadiness,
+    shutdown: Arc<AtomicBool>,
+) -> std::thread::JoinHandle<()> {
+    let path = path.to_path_buf();
+    std::thread::spawn(move || {
+        // Canonicalize so the absolute paths `notify` delivers (which resolve
+        // symlinks -- e.g. macOS /var -> /private/var, /tmp -> /private/tmp)
+        // can be `strip_prefix`-ed against `path` without mismatch inside
+        // `classify_changes`; same fix `commands::watch::run` applies before
+        // its own watcher. Fail-open: if canonicalization fails (path already
+        // gone), fall back to the original rather than aborting the watcher.
+        let path = path.canonicalize().unwrap_or(path);
+
+        let seed = loop {
+            if shutdown.load(Ordering::Relaxed) {
+                return;
+            }
+            let wait = match readiness.read() {
+                Ok(g) => classify_watcher_wait(&g),
+                Err(poisoned) => classify_watcher_wait(&poisoned.into_inner()),
+            };
+            match wait {
+                WatcherWait::Seed(idx) => break idx,
+                WatcherWait::Abort => {
+                    eprintln!(
+                        "cxpak: MCP watcher aborting — background build failed, \
+                         nothing to watch over"
+                    );
+                    return;
+                }
+                WatcherWait::Pending => std::thread::sleep(WATCHER_WAIT_POLL),
+            }
+        };
+
+        let shared: SharedIndex = Arc::new(RwLock::new(seed));
+
+        let watcher = match FileWatcher::new(&path) {
+            Ok(w) => w,
+            Err(e) => {
+                eprintln!("cxpak: MCP watcher failed to start: {e} — index will not refresh");
+                return;
+            }
+        };
+
+        while !shutdown.load(Ordering::Relaxed) {
+            let Some(first) = watcher.recv_timeout(Duration::from_secs(1)) else {
+                continue;
+            };
+            let mut changes = vec![first];
+            std::thread::sleep(Duration::from_millis(50));
+            changes.extend(watcher.drain());
+            process_watcher_changes(&changes, &path, &shared);
+
+            let republished = republish_watcher_index(&shared);
+            match readiness.write() {
+                Ok(mut g) => *g = IndexReadiness::Ready(republished),
+                Err(poisoned) => *poisoned.into_inner() = IndexReadiness::Ready(republished),
+            }
+        }
+    })
 }
 
 /// Snapshot the base index if the background build has finished, else return the
@@ -2444,9 +2613,12 @@ fn snapshot_ready_index(readiness: &SharedReadiness) -> Result<Arc<CodebaseIndex
 /// Run the MCP stdio loop against a background-built index (Task R0).
 ///
 /// The index is published asynchronously into `readiness` by
-/// [`spawn_mcp_index_build`]; the loop itself never blocks on the build.
-/// Connections are typically short-lived (one task ≈ one connection); a
-/// long-lived session would keep the first ready index (no periodic rebuild).
+/// [`spawn_mcp_index_build`]; the loop itself never blocks on the build. A
+/// long-lived session stays fresh: `run_mcp` also spawns
+/// [`spawn_mcp_watcher`] (Task #18, ADR-0200) against the same `readiness`
+/// cell, so a `tools/call` here picks up every debounced edit with no
+/// protocol change — the loop simply snapshots whatever `Ready`/`ReadyEnriched`
+/// is current.
 fn mcp_stdio_loop(
     repo_path: &Path,
     readiness: &SharedReadiness,
@@ -4588,6 +4760,349 @@ mod tests {
                 .unwrap()
                 .has_embedding_index(),
             "after the swap the cell must be enriched"
+        );
+    }
+
+    // --- Task #18 (ADR-0200): enrichment compare-and-swap ---
+    //
+    // `publish_ready_enriched` runs on the one-shot background build thread,
+    // seconds after `Ready`. A long-lived MCP session's watcher (N18.2) can
+    // republish a *fresh* `Ready(Arc)` into the same cell in that window; a
+    // blind swap would clobber the fresh watcher republish with the stale
+    // pre-edit base the enrichment was built from — reintroducing the exact
+    // staleness #18 fixes. The publish must be a compare-and-swap: swap to
+    // `ReadyEnriched` only if the cell still holds the *exact* base Arc this
+    // enrichment was built from (`Arc::ptr_eq`); otherwise skip and keep
+    // serving whatever fresher `Ready` landed.
+
+    /// The base moved (a watcher republish landed) between the enrich build
+    /// starting and its publish: the CAS must skip the swap and leave the
+    /// cell exactly as the watcher left it — never resurrect the stale base
+    /// the enrichment was built from.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn enrich_cas_skips_when_base_moved() {
+        let idx0 = Arc::new(make_test_index());
+        let readiness: SharedReadiness =
+            Arc::new(RwLock::new(IndexReadiness::Ready(Arc::clone(&idx0))));
+
+        // Simulate a watcher republish landing *during* enrichment: a fresh
+        // Arc allocation, not the one this enrichment was built from.
+        let idx1 = Arc::new(make_test_index());
+        *readiness.write().unwrap() = IndexReadiness::Ready(Arc::clone(&idx1));
+
+        let mut emb = crate::embeddings::EmbeddingIndex::new(3);
+        emb.add("src/main.rs".to_string(), vec![0.1, 0.2, 0.3]);
+        publish_ready_enriched(&readiness, &idx0, emb);
+
+        let guard = readiness.read().unwrap();
+        let IndexReadiness::Ready(cur) = &*guard else {
+            panic!(
+                "a stale enrichment must not clobber the watcher's republish \
+                 -- expected the cell to still be Ready, not ReadyEnriched"
+            );
+        };
+        assert!(
+            Arc::ptr_eq(cur, &idx1),
+            "cell must still hold the watcher's republished Arc, not the \
+             stale enrichment's base"
+        );
+    }
+
+    /// The base is unchanged since the enrichment started: the CAS proceeds
+    /// and swaps in `ReadyEnriched` exactly as the pre-CAS behavior did.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn enrich_cas_swaps_when_base_unchanged() {
+        let idx0 = Arc::new(make_test_index());
+        let readiness: SharedReadiness =
+            Arc::new(RwLock::new(IndexReadiness::Ready(Arc::clone(&idx0))));
+
+        let mut emb = crate::embeddings::EmbeddingIndex::new(3);
+        emb.add("src/main.rs".to_string(), vec![0.1, 0.2, 0.3]);
+        publish_ready_enriched(&readiness, &idx0, emb);
+
+        assert!(
+            matches!(
+                &*readiness.read().unwrap(),
+                IndexReadiness::ReadyEnriched(_)
+            ),
+            "cell must swap to ReadyEnriched when the base is unchanged"
+        );
+    }
+
+    // --- Task #18 (ADR-0200): the MCP freshness watcher ---
+
+    /// `classify_watcher_wait` is the single dispatch point `spawn_mcp_watcher`
+    /// polls during its pre-`Ready` wait, so unit-testing it directly proves
+    /// the watcher's wait behavior deterministically — no thread, no real
+    /// `FileWatcher`, no timing dependence.
+    #[test]
+    fn classify_watcher_wait_seeds_from_ready() {
+        let idx = Arc::new(make_test_index());
+        match classify_watcher_wait(&IndexReadiness::Ready(Arc::clone(&idx))) {
+            WatcherWait::Seed(got) => assert!(Arc::ptr_eq(&got, &idx)),
+            _ => panic!("Ready must yield Seed"),
+        }
+    }
+
+    /// finding MAJOR-2: a session where the base was already enriched before
+    /// the watcher's first poll (a fast build + fast opt-in enrich) must still
+    /// be treated as a valid seed, not stall waiting for a plain `Ready` that
+    /// will never come again.
+    #[test]
+    fn mcp_watcher_seeds_from_ready_enriched() {
+        let idx = Arc::new(make_test_index());
+        match classify_watcher_wait(&IndexReadiness::ReadyEnriched(Arc::clone(&idx))) {
+            WatcherWait::Seed(got) => assert!(Arc::ptr_eq(&got, &idx)),
+            _ => panic!("ReadyEnriched must be treated as a valid seed, not Pending/Abort"),
+        }
+    }
+
+    #[test]
+    fn classify_watcher_wait_pending_on_building() {
+        assert!(matches!(
+            classify_watcher_wait(&IndexReadiness::Building),
+            WatcherWait::Pending
+        ));
+    }
+
+    /// The one-shot build never became queryable — nothing to watch over, so
+    /// the watcher must abort rather than poll forever.
+    #[test]
+    fn mcp_watcher_aborts_on_failed_build() {
+        assert!(matches!(
+            classify_watcher_wait(&IndexReadiness::Failed("boom".to_string())),
+            WatcherWait::Abort
+        ));
+    }
+
+    /// finding M5: a watcher republish must actively clear `embedding_index`,
+    /// not carry it forward stale. Exercises `republish_watcher_index`
+    /// directly (the function `spawn_mcp_watcher`'s loop calls on every
+    /// debounced batch) — deterministic, no real edit or `FileWatcher` needed.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn mcp_watcher_swap_clears_embedding() {
+        let mut idx = make_test_index();
+        let mut emb = crate::embeddings::EmbeddingIndex::new(3);
+        emb.add("src/main.rs".to_string(), vec![0.1, 0.2, 0.3]);
+        idx.embedding_index = Some(emb);
+        assert!(idx.has_embedding_index());
+        let shared: SharedIndex = Arc::new(RwLock::new(Arc::new(idx)));
+
+        let republished = republish_watcher_index(&shared);
+
+        assert!(
+            !republished.has_embedding_index(),
+            "a watcher republish must actively clear embedding_index, not \
+             carry it forward stale"
+        );
+    }
+
+    /// Deterministic: the shutdown signal is already set before the watcher's
+    /// very first poll, so it must return without ever touching the
+    /// filesystem or installing a real `FileWatcher`.
+    #[test]
+    fn mcp_watcher_shuts_down_on_signal() {
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Ready(Arc::new(
+            make_test_index(),
+        ))));
+        let shutdown = Arc::new(AtomicBool::new(true));
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let handle = spawn_mcp_watcher(dir.path(), readiness, shutdown);
+        handle
+            .join()
+            .expect("watcher thread must join promptly once already signalled");
+    }
+
+    /// finding MAJOR-3: the cell never becomes `Ready` (stays `Building` for
+    /// the whole test), so only the shutdown signal can end the pre-`Ready`
+    /// wait. Proves the wait polls `shutdown` rather than blocking on the
+    /// build — a stdin EOF during the initial 13–34s build must join
+    /// promptly, not ride out the full build.
+    #[test]
+    fn mcp_watcher_shuts_down_during_pre_ready_wait() {
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Building));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let handle = spawn_mcp_watcher(dir.path(), Arc::clone(&readiness), Arc::clone(&shutdown));
+        std::thread::sleep(Duration::from_millis(50));
+        shutdown.store(true, Ordering::Relaxed);
+        handle
+            .join()
+            .expect("watcher must join promptly on shutdown, without waiting for Ready");
+    }
+
+    /// End-to-end: a real edit through a real `FileWatcher` is mirrored into
+    /// the readiness cell as a fresh `Ready(..)`. Bounded poll for the
+    /// debounced republish to land (not a fixed sleep-then-assert) — the FS
+    /// event itself is inherently best-effort/platform-timed, so this test
+    /// documents that tradeoff rather than hiding it; the fast, fully
+    /// deterministic assertions (wait predicate, shutdown, embedding-clearing)
+    /// live in the tests above, driving the pure functions directly.
+    #[test]
+    fn mcp_watcher_republishes_ready() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/main.rs"), "fn main() {}").unwrap();
+        std::fs::write(dir.path().join("src/lib.rs"), "pub fn hello() {}").unwrap();
+
+        let idx0 = Arc::new(make_test_index()); // matches the 2 files on disk above
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Ready(idx0)));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let handle = spawn_mcp_watcher(dir.path(), Arc::clone(&readiness), Arc::clone(&shutdown));
+
+        // Let the watcher install its FileWatcher before the edit below --
+        // a real (if generous) startup allowance, not a substitute for the
+        // bounded poll that follows.
+        std::thread::sleep(Duration::from_millis(300));
+        std::fs::write(dir.path().join("src/new_file.rs"), "fn brand_new() {}").unwrap();
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut observed = 2;
+        while std::time::Instant::now() < deadline {
+            if let Ok(g) = readiness.read() {
+                if let IndexReadiness::Ready(idx) = &*g {
+                    observed = idx.total_files;
+                    if observed == 3 {
+                        break;
+                    }
+                }
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+
+        shutdown.store(true, Ordering::Relaxed);
+        handle.join().expect("watcher must join after shutdown");
+        assert_eq!(
+            observed, 3,
+            "watcher must republish a Ready index reflecting the new file"
+        );
+    }
+
+    /// A committed git repo `build_index` can index — `spawn_mcp_index_build`
+    /// walks git-tracked files (ADR-0185). `b.rs` imports `a.rs`'s `helper` fn
+    /// via `use crate::a::helper;` -- a *leaf-item* import, the pattern that
+    /// actually resolves to a graph edge (`resolve_rust_import`, index/graph.rs,
+    /// strips the last segment as the imported name and resolves the rest as
+    /// the source file). A bare `use crate::a;` does NOT resolve the same way
+    /// -- the whole-module form has no leaf segment to strip, so it never
+    /// produces a source path the resolver can match.
+    fn make_watcher_test_repo() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src/a.rs"), "pub fn helper() {}\n").unwrap();
+        std::fs::write(
+            dir.path().join("src/b.rs"),
+            "use crate::a::helper;\npub fn go() { helper(); }\n",
+        )
+        .unwrap();
+        let repo = git2::Repository::init(dir.path()).expect("git2 init");
+        let mut index = repo.index().expect("repo index");
+        for rel in ["src/a.rs", "src/b.rs"] {
+            index.add_path(std::path::Path::new(rel)).expect("git add");
+        }
+        index.write().expect("index write");
+        let tree_oid = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_oid).expect("find tree");
+        let sig = git2::Signature::now("t", "t@t").expect("sig");
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .expect("initial commit");
+        dir
+    }
+
+    /// N18.3 — the wiring `run_mcp` adds: a real background build
+    /// ([`spawn_mcp_index_build`]) plus a real freshness watcher
+    /// ([`spawn_mcp_watcher`]) sharing one `readiness` cell, driven through
+    /// the real JSON-RPC loop ([`mcp_stdio_loop_readiness`]). `run_mcp`
+    /// itself can't be driven in-process (it owns real stdin/stdout), so this
+    /// exercises the exact components it wires together end-to-end — a warm
+    /// session's `tools/call` reflects a post-startup edit, closing #18.
+    #[test]
+    fn run_mcp_warm_session_reflects_edit() {
+        let repo = make_watcher_test_repo();
+        let path = repo.path().to_path_buf();
+
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Building));
+        let build_handle = spawn_mcp_index_build(&path, Arc::clone(&readiness));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let watcher_handle =
+            spawn_mcp_watcher(&path, Arc::clone(&readiness), Arc::clone(&shutdown));
+
+        // Bounded wait for the real background build to publish `Ready`.
+        let build_deadline = std::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            if matches!(&*readiness.read().unwrap(), IndexReadiness::Ready(_)) {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < build_deadline,
+                "background build did not become ready within 30s"
+            );
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        build_handle.join().expect("build thread joins cleanly");
+
+        let call_node_a = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","#,
+            r#""params":{"name":"cxpak_graph","arguments":{"op":"graph","graph_op":"node","id":"src/a.rs"}}}"#,
+            "\n",
+        );
+        let drive = |input: &str| -> Value {
+            let snapshot: SharedSnapshot = Arc::new(RwLock::new(None));
+            let mut out: Vec<u8> = Vec::new();
+            mcp_stdio_loop_readiness(
+                &path,
+                &readiness,
+                &snapshot,
+                std::io::Cursor::new(input.as_bytes()),
+                &mut out,
+            )
+            .expect("mcp loop");
+            let line = String::from_utf8(out).unwrap();
+            let resp: Value = serde_json::from_str(line.lines().next().unwrap()).unwrap();
+            let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+            serde_json::from_str(text).expect("tool result JSON")
+        };
+
+        // BEFORE the edit: a.rs is imported by b.rs (in_degree 1) but imports
+        // nothing itself (out_degree 0) -- the exact #18 repro shape.
+        let before = drive(call_node_a);
+        assert_eq!(before["exists"], true, "before edit: {before}");
+        assert_eq!(before["out_degree"], 0, "before edit: {before}");
+
+        // Give the watcher's FileWatcher a moment to be installed, then make
+        // the edit the #18 repro exercises: a.rs gains an out-edge.
+        std::thread::sleep(Duration::from_millis(300));
+        std::fs::write(path.join("src/c.rs"), "pub fn cee() {}\n").unwrap();
+        std::fs::write(
+            path.join("src/a.rs"),
+            "use crate::c::cee;\npub fn helper() { cee(); }\n",
+        )
+        .unwrap();
+
+        // AFTER the edit: bounded poll (not a fixed sleep) on the warm
+        // session's own tool call -- the same call the client would replay.
+        let edit_deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut after = before.clone();
+        while std::time::Instant::now() < edit_deadline {
+            after = drive(call_node_a);
+            if after["out_degree"] == 1 {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        shutdown.store(true, Ordering::Relaxed);
+        watcher_handle.join().expect("watcher joins after shutdown");
+
+        assert_eq!(
+            after["out_degree"], 1,
+            "warm MCP session must reflect the edit, not serve the stale \
+             startup index (issue #18): {after}"
         );
     }
 

--- a/tests/mcp_freshness_subprocess.rs
+++ b/tests/mcp_freshness_subprocess.rs
@@ -1,0 +1,213 @@
+//! Real-subprocess `cxpak serve --mcp` freshness test (issue #18, ADR-0200).
+//!
+//! Promotes the ad hoc `mcp_driver.py` stale-repro (Phase 0, REPRO.md) to a
+//! committed Rust regression guard: spawns the real `cxpak serve --mcp`
+//! binary against a real git repo, drives the real newline-delimited
+//! JSON-RPC stdio protocol, makes a real filesystem edit, and asserts a warm
+//! session's `tools/call` reflects it through the real `notify` `FileWatcher`
+//! -- the exact repro (`node src/a.rs`: `out_degree 0` before the edit,
+//! `out_degree 1` after, same session, no restart).
+//!
+//! The in-process regression test
+//! (`commands::serve::tests::run_mcp_warm_session_reflects_edit`) exercises
+//! the same wiring deterministically and faster; this test additionally
+//! covers the real CLI dispatch (`main.rs` -> `run_mcp`) and the real stdio
+//! framing, which an in-process test can't reach. The FS-event debounce
+//! itself is inherently platform-timed, so both the readiness poll below and
+//! the process-exit poll are bounded (not fixed sleeps).
+#![cfg(feature = "daemon")]
+
+use assert_cmd::cargo_bin;
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::process::{self, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+/// See `commands::serve::tests::make_watcher_test_repo` (serve.rs) for why
+/// `b.rs` imports `a.rs`'s `helper` fn specifically via
+/// `use crate::a::helper;` -- a leaf-item import is what
+/// `resolve_rust_import` (index/graph.rs) resolves to a graph edge; a bare
+/// `use crate::a;` (whole-module) does not.
+fn make_test_repo() -> tempfile::TempDir {
+    let dir = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(dir.path().join("src/a.rs"), "pub fn helper() {}\n").unwrap();
+    std::fs::write(
+        dir.path().join("src/b.rs"),
+        "use crate::a::helper;\npub fn go() { helper(); }\n",
+    )
+    .unwrap();
+    let repo = git2::Repository::init(dir.path()).expect("git2 init");
+    let mut index = repo.index().expect("repo index");
+    for rel in ["src/a.rs", "src/b.rs"] {
+        index.add_path(std::path::Path::new(rel)).expect("git add");
+    }
+    index.write().expect("index write");
+    let tree_oid = index.write_tree().expect("write tree");
+    let tree = repo.find_tree(tree_oid).expect("find tree");
+    let sig = git2::Signature::now("t", "t@t").expect("sig");
+    repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+        .expect("initial commit");
+    dir
+}
+
+/// Background reader: forwards each newline-delimited JSON-RPC response onto
+/// `tx` as it arrives, so the test can bound every wait with `recv_timeout`
+/// instead of blocking indefinitely on a hung or slow server.
+fn spawn_reader(stdout: process::ChildStdout) -> mpsc::Receiver<Value> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if line.is_empty() {
+                continue;
+            }
+            let Ok(v) = serde_json::from_str::<Value>(&line) else {
+                continue;
+            };
+            if tx.send(v).is_err() {
+                break; // test side dropped the receiver
+            }
+        }
+    });
+    rx
+}
+
+fn write_line(stdin: &mut process::ChildStdin, body: &Value) {
+    stdin.write_all(body.to_string().as_bytes()).unwrap();
+    stdin.write_all(b"\n").unwrap();
+    stdin.flush().unwrap();
+}
+
+/// Bounded wait for process exit -- `Child::wait` has no built-in timeout, and
+/// a hang here (a leaked/un-joined background thread) must fail the test
+/// rather than the whole suite.
+fn wait_bounded(child: &mut process::Child, timeout: Duration) -> Option<process::ExitStatus> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            return Some(status);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Real end-to-end: a warm `cxpak serve --mcp` session reflects a
+/// post-startup edit -- issue #18's exact repro, driven through the real
+/// binary and the real stdio protocol.
+#[test]
+fn mcp_subprocess_warm_session_reflects_edit() {
+    let repo = make_test_repo();
+    let path = repo.path().to_path_buf();
+
+    let mut child = process::Command::new(cargo_bin!("cxpak"))
+        .args(["serve", "--mcp", path.to_str().unwrap()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("cxpak binary should spawn for serve --mcp");
+
+    let mut stdin = child.stdin.take().expect("stdin pipe");
+    let stdout = child.stdout.take().expect("stdout pipe");
+    let rx = spawn_reader(stdout);
+
+    write_line(
+        &mut stdin,
+        &serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}),
+    );
+    let init = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("initialize must answer promptly, off the index-build path");
+    assert_eq!(init["id"], 1);
+    assert_eq!(init["result"]["serverInfo"]["name"], "cxpak");
+
+    let call_node_a = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "cxpak_graph",
+            "arguments": {"op": "graph", "graph_op": "node", "id": "src/a.rs"}
+        }
+    });
+
+    // Poll (bounded) until the background build is ready -- before that, the
+    // same tool call returns the "indexing in progress" retry text rather
+    // than JSON.
+    let mut node: Option<Value> = None;
+    let build_deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while std::time::Instant::now() < build_deadline {
+        write_line(&mut stdin, &call_node_a);
+        let resp = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("tools/call must answer");
+        let text = resp["result"]["content"][0]["text"]
+            .as_str()
+            .expect("tool result text");
+        if let Ok(v) = serde_json::from_str::<Value>(text) {
+            node = Some(v);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    let before = node.expect("background build did not become ready within 30s");
+    assert_eq!(before["exists"], true, "before edit: {before}");
+    assert_eq!(before["out_degree"], 0, "before edit: {before}");
+
+    // The build reaching `Ready` only proves the *build* thread is done;
+    // `spawn_mcp_watcher` polls the same cell independently (every
+    // `WATCHER_WAIT_POLL`) before it installs its own `FileWatcher`. Give it
+    // a moment -- an edit that lands before the watcher exists produces no
+    // event to miss, so the assertion below would hang until `edit_deadline`
+    // for a reason unrelated to #18. This is the FS-event timing tradeoff
+    // this test documents (see module doc comment).
+    std::thread::sleep(Duration::from_millis(500));
+
+    // Real edit -- the exact #18 repro: a.rs gains an out-edge.
+    std::fs::write(path.join("src/c.rs"), "pub fn cee() {}\n").unwrap();
+    std::fs::write(
+        path.join("src/a.rs"),
+        "use crate::c::cee;\npub fn helper() { cee(); }\n",
+    )
+    .unwrap();
+
+    // Bounded poll -- same warm session, no restart -- for the watcher's
+    // debounced republish to land.
+    let mut after = before.clone();
+    let edit_deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < edit_deadline {
+        write_line(&mut stdin, &call_node_a);
+        let resp = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("tools/call must answer");
+        let text = resp["result"]["content"][0]["text"]
+            .as_str()
+            .expect("tool result text");
+        after = serde_json::from_str(text).expect("tool result JSON");
+        if after["out_degree"] == 1 {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    assert_eq!(
+        after["out_degree"], 1,
+        "warm MCP session must reflect the edit, not serve the stale \
+         startup index (issue #18): {after}"
+    );
+
+    // Clean shutdown: closing stdin is the documented EOF path -- `run_mcp`
+    // joins both background threads before the process exits.
+    drop(stdin);
+    let status = wait_bounded(&mut child, Duration::from_secs(10))
+        .expect("cxpak serve --mcp must exit promptly on stdin EOF, not hang");
+    assert!(
+        status.success(),
+        "cxpak serve --mcp must exit cleanly on stdin EOF"
+    );
+}

--- a/tests/mcp_freshness_subprocess.rs
+++ b/tests/mcp_freshness_subprocess.rs
@@ -121,9 +121,14 @@ fn mcp_subprocess_warm_session_reflects_edit() {
         &mut stdin,
         &serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}),
     );
+    // Generous upper bound, not a latency assertion: `initialize` is answered
+    // off the index-build path, but a cold fork+exec+dynamic-link of the large
+    // cxpak binary plus the first JSON-RPC roundtrip can take several seconds on
+    // a saturated CI runner. The bound only exists to fail instead of hang; it
+    // costs nothing on the happy path (returns the instant the response lands).
     let init = rx
-        .recv_timeout(Duration::from_secs(5))
-        .expect("initialize must answer promptly, off the index-build path");
+        .recv_timeout(Duration::from_secs(30))
+        .expect("initialize must answer before the process is presumed hung");
     assert_eq!(init["id"], 1);
     assert_eq!(init["result"]["serverInfo"]["name"], "cxpak");
 
@@ -160,28 +165,22 @@ fn mcp_subprocess_warm_session_reflects_edit() {
     assert_eq!(before["exists"], true, "before edit: {before}");
     assert_eq!(before["out_degree"], 0, "before edit: {before}");
 
-    // The build reaching `Ready` only proves the *build* thread is done;
-    // `spawn_mcp_watcher` polls the same cell independently (every
-    // `WATCHER_WAIT_POLL`) before it installs its own `FileWatcher`. Give it
-    // a moment -- an edit that lands before the watcher exists produces no
-    // event to miss, so the assertion below would hang until `edit_deadline`
-    // for a reason unrelated to #18. This is the FS-event timing tradeoff
-    // this test documents (see module doc comment).
-    std::thread::sleep(Duration::from_millis(500));
-
-    // Real edit -- the exact #18 repro: a.rs gains an out-edge.
-    std::fs::write(path.join("src/c.rs"), "pub fn cee() {}\n").unwrap();
-    std::fs::write(
-        path.join("src/a.rs"),
-        "use crate::c::cee;\npub fn helper() { cee(); }\n",
-    )
-    .unwrap();
-
     // Bounded poll -- same warm session, no restart -- for the watcher's
-    // debounced republish to land.
+    // debounced republish to land. The edit (a.rs gains an out-edge to a new
+    // c.rs -- the exact #18 repro) is re-asserted each iteration rather than
+    // written once after a fixed sleep: `spawn_mcp_watcher` polls the readiness
+    // cell independently before it installs its `FileWatcher`, so an edit that
+    // lands before that install produces no event and is missed with no retry.
+    // Re-writing keeps producing modify events until the watcher is live and
+    // catches one -- no guessed-duration sleep, no install-timing flake.
     let mut after = before.clone();
     let edit_deadline = std::time::Instant::now() + Duration::from_secs(15);
     while std::time::Instant::now() < edit_deadline {
+        let _ = std::fs::write(path.join("src/c.rs"), "pub fn cee() {}\n");
+        let _ = std::fs::write(
+            path.join("src/a.rs"),
+            "use crate::c::cee;\npub fn helper() { cee(); }\n",
+        );
         write_line(&mut stdin, &call_node_a);
         let resp = rx
             .recv_timeout(Duration::from_secs(5))


### PR DESCRIPTION
Fixes #18.

## Problem
`cxpak serve --mcp` built its index once at startup and never refreshed it (its own doc comment admitted "no periodic rebuild"). A warm MCP session returned stale structural answers after any edit — silently, no signal, no way to refresh short of restarting. The HTTP server (`cxpak serve`) already watched and hot-updated; the two transports had asymmetric freshness.

## Fix — ADR-0200 (in this PR)
Wire the proven HTTP watcher primitives into `run_mcp`, but with an **owned, terminable** thread (the HTTP watcher is a detached infinite loop — fine for a process-lifetime server, but it would leak into in-process tests and can't be joined on shutdown):
- `spawn_mcp_watcher` waits for the background build to become queryable (`Ready` **or** `ReadyEnriched`), seeds a mirrored `SharedIndex`, runs the existing `process_watcher_changes` on each debounced edit, and republishes `Ready(new)` into the readiness cell — which `tools/call` already snapshots per call.
- Lifecycle is owned: a `shutdown` `AtomicBool` is checked in both the pre-Ready wait (every 100ms → stdin EOF during the 13–34s build joins promptly) and the main poll loop; a `Failed` build aborts the watcher; `FileWatcher::new` failure is fail-open. `run_mcp` sets `shutdown` and joins both threads on exit.

### The subtle part — a race this fix had to *close*, not introduce
The opt-in embedding-enrichment phase (`publish_ready_enriched`, ADR-0186) is a **second writer** of the readiness cell: it blind-swapped `ReadyEnriched(startup_base)` seconds after `Ready`. Left naive, a watcher republish landing in that window would be silently clobbered by the late enrichment — reintroducing #18's exact defect with an embedding-adorned stale index. Fix: `publish_ready_enriched` is now a **compare-and-swap** — it swaps `ReadyEnriched` only if the cell still holds the exact base `Arc` it enriched (`Arc::ptr_eq`), else skips + logs. The `RwLock::write()` guard spans the full check-then-set, so it's a true atomic CAS. Every interleaving converges to the fresh index. Each watcher republish also clears `embedding_index` (a delta-rebuilt clone would otherwise serve a stale 7th signal). (This race was caught by the validation gate before implementation, not in review.)

The `refresh`/`reindex` MCP tool (the issue's stated *nice-to-have*) is deferred — it would be a third, uncoordinated writer of the cell; the debounced watcher fixes the core bug.

## Before / after (manual QA, real MCP stdio path)
```
BEFORE edit  node(src/foo.rs): out_degree 0
< edit: a.rs gains an out-edge, git commit >
AFTER edit   node(src/foo.rs): out_degree 1   <-- WARM session, no restart
```
(The Phase-0 reproduction served `out_degree 0` after the edit; now it reflects it.)

## Tests (RED→GREEN, deterministic)
Pure-function unit tests (no fixed-sleep asserts): enrich CAS skips-when-moved / swaps-when-unchanged; `classify_watcher_wait` (Ready/ReadyEnriched/Building/Failed); `republish_watcher_index` clears embedding; shutdown-on-signal and shutdown-during-pre-Ready-wait; abort-on-failed-build. Plus a **real-subprocess integration test** (`tests/mcp_freshness_subprocess.rs`): real `serve --mcp` binary, real stdio JSON-RPC, real FS edit through the `notify` FileWatcher, asserting the warm session reflects the edit and exits cleanly on stdin EOF — all waits bounded.

- `cargo test --workspace --features daemon`: green (incl. embeddings-gated CAS tests). `clippy --all-targets --all-features -D warnings`: clean. `fmt --check`: clean.
- Golden fixture `spa_output_matches_golden_fixture`: byte-identical. HTTP `run` watcher path untouched.
- Independent pre-PR review: enrich race confirmed fully closed for all interleavings; no blockers.

### Known, accepted limitations
- A watcher swap drops embedding enrichment (7→6 signal) until a future re-enrich (out of scope; logged).
- The `FileWatcher::new`-failure fail-open branch has no cheap failure-injection seam (scoped to the CI 90% coverage floor).
- A panic unwinding through the stdio loop would skip the thread joins — a pre-existing pattern (the build thread had the same), not a regression.

https://claude.ai/code/session_019hJMLmPVoGS2FeUUX4w4Jz
