### PR TITLE
fix: restrict test_coverage denominator to code files

### DIFF
--- a/src/intelligence/health.rs
+++ b/src/intelligence/health.rs
@@ -143,12 +143,24 @@ pub(crate) fn has_inline_tests(file: &crate::core_graph::IndexedFile) -> bool {
     }
 }
 
-/// Test coverage dimension: ratio of source files with >= 1 mapped test file or inline
-/// tests, scaled to [0, 10].
+/// Test coverage dimension: ratio of *code* source files with >= 1 mapped test file or
+/// inline tests, scaled to [0, 10].
+///
+/// The denominator is restricted to Tier-1 programming-language files
+/// (`parser::is_code_language`) — Tier-2 structural/config/doc files
+/// (Markdown, YAML, TOML, JSON, ...) and DB DSLs (SQL, Prisma) can never
+/// carry an inline test or a name-mapped test file, so counting them as
+/// uncovered "source files" dilutes the ratio. Files with an unrecognized
+/// or missing `language` are excluded too (can't classify as code).
 fn score_test_coverage(index: &CodebaseIndex) -> f64 {
     let source_files: Vec<&crate::core_graph::IndexedFile> = index
         .files
         .iter()
+        .filter(|f| {
+            f.language
+                .as_deref()
+                .is_some_and(crate::parser::is_code_language)
+        })
         .filter(|f| {
             // Exclude test files themselves from the denominator
             let p = &f.relative_path;
@@ -777,6 +789,87 @@ mod tests {
         assert!(
             (score - 5.0).abs() < 1e-9,
             "expected coverage score 5.0, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_score_test_coverage_excludes_non_code_files_from_denominator() {
+        // Regression for the bug where Tier-2 doc/config files (markdown,
+        // yaml, ...) were counted as uncovered "source files", diluting the
+        // ratio. Only the 2 Rust *code* files should land in the
+        // denominator; the 3 non-code files must be excluded entirely.
+        use crate::budget::counter::TokenCounter;
+        use crate::parser::language::ParseResult;
+        use crate::scanner::ScannedFile;
+        use std::collections::HashMap;
+
+        let counter = TokenCounter::new();
+        let files = vec![
+            ScannedFile {
+                relative_path: "src/with_tests.rs".into(),
+                absolute_path: std::path::PathBuf::from("/tmp/with_tests.rs"),
+                language: Some("rust".into()),
+                size_bytes: 60,
+            },
+            ScannedFile {
+                relative_path: "src/no_tests.rs".into(),
+                absolute_path: std::path::PathBuf::from("/tmp/no_tests.rs"),
+                language: Some("rust".into()),
+                size_bytes: 20,
+            },
+            ScannedFile {
+                relative_path: "docs/adrs/0001-example.md".into(),
+                absolute_path: std::path::PathBuf::from("/tmp/0001-example.md"),
+                language: Some("markdown".into()),
+                size_bytes: 40,
+            },
+            ScannedFile {
+                relative_path: "config/app.yaml".into(),
+                absolute_path: std::path::PathBuf::from("/tmp/app.yaml"),
+                language: Some("yaml".into()),
+                size_bytes: 15,
+            },
+            ScannedFile {
+                relative_path: "Cargo.toml".into(),
+                absolute_path: std::path::PathBuf::from("/tmp/Cargo.toml"),
+                language: Some("toml".into()),
+                size_bytes: 10,
+            },
+        ];
+        let parse_results: HashMap<String, ParseResult> = HashMap::new();
+        let mut content_map = HashMap::new();
+        content_map.insert(
+            "src/with_tests.rs".to_string(),
+            "pub fn foo() {}\n\n#[cfg(test)]\nmod tests { #[test] fn t() {} }".to_string(),
+        );
+        content_map.insert("src/no_tests.rs".to_string(), "pub fn bar() {}".to_string());
+        content_map.insert(
+            "docs/adrs/0001-example.md".to_string(),
+            "# ADR 0001\n\nSome decision text.".to_string(),
+        );
+        content_map.insert(
+            "config/app.yaml".to_string(),
+            "key: value\nother: 1".to_string(),
+        );
+        content_map.insert(
+            "Cargo.toml".to_string(),
+            "[package]\nname = \"x\"".to_string(),
+        );
+
+        let index = crate::core_graph::CodebaseIndex::build_with_content(
+            files,
+            parse_results,
+            &counter,
+            content_map,
+        );
+        let score = score_test_coverage(&index);
+        // Denominator must be the 2 Rust files only (docs/config excluded);
+        // 1 of 2 covered → 0.5 × 10 = 5.0. Before the fix, the denominator
+        // includes all 5 files (1 of 5 covered → 2.0), so this assertion
+        // fails on the pre-fix code.
+        assert!(
+            (score - 5.0).abs() < 1e-9,
+            "expected coverage score 5.0 (2 code files, 1 covered), got {score}"
         );
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -4,6 +4,53 @@ pub mod languages;
 use language::LanguageSupport;
 use std::collections::HashMap;
 
+/// Returns `true` when `lang` (an `IndexedFile.language`/`detect_language()`
+/// identifier, e.g. `"rust"`) names a Tier-1 programming language rather than
+/// a Tier-2 structural/config/doc language or a DB DSL.
+///
+/// Allowlist by design (Tier-1 identifiers only) rather than a denylist of
+/// non-code languages, so a future Tier-2 addition can't silently get
+/// counted as code. Independent of which `lang-*` feature flags are
+/// compiled in — a scanned file keeps its detected language even when the
+/// corresponding parser feature is disabled, so this can't be derived from
+/// `LanguageRegistry::supported_languages()`.
+///
+/// Used by `intelligence::health::score_test_coverage` to keep the
+/// denominator restricted to files that could plausibly carry a test.
+pub fn is_code_language(lang: &str) -> bool {
+    matches!(
+        lang,
+        "rust"
+            | "typescript"
+            | "javascript"
+            | "java"
+            | "python"
+            | "go"
+            | "c"
+            | "cpp"
+            | "ruby"
+            | "csharp"
+            | "swift"
+            | "kotlin"
+            | "bash"
+            | "php"
+            | "dart"
+            | "scala"
+            | "lua"
+            | "clojure"
+            | "elixir"
+            | "zig"
+            | "haskell"
+            | "groovy"
+            | "objc"
+            | "r"
+            | "julia"
+            | "ocaml"
+            | "ocaml_interface"
+            | "matlab"
+    )
+}
+
 pub struct LanguageRegistry {
     languages: HashMap<String, Box<dyn LanguageSupport>>,
 }
@@ -218,5 +265,28 @@ mod tests {
     fn test_get_nonexistent_language() {
         let registry = LanguageRegistry::new();
         assert!(registry.get("brainfuck").is_none());
+    }
+
+    #[test]
+    fn test_is_code_language_tier1() {
+        assert!(is_code_language("rust"));
+        assert!(is_code_language("python"));
+        assert!(is_code_language("java"));
+    }
+
+    #[test]
+    fn test_is_code_language_excludes_tier2() {
+        assert!(!is_code_language("markdown"));
+        assert!(!is_code_language("yaml"));
+        assert!(!is_code_language("toml"));
+        assert!(!is_code_language("json"));
+        assert!(!is_code_language("sql"));
+        assert!(!is_code_language("prisma"));
+    }
+
+    #[test]
+    fn test_is_code_language_unknown_is_not_code() {
+        assert!(!is_code_language("brainfuck"));
+        assert!(!is_code_language(""));
     }
 }


### PR DESCRIPTION
## Bug

`score_test_coverage` in `src/intelligence/health.rs` counted *every* scanned
file as a "source file" in its denominator, filtering out only test-*path*
patterns (`/tests/`, `_test.`, `.spec.`, etc.). It did not exclude non-code
files. cxpak scans Markdown, YAML, TOML, JSON, and other Tier-2 structural
files as first-class entries in `index.files`. None of these can carry an
inline test or a name-mapped test file, so every one of them was counted as
an *uncovered* "source file", diluting the ratio.

On this repo, 222 `.md`/config files alongside 173 `.rs` files (150 of which,
~87%, have inline `#[cfg(test)]` modules) tanked `test_coverage` to 4.4/10.

## Fix

- Add `parser::is_code_language(lang: &str) -> bool` — an allowlist of the
  28 Tier-1 programming-language identifiers (Rust, TypeScript, JavaScript,
  Python, Java, Go, C, C++, Ruby, C#, Swift, Kotlin, Bash, PHP, Dart, Scala,
  Lua, Elixir, Zig, Haskell, Groovy, Objective-C, R, Julia, OCaml, MATLAB,
  Clojure). No existing tier predicate was found to reuse (checked
  `LanguageSupport`/`LanguageRegistry`, the scanner, conventions, index
  modules) so this is new.
- `score_test_coverage` now filters its denominator through
  `f.language.as_deref().is_some_and(is_code_language)` *in addition to* the
  existing test-path exclusion. Tier-2 structural/config/doc languages
  (Markdown, JSON, YAML, TOML, Dockerfile, HCL, Protobuf, Svelte, Makefile,
  HTML, GraphQL, XML, CSS, SCSS), DB DSLs (SQL, Prisma), and files with an
  unrecognized/missing `language` are excluded from the denominator.

## Test

New RED-first unit test
`test_score_test_coverage_excludes_non_code_files_from_denominator` builds an
index with 2 Rust files (1 with `#[cfg(test)]`, 1 without) plus markdown/
yaml/toml files. Asserts the score is `5.0` (1 of 2 *code* files covered).
Confirmed it fails pre-fix (denominator = 5 files → `2.0`) and passes
post-fix. Existing `test_score_test_coverage_counts_inline_tests` (Rust-only
fixture) is unaffected and still passes. Added 3 unit tests for
`is_code_language` (Tier-1 true, Tier-2/DSL false, unknown/empty false).

Self-check: `cxpak overview --health .` on this repo — `test_coverage` went
from the previously observed 4.4/10 to **8.4/10** post-fix (composite 8.1/10).

## Scope

Restricted to the `test_coverage` denominator only; the other five health
dimensions are untouched. A further refinement — excluding zero-function
code files (e.g. re-export-only `mod.rs`) from the denominator — is a
reasonable follow-up but out of scope here.

Fixes #25