### PR TITLE
fix: canonicalize HTTP serve watcher root to stop silent staleness (#24)

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1377,8 +1377,28 @@ pub fn run(
     let shared = Arc::new(RwLock::new(Arc::new(index)));
     let shared_path = Arc::new(path.to_path_buf());
 
-    // Background watcher thread
-    let watcher_path = path.to_path_buf();
+    // Background watcher thread.
+    //
+    // Canonicalize the watch root: `notify` delivers canonical,
+    // symlink-resolved absolute paths, so `classify_changes`'
+    // `strip_prefix(base_path)` only matches when `base_path` is itself
+    // canonical. A raw (relative, or macOS `/tmp` -> `/private/tmp`, `/var`
+    // -> `/private/var`) root makes every event miss `strip_prefix`, silently
+    // dropping all edits and serving a stale index forever (issue #24 -- the
+    // HTTP-transport twin of #18's MCP watcher). Fail-open: if canonicalize
+    // fails (path already gone), fall back to the raw path rather than
+    // aborting the watcher, but log it because the miss is otherwise silent.
+    let watcher_path = match path.canonicalize() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!(
+                "cxpak: HTTP watcher canonicalize failed for {}: {e} — \
+                 file-change matching may silently miss edits under this root",
+                path.display()
+            );
+            path.to_path_buf()
+        }
+    };
     let watcher_index = Arc::clone(&shared);
     std::thread::spawn(move || {
         let watcher = match FileWatcher::new(&watcher_path) {

--- a/tests/serve_v1_subprocess.rs
+++ b/tests/serve_v1_subprocess.rs
@@ -642,6 +642,75 @@ mod v1_subprocess_tests {
         child.wait().ok();
     }
 
+    // ─── Warm-server index freshness (issue #24) ────────────────────────────
+
+    /// A warm `cxpak serve` (HTTP) must reflect a post-startup filesystem edit,
+    /// not serve the stale startup index forever.
+    ///
+    /// Regression guard for #24 (the HTTP-transport twin of #18): the watcher
+    /// thread in `commands::serve::run` watched the RAW CLI path, never the
+    /// canonicalized one. `notify` delivers canonical, symlink-resolved
+    /// absolute paths, so `classify_changes`' `strip_prefix(base_path)` missed
+    /// on every event when `base_path` was non-canonical — which every macOS
+    /// `TMPDIR` temp dir is (`/var/folders/...` -> `/private/var/folders/...`).
+    /// A `tempfile::TempDir` therefore reproduces the exact bug: pre-fix, the
+    /// server drops every edit and `total_files` never moves.
+    ///
+    /// The observable is `/v1/health`'s `total_files`, read live from the
+    /// swapped-in index under the read lock. Adding a file bumps it from N to
+    /// N+1 once the watcher applies the change; pre-fix it stays at N and this
+    /// test times out on the poll, failing.
+    #[test]
+    fn warm_server_reflects_new_file() {
+        let repo = make_test_repo();
+        let port = find_free_port();
+        let mut child = spawn_serve(&repo, port, None);
+        assert!(wait_for_server(port), "server did not start within 60s");
+
+        // Baseline count from the live index.
+        let (status, body) = http_request(port, "GET", "/v1/health", None, None);
+        assert_eq!(status, 200, "GET /v1/health baseline; body: {body}");
+        let before: u64 = serde_json::from_str::<Value>(&body)
+            .expect("/v1/health body must be JSON")["total_files"]
+            .as_u64()
+            .expect("/v1/health must return total_files");
+
+        // Bounded poll for the watcher's debounced rebuild to land. The new
+        // file is (re-)written each iteration rather than once before a fixed
+        // sleep: the watcher thread installs its `FileWatcher` asynchronously
+        // after `run` spawns it, so a create event that fires before the
+        // watch is installed produces nothing and is missed with no retry.
+        // Re-writing keeps producing events until the watch is live and
+        // catches one — no guessed-duration sleep, no install-timing flake.
+        let added = repo.path().join("src/added_by_test.rs");
+        let mut after = before;
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while Instant::now() < deadline {
+            std::fs::write(&added, "pub fn added() -> i32 { 7 }\n")
+                .expect("write new source file into the watched repo");
+            let (status, body) = http_request(port, "GET", "/v1/health", None, None);
+            assert_eq!(status, 200, "GET /v1/health during poll; body: {body}");
+            after = serde_json::from_str::<Value>(&body).expect("/v1/health body must be JSON")
+                ["total_files"]
+                .as_u64()
+                .expect("/v1/health must return total_files");
+            if after > before {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(200));
+        }
+
+        assert!(
+            after > before,
+            "warm HTTP server must reflect the added file (total_files {before} -> \
+             expected > {before}, got {after}) — the watcher is serving a stale \
+             index (issue #24)"
+        );
+
+        child.kill().ok();
+        child.wait().ok();
+    }
+
     // ─── SIGTERM graceful shutdown (Unix only) ──────────────────────────────
 
     /// Verifies that `cxpak serve` exits cleanly when sent SIGTERM, draining


### PR DESCRIPTION
Fixes #24.

## Problem
The background file-watcher spawned by `cxpak serve` (HTTP transport, `commands::serve::run`) watched the **raw** CLI path — `watcher_path = path.to_path_buf()` — never canonicalized. `notify` delivers canonical, symlink-resolved absolute paths, and `classify_changes` does `strip_prefix(base_path)` on every event. So when `base_path` is non-canonical — a relative dir, or anything under macOS `/tmp`/`/var` (every per-user `TMPDIR` resolves `/var` → `/private/var`) — **every** event's `strip_prefix` misses, and the HTTP server silently drops all edits and serves the startup index forever.

This is the **HTTP-transport twin of #18**, which fixed the identical silent-staleness mode for the MCP watcher in #23. The two watchers are separate setup paths, so #23's MCP-scoped fix didn't cover this one — hence this fast-follow.

## Fix
Canonicalize `watcher_path` in `run` with the same fail-open, log-on-failure guard used for the MCP watcher: on canonicalize failure fall back to the raw path (don't abort the watcher), but log it — the miss is otherwise silent.

## Test
`warm_server_reflects_new_file` (tests/serve_v1_subprocess.rs): a real `cxpak serve` subprocess on a `tempfile::TempDir` repo (non-canonical under macOS `TMPDIR` — exercises the exact bug) reads `/v1/health`'s `total_files` baseline, then in a bounded 30s deadline-poll re-writes a new source file each iteration and asserts `total_files` increments. No fixed sleep; the edit is re-asserted each poll so an event firing before the watcher installs isn't permanently missed. **Confirmed discriminating:** RED (fix reverted) failed `total_files 2 → 2` after 36s; GREEN (fix in place) passed `2 → 3` in 4s.

Full pre-commit suite green (fmt + clippy `-D warnings` + entire suite: 2464 lib + all integration binaries, 0 failed).

## Scope
HTTP watcher only. Independent of #18 (pre-existing on `main`), so this branches off `main`, not the #23 branch. When both land, the two watchers' near-identical canonicalize guards are a candidate for a shared helper — noted as a possible tidy-up, not done here.

https://claude.ai/code/session_019hJMLmPVoGS2FeUUX4w4Jz
