### PR TITLE
test: restore coverage gate (exclude vendored code, cover intelligence gaps)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         run: cargo install cargo-tarpaulin --version 0.35.2 --locked
       - name: Check coverage (90% minimum)
         run: |
-          OUTPUT=$(cargo tarpaulin --engine llvm --skip-clean --no-default-features --features "daemon,lang-rust,lang-typescript,lang-javascript,lang-java,lang-python,lang-go,lang-c,lang-cpp,lang-ruby,lang-csharp,lang-swift,lang-kotlin,lang-bash,lang-css,lang-scss,lang-php,lang-markdown,lang-json,lang-yaml,lang-toml,lang-dockerfile,lang-hcl,lang-dart,lang-scala,lang-lua,lang-clojure,lang-elixir,lang-zig,lang-haskell,lang-groovy,lang-objc,lang-r,lang-julia,lang-ocaml,lang-matlab,lang-proto,lang-svelte,lang-makefile,lang-html,lang-graphql,lang-xml,lang-sql,lang-prisma" --all-targets --timeout 600 2>&1) || true
+          OUTPUT=$(cargo tarpaulin --engine llvm --skip-clean --no-default-features --features "daemon,lang-rust,lang-typescript,lang-javascript,lang-java,lang-python,lang-go,lang-c,lang-cpp,lang-ruby,lang-csharp,lang-swift,lang-kotlin,lang-bash,lang-css,lang-scss,lang-php,lang-markdown,lang-json,lang-yaml,lang-toml,lang-dockerfile,lang-hcl,lang-dart,lang-scala,lang-lua,lang-clojure,lang-elixir,lang-zig,lang-haskell,lang-groovy,lang-objc,lang-r,lang-julia,lang-ocaml,lang-matlab,lang-proto,lang-svelte,lang-makefile,lang-html,lang-graphql,lang-xml,lang-sql,lang-prisma" --all-targets --timeout 600 --exclude-files 'vendor/*' 'references/*' 2>&1) || true
           echo "$OUTPUT"
           COVERAGE=$(echo "$OUTPUT" | grep -oP '[\d.]+(?=% coverage)' | tail -1)
           echo "Coverage: ${COVERAGE}%"

--- a/src/commands/overview.rs
+++ b/src/commands/overview.rs
@@ -1017,4 +1017,105 @@ mod tests {
         // Should show 0% for each language
         assert!(result.contains("0%"));
     }
+
+    // -----------------------------------------------------------------------
+    // End-to-end `run()` coverage: empty repo error path, and a full
+    // pipeline run exercising pack mode, verbose logging, the health
+    // section, writing to an output file, and the cache-save failure path.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_run_errors_on_no_source_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+
+        let result = run(
+            dir.path(),
+            50000,
+            &OutputFormat::Markdown,
+            None,
+            false,
+            None,
+            false,
+            false,
+            None,
+        );
+
+        let err = result.expect_err("empty repo must fail with no source files");
+        assert!(
+            err.to_string().contains("no source files"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn test_run_full_pipeline_pack_mode_health_and_cache_error() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+
+        // Keep the scanner from walking our synthetic .cxpak/cache fixture.
+        std::fs::write(dir.path().join(".gitignore"), ".cxpak/\n").unwrap();
+
+        // Pre-seed .cxpak/cache as a *file* (not a directory). The cache
+        // refresh step will then fail to `create_dir_all` over it, exercising
+        // the verbose warning branch on the save error path.
+        std::fs::create_dir_all(dir.path().join(".cxpak")).unwrap();
+        std::fs::write(dir.path().join(".cxpak").join("cache"), "not a directory").unwrap();
+
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"fixture\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        let mut main_rs = String::from("fn main() {\n    greet();\n}\n\n");
+        for i in 0..40 {
+            main_rs.push_str(&format!(
+                "pub fn helper_{i}(value: i32) -> i32 {{ value + {i} }}\n"
+            ));
+        }
+        std::fs::write(dir.path().join("src").join("main.rs"), &main_rs).unwrap();
+        std::fs::write(
+            dir.path().join("src").join("lib.rs"),
+            "pub fn greet() -> String { \"hello\".to_string() }\n",
+        )
+        .unwrap();
+
+        let out_path = dir.path().join("context.md");
+
+        // A tiny budget forces pack_mode and truncates every section,
+        // guaranteeing at least one detail file gets written.
+        let result = run(
+            dir.path(),
+            100,
+            &OutputFormat::Markdown,
+            Some(out_path.as_path()),
+            true, // verbose: exercises the "wrote", "pack mode", "written to",
+            // and cache-save-warning eprintln branches
+            None,
+            false,
+            true, // health: appends the Codebase Health section
+            None,
+        );
+
+        assert!(
+            result.is_ok(),
+            "run() must still succeed despite the cache-save error: {result:?}"
+        );
+
+        let rendered = std::fs::read_to_string(&out_path).expect("output file must be written");
+        assert!(
+            rendered.contains("Codebase Health"),
+            "health section must be appended when health=true"
+        );
+        assert!(
+            rendered.contains("Composite:"),
+            "health section must include the composite score"
+        );
+
+        assert!(
+            dir.path().join(".cxpak").exists(),
+            "pack mode must keep the .cxpak directory"
+        );
+    }
 }

--- a/src/context_quality/degradation.rs
+++ b/src/context_quality/degradation.rs
@@ -511,6 +511,13 @@ mod tests {
     }
 
     #[test]
+    fn test_concept_priority_catch_all_variant() {
+        // SymbolKind::Macro has no explicit arm in concept_priority — it must
+        // fall through to the catch-all (imports and any future variants).
+        assert_eq!(concept_priority(&SymbolKind::Macro), 0.14);
+    }
+
+    #[test]
     fn test_concept_priority_ordering_is_monotonic() {
         assert!(concept_priority(&SymbolKind::Function) > concept_priority(&SymbolKind::Struct));
         assert!(concept_priority(&SymbolKind::Struct) > concept_priority(&SymbolKind::Message));
@@ -765,6 +772,38 @@ mod tests {
     }
 
     #[test]
+    fn test_split_giant_single_line_becomes_own_chunk() {
+        // A single line whose own token count alone exceeds MAX_SYMBOL_TOKENS is
+        // the pathological case: it must be flushed as its own one-line chunk
+        // rather than merged with surrounding lines.
+        let giant_line = "word ".repeat(5000);
+        let body = format!("pub fn giant() {{\n{giant_line}\n    let after = 1;\n}}");
+        let sym = Symbol {
+            name: "giant".to_string(),
+            kind: SymbolKind::Function,
+            visibility: Visibility::Public,
+            signature: "pub fn giant()".to_string(),
+            body: body.clone(),
+            start_line: 1,
+            end_line: 3,
+        };
+        let chunks = split_oversized_symbol(&sym, &body);
+        assert!(
+            chunks.len() > 1,
+            "the giant line must force a split, got {} chunk(s)",
+            chunks.len()
+        );
+        let has_isolated_giant_chunk = chunks
+            .iter()
+            .any(|c| c.rendered.contains("word word") && !c.rendered.contains("let after"));
+        assert!(
+            has_isolated_giant_chunk,
+            "the oversized line must occupy a chunk by itself, chunk sizes: {:?}",
+            chunks.iter().map(|c| c.rendered.len()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn test_split_line_numbers_adjusted() {
         let big_body = (0..500)
             .map(|i| format!("    let v{i} = f{i}();"))
@@ -875,6 +914,88 @@ mod tests {
         let files = vec![(&file, FileRole::Selected, 0.8)];
         let result = allocate_with_degradation(&files, 1000, None);
         assert_eq!(result[0].level, DetailLevel::Full);
+    }
+
+    #[test]
+    fn test_allocate_skips_raw_fast_path_but_fits_at_full_render() {
+        // The file's stored `token_count` (an independent, inflated field —
+        // e.g. computed from raw file bytes including whitespace/comments) is
+        // far above budget, so the raw-token fast path must be skipped. But
+        // the symbol's actual rendered body is tiny, so the *next* fast path
+        // (compute_total of the real Full-detail render) must still succeed.
+        let file = make_indexed_file("inflated.rs", 5000, vec![make_fn_symbol("tiny", 5)]);
+        let files = vec![(&file, FileRole::Selected, 0.8)];
+        let result = allocate_with_degradation(&files, 100, None);
+        assert_eq!(result[0].path, "inflated.rs");
+        assert_eq!(
+            result[0].level,
+            DetailLevel::Full,
+            "real rendered content fits the budget even though the raw token_count field did not"
+        );
+    }
+
+    fn make_long_signature_symbol(name: &str, num_params: usize) -> Symbol {
+        let params: String = (0..num_params)
+            .map(|i| format!("arg_{i}: Type{i}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let signature = format!("pub fn {name}({params})");
+        Symbol {
+            name: name.to_string(),
+            kind: SymbolKind::Function,
+            visibility: Visibility::Public,
+            signature: signature.clone(),
+            body: format!("{signature} {{\n    do_work();\n}}"),
+            start_line: 1,
+            end_line: 3,
+        }
+    }
+
+    #[test]
+    fn test_allocate_phase3_drops_dependency_when_degradation_alone_is_not_enough() {
+        // Two dependency files carry huge parameter-list signatures, so their
+        // cost survives every detail level down to Stub (Stub still renders
+        // the full signature). The selected file is tiny. Degrading everything
+        // to its floor (dep=Stub, sel=Documented) still cannot fit the budget,
+        // so Phase 3 must drop a dependency's content entirely to succeed.
+        // token_count must reflect the real rendered cost (~2100 tokens for a
+        // 300-param signature) so the raw-token-count fast path at the top of
+        // allocate_with_degradation does not short-circuit before Phase 3 runs.
+        let sel = make_indexed_file("sel.rs", 15, vec![make_fn_symbol("sel", 10)]);
+        let dep_a = make_indexed_file(
+            "dep_a.rs",
+            2200,
+            vec![make_long_signature_symbol("dep_a", 300)],
+        );
+        let dep_b = make_indexed_file(
+            "dep_b.rs",
+            2200,
+            vec![make_long_signature_symbol("dep_b", 300)],
+        );
+
+        let files = vec![
+            (&sel, FileRole::Selected, 0.9),
+            (&dep_a, FileRole::Dependency, 0.2),
+            (&dep_b, FileRole::Dependency, 0.1),
+        ];
+
+        let result = allocate_with_degradation(&files, 900, None);
+
+        let dep_a_alloc = result.iter().find(|r| r.path == "dep_a.rs").unwrap();
+        let dep_b_alloc = result.iter().find(|r| r.path == "dep_b.rs").unwrap();
+        assert!(
+            dep_a_alloc.symbols.is_empty() || dep_b_alloc.symbols.is_empty(),
+            "expected at least one huge-signature dependency to be dropped entirely by Phase 3: \
+             dep_a symbols={}, dep_b symbols={}",
+            dep_a_alloc.symbols.len(),
+            dep_b_alloc.symbols.len()
+        );
+        // The selected file must always survive with rendered content.
+        let sel_alloc = result.iter().find(|r| r.path == "sel.rs").unwrap();
+        assert!(
+            !sel_alloc.symbols.is_empty(),
+            "a Selected file must never be dropped entirely"
+        );
     }
 
     // --- pagerank-aware allocation test ---

--- a/src/index/graph.rs
+++ b/src/index/graph.rs
@@ -592,6 +592,19 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_rust_super_exhausted_returns_none() {
+        // `super::` resolves to a real directory, but no candidate file for the
+        // remaining path segment exists anywhere (neither the direct file, nor
+        // any progressive-shortening prefix, nor the zero-segment mod.rs
+        // fallback) — must fall through to the final `None`.
+        let all: HashSet<&str> = ["src/other.rs"].iter().copied().collect();
+        assert_eq!(
+            resolve_rust_import("src/sub/mod.rs", "super::totally_missing", &all),
+            None
+        );
+    }
+
+    #[test]
     fn test_resolve_rust_external_returns_none() {
         let all: HashSet<&str> = ["src/main.rs"].iter().copied().collect();
         assert_eq!(
@@ -638,6 +651,67 @@ mod tests {
         assert_eq!(
             resolve_python_import("app/bar.py", ".", &all),
             Some("app/__init__.py".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_python_single_dot_no_match_returns_none() {
+        // Progressive prefix shortening exhausts every candidate for a single
+        // leading dot with no matching file anywhere.
+        let all: HashSet<&str> = ["app/other.py"].iter().copied().collect();
+        assert_eq!(resolve_python_import("app/bar.py", ".missing", &all), None);
+    }
+
+    #[test]
+    fn test_resolve_python_bare_double_dot_package() {
+        // `from .. import Y` (dots=2, nothing after) walks up one directory
+        // from a non-top-level file and resolves to that package's __init__.py.
+        let all: HashSet<&str> = ["app/__init__.py"].iter().copied().collect();
+        assert_eq!(
+            resolve_python_import("app/sub/inner.py", "..", &all),
+            Some("app/__init__.py".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_python_bare_double_dot_from_top_level() {
+        // From a top-level file, walking up one more directory than exists
+        // leaves an empty target_dir — exercises the target_dir.is_empty()
+        // branch when the remaining path (after the dots) is also empty.
+        let all: HashSet<&str> = ["__init__.py"].iter().copied().collect();
+        assert_eq!(
+            resolve_python_import("sub/inner.py", "..", &all),
+            Some("__init__.py".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_python_double_dot_target_dir_empty_with_name() {
+        // From a top-level file, ".." plus a following segment still resolves
+        // when walking up leaves an empty target_dir (root-relative candidates,
+        // the target_dir.is_empty() branch of the progressive-shortening loop).
+        let all: HashSet<&str> = ["sibling.py"].iter().copied().collect();
+        assert_eq!(
+            resolve_python_import("inner.py", "..sibling", &all),
+            Some("sibling.py".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_python_double_dot_no_match_returns_none() {
+        let all: HashSet<&str> = ["app/other.py"].iter().copied().collect();
+        assert_eq!(
+            resolve_python_import("app/sub/inner.py", "..missing", &all),
+            None
+        );
+    }
+
+    #[test]
+    fn test_resolve_python_absolute_no_match_returns_none() {
+        let all: HashSet<&str> = ["other/thing.py"].iter().copied().collect();
+        assert_eq!(
+            resolve_python_import("main.py", "missing.module", &all),
+            None
         );
     }
 
@@ -716,6 +790,28 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_ts_dot_without_slash() {
+        // `.foo` (a leading dot with no following slash) is the edge case
+        // fallback branch, distinct from `./foo` and `../foo`.
+        let all: HashSet<&str> = ["src/foo.ts"].iter().copied().collect();
+        assert_eq!(
+            resolve_ts_import("src/bar.ts", ".foo", &all),
+            Some("src/foo.ts".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_ts_dot_without_slash_top_level() {
+        // Same edge case, but the source file has no directory component —
+        // exercises the source_dir.is_empty() branch of that fallback.
+        let all: HashSet<&str> = ["foo.ts"].iter().copied().collect();
+        assert_eq!(
+            resolve_ts_import("bar.ts", ".foo", &all),
+            Some("foo.ts".to_string())
+        );
+    }
+
+    #[test]
     fn test_resolve_ts_external_returns_none() {
         let all: HashSet<&str> = ["src/main.ts"].iter().copied().collect();
         assert_eq!(resolve_ts_import("src/main.ts", "react", &all), None);
@@ -752,6 +848,17 @@ mod tests {
         assert_eq!(
             resolve_import("app/views.py", ".models", &all),
             Some("app/models.py".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_import_dispatches_legacy_for_unknown_extension() {
+        // A source file extension that isn't rs/py/pyi/ts/tsx/js/jsx/mjs falls
+        // through to the catch-all legacy resolver.
+        let all: HashSet<&str> = ["foo.go"].iter().copied().collect();
+        assert_eq!(
+            resolve_import("main.go", "foo", &all),
+            Some("foo.go".to_string())
         );
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -1546,4 +1546,146 @@ mod tests {
         assert_eq!(index.files.len(), 1);
         assert_eq!(index.files[0].relative_path, "a.rs");
     }
+
+    #[test]
+    fn test_incremental_rebuild_reparses_when_existing_mtime_missing() {
+        // When the stored IndexedFile has no mtime (e.g. loaded from a cache
+        // that didn't record one), the `needs_update` match falls into its
+        // wildcard arm and must always force a re-parse, regardless of what
+        // the freshly-scanned file's mtime turns out to be.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let fp = dir.path().join("a.rs");
+        std::fs::write(&fp, "fn old() {}").unwrap();
+        let files = vec![ScannedFile {
+            relative_path: "a.rs".into(),
+            absolute_path: fp.clone(),
+            language: Some("rust".into()),
+            size_bytes: 11,
+        }];
+        let mut index = CodebaseIndex::build(files, HashMap::new(), &counter);
+        assert!(
+            index.files[0].mtime_secs.is_some(),
+            "precondition: disk build populates mtime"
+        );
+        index.files[0].mtime_secs = None;
+
+        let current = vec![ScannedFile {
+            relative_path: "a.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: 11,
+        }];
+        index.incremental_rebuild(&current, &HashMap::new(), &counter);
+        assert!(
+            index.files[0].mtime_secs.is_some(),
+            "the wildcard re-parse arm must have run upsert_file, repopulating mtime_secs from disk"
+        );
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn test_build_embedding_index_no_public_symbols_returns_none() {
+        // create_provider succeeds (api_key_env is left empty so no environment
+        // variable is required), but the index has no files/symbols at all —
+        // must short-circuit to None before ever attempting to embed anything.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(".cxpak.json"),
+            r#"{"embeddings": {"provider": "openai", "api_key_env": "", "base_url": "http://127.0.0.1:1", "dimensions": 4}}"#,
+        )
+        .unwrap();
+        let index = CodebaseIndex::empty();
+        let result =
+            build_embedding_index(&index, dir.path(), crate::relevance::RelevanceMode::Inert);
+        assert!(
+            result.is_none(),
+            "an index with no symbols must yield no embedding index"
+        );
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn test_build_embedding_index_success_bare_and_contextual() {
+        // Spin up a loopback-only fake OpenAI-compatible embeddings endpoint so
+        // the full success path (provider construction, symbol collection,
+        // batch embedding, and index population) runs without any real network
+        // access or model download. Exercised under both RelevanceMode::Inert
+        // (bare signature embedded) and RelevanceMode::Active (contextual
+        // header prepended), since both branches live in the same function.
+        use tiny_http::{Response, Server};
+
+        let server = Server::http("127.0.0.1:0").expect("failed to bind local HTTP server");
+        let port = server
+            .server_addr()
+            .to_ip()
+            .expect("server_addr is not an IP")
+            .port();
+        let _handle = std::thread::spawn(move || {
+            for request in server.incoming_requests() {
+                let body = serde_json::json!({
+                    "data": [{"embedding": [0.1_f32, 0.2, 0.3, 0.4]}]
+                });
+                let response = Response::from_string(body.to_string()).with_header(
+                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                        .expect("valid header"),
+                );
+                let _ = request.respond(response);
+            }
+        });
+
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let fp = dir.path().join("api.rs");
+        std::fs::write(&fp, "pub fn handle_request() {}").unwrap();
+        let files = vec![ScannedFile {
+            relative_path: "api.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: 27,
+        }];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "api.rs".to_string(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "handle_request".into(),
+                    kind: crate::parser::language::SymbolKind::Function,
+                    visibility: Visibility::Public,
+                    signature: "pub fn handle_request()".into(),
+                    body: "{}".into(),
+                    start_line: 1,
+                    end_line: 1,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let index = CodebaseIndex::build(files, parse_results, &counter);
+
+        std::fs::write(
+            dir.path().join(".cxpak.json"),
+            format!(
+                r#"{{"embeddings": {{"provider": "openai", "api_key_env": "", "base_url": "http://127.0.0.1:{port}", "dimensions": 4, "batch_size": 64}}}}"#
+            ),
+        )
+        .unwrap();
+
+        let bare =
+            build_embedding_index(&index, dir.path(), crate::relevance::RelevanceMode::Inert)
+                .expect(
+                "bare-mode embedding index should build successfully against the local fake server",
+            );
+        assert!(
+            !bare.is_empty(),
+            "successful embed_batch must populate the index"
+        );
+        assert_eq!(bare.len(), 1);
+
+        let contextual =
+            build_embedding_index(&index, dir.path(), crate::relevance::RelevanceMode::Active)
+                .expect("contextual-mode embedding index should build successfully");
+        assert!(!contextual.is_empty());
+        assert_eq!(contextual.len(), 1);
+    }
 }

--- a/src/intelligence/call_graph.rs
+++ b/src/intelligence/call_graph.rs
@@ -1174,4 +1174,149 @@ fn helper(_y: i32) -> i32 { 0 }
             cg.unresolved
         );
     }
+
+    // ─── extract_body_from_offset direct tests ──────────────────────────────
+
+    #[test]
+    fn extract_body_from_offset_returns_empty_when_body_start_beyond_end() {
+        let source = "fn foo(";
+        let offset = source.len();
+        assert_eq!(extract_body_from_offset(source, offset), "");
+    }
+
+    #[test]
+    fn extract_body_from_offset_handles_nested_braces() {
+        // Depth must go 1 (entering) -> 2 (nested open) -> 1 (nested close,
+        // not yet zero) -> 0 (final close, stop).
+        let body = extract_body_from_offset("X{a{b}c}", 0);
+        assert_eq!(body, "a{b}c");
+    }
+
+    #[test]
+    fn extract_body_from_offset_handles_colon_delimited_body() {
+        // No opening brace before EOF but a ':' — the indent-delimited
+        // (Python-style) fallback takes the following lines verbatim.
+        let source = "def foo():\n    return 1\n    return 2\n";
+        let body = extract_body_from_offset(source, 0);
+        assert!(body.contains("return 1"));
+        assert!(body.contains("return 2"));
+    }
+
+    // ─── extract_func_name / find_identifier_deep direct tests ─────────────
+
+    #[cfg(feature = "lang-go")]
+    #[test]
+    fn test_extract_calls_go_receiver_method_name_unresolved() {
+        // Go's `method_declaration` name field is a `field_identifier`, not
+        // `identifier` — `extract_func_name` has no branch that resolves that
+        // kind (no "identifier"/"name" child, no declarator chain), so a
+        // receiver method's call sites are never attributed to it. This pins
+        // down the current (fallback-to-None) behaviour rather than treating
+        // it as a Go-support gap to fix here.
+        let source =
+            "package main\ntype Receiver struct{}\nfunc (r *Receiver) DoWork() {\n\thelper()\n}\nfunc helper() {}\n";
+        let calls = extract_call_sites_from_source(source, "go", "DoWork");
+        assert!(
+            calls.is_empty(),
+            "receiver method name cannot currently be resolved by extract_func_name: {:?}",
+            calls
+        );
+    }
+
+    #[cfg(feature = "lang-c")]
+    #[test]
+    fn find_identifier_deep_returns_none_for_subtree_without_identifier_then_continues() {
+        // `function_definition`'s first child is the return-type node (e.g.
+        // the `void` `primitive_type` leaf), which has no identifier
+        // subtree anywhere — `find_identifier_deep` must return None for it
+        // (its empty-recursion fallback) before the search loop continues to
+        // the `declarator` child, which does contain the function's name.
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_c::LANGUAGE.into())
+            .unwrap();
+        let source = "void handler() { init(); }\n";
+        let tree = parser.parse(source, None).unwrap();
+        let root = tree.root_node();
+        let func_def = root.child(0).expect("function_definition node");
+        assert_eq!(func_def.kind(), "function_definition");
+
+        let name = find_identifier_deep(&func_def, source.as_bytes());
+        assert_eq!(name, Some("handler".to_string()));
+    }
+
+    // ─── extract_call_name attribute-fallback direct test ───────────────────
+
+    #[test]
+    fn test_extract_calls_python_method_call_via_attribute_access() {
+        // Python's `attribute` node names its member field with plain
+        // `identifier` (not `field_identifier`/`property_identifier`), so
+        // resolution must go through extract_call_name's fallback branch
+        // that scans for a bare identifier/name child.
+        let source = "class Foo:\n    def run(self):\n        self.helper()\n        obj.method_call()\n    def helper(self):\n        pass\n";
+        let calls = extract_call_sites_from_source(source, "python", "run");
+        assert!(
+            calls.contains(&"helper".to_string()),
+            "expected helper via self.helper() attribute call, got {:?}",
+            calls
+        );
+        assert!(
+            calls.contains(&"method_call".to_string()),
+            "expected method_call via obj.method_call() attribute call, got {:?}",
+            calls
+        );
+    }
+
+    // ─── build_call_graph self-recursion test ───────────────────────────────
+
+    #[test]
+    fn test_build_call_graph_skips_self_recursive_calls() {
+        use crate::core_graph::CodebaseIndex;
+        use crate::parser::language::{ParseResult, Symbol, SymbolKind, Visibility};
+        use crate::scanner::ScannedFile;
+        use std::collections::HashMap;
+
+        let counter = crate::budget::counter::TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let src =
+            "fn factorial(n: i32) -> i32 {\n    if n <= 1 { 1 } else { n * factorial(n - 1) }\n}\n";
+        let fp = dir.path().join("lib.rs");
+        std::fs::write(&fp, src).unwrap();
+
+        let files = vec![ScannedFile {
+            relative_path: "lib.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: src.len() as u64,
+        }];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "lib.rs".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "factorial".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Private,
+                    signature: "fn factorial(n: i32) -> i32".into(),
+                    body: "{}".into(),
+                    start_line: 1,
+                    end_line: 3,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let mut content_map = HashMap::new();
+        content_map.insert("lib.rs".to_string(), src.to_string());
+        let index = CodebaseIndex::build_with_content(files, parse_results, &counter, content_map);
+
+        let cg = build_call_graph(&index);
+        assert!(
+            !cg.edges
+                .iter()
+                .any(|e| e.caller_symbol == "factorial" && e.callee_symbol == "factorial"),
+            "a recursive self-call must not produce a self-referencing edge: {:?}",
+            cg.edges
+        );
+    }
 }

--- a/src/intelligence/cross_lang.rs
+++ b/src/intelligence/cross_lang.rs
@@ -1117,4 +1117,432 @@ subprocess.run(["my-binary", "--arg"])
         assert_eq!(edge.target_language, "python");
         assert_eq!(edge.bridge_type, BridgeType::HttpCall);
     }
+
+    #[test]
+    fn test_is_test_path_matches_dunder_tests_directory() {
+        assert!(is_test_path("frontend/__tests__/api.spec.ts"));
+        assert!(!is_test_path("frontend/components/api.ts"));
+    }
+
+    #[test]
+    fn test_normalize_route_path_trims_to_root() {
+        // A bare "/" trims to an empty string internally and must normalize
+        // back to "/", not "".
+        assert_eq!(normalize_route_path("/"), "/");
+        assert_eq!(normalize_route_path("/users/"), "/users");
+    }
+
+    #[test]
+    fn test_detect_http_bridge_skips_self_referencing_route() {
+        // A fetch() call to a route registered in the SAME file must not
+        // produce a self-referencing edge.
+        let index = build_index(&[(
+            "backend/api.py",
+            "python",
+            "from fastapi import FastAPI\n@app.get(\"/api/users\")\ndef get_users():\n    return fetch(\"/api/users\")\n",
+        )]);
+        let edges = detect_http_bridges(&index);
+        assert!(
+            edges.is_empty(),
+            "a fetch call to a route defined in the same file must not self-link: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn test_detect_ffi_binding_python_ctypes() {
+        // ctypes.CDLL("libfoo.so").my_c_func(...) should resolve to the C
+        // file that exports a symbol named `my_c_func`.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let py = dir.path().join("wrapper.py");
+        std::fs::write(
+            &py,
+            "import ctypes\nresult = ctypes.CDLL(\"libfoo.so\").my_c_func(3)\n",
+        )
+        .unwrap();
+
+        let c = dir.path().join("native/foo.c");
+        std::fs::create_dir_all(c.parent().unwrap()).unwrap();
+        std::fs::write(&c, "int my_c_func(int x) { return x + 1; }\n").unwrap();
+
+        let files = vec![
+            ScannedFile {
+                relative_path: "wrapper.py".into(),
+                absolute_path: py,
+                language: Some("python".into()),
+                size_bytes: 64,
+            },
+            ScannedFile {
+                relative_path: "native/foo.c".into(),
+                absolute_path: c,
+                language: Some("c".into()),
+                size_bytes: 40,
+            },
+        ];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "wrapper.py".to_string(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "<module>".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Private,
+                    signature: "".into(),
+                    body: "".into(),
+                    start_line: 1,
+                    end_line: 2,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        parse_results.insert(
+            "native/foo.c".to_string(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "my_c_func".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Public,
+                    signature: "int my_c_func(int)".into(),
+                    body: "{}".into(),
+                    start_line: 1,
+                    end_line: 1,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let index = CodebaseIndex::build(files, parse_results, &counter);
+        let edges = detect_ffi_bridges(&index);
+        assert!(
+            edges.iter().any(|e| e.bridge_type == BridgeType::FfiBinding
+                && e.source_file == "wrapper.py"
+                && e.target_file == "native/foo.c"
+                && e.target_symbol == "my_c_func"
+                && e.source_language == "python"
+                && e.target_language == "c"),
+            "expected Python ctypes.CDLL FFI edge: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn test_detect_grpc_call_with_service_kinded_symbol() {
+        // Unlike `test_detect_grpc_call` (which uses a mis-kinded symbol and
+        // tolerates zero matches), this seeds `SymbolKind::Service` so the
+        // detector must deterministically produce exactly one edge.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let go = dir.path().join("client/main.go");
+        std::fs::create_dir_all(go.parent().unwrap()).unwrap();
+        std::fs::write(
+            &go,
+            "package main\nfunc run() { userServiceClient.GetUser(ctx, req) }\n",
+        )
+        .unwrap();
+
+        let proto = dir.path().join("proto/user.proto");
+        std::fs::create_dir_all(proto.parent().unwrap()).unwrap();
+        std::fs::write(
+            &proto,
+            "service UserService { rpc GetUser (GetUserRequest) returns (User); }\n",
+        )
+        .unwrap();
+
+        let files = vec![
+            ScannedFile {
+                relative_path: "client/main.go".into(),
+                absolute_path: go,
+                language: Some("go".into()),
+                size_bytes: 80,
+            },
+            ScannedFile {
+                relative_path: "proto/user.proto".into(),
+                absolute_path: proto,
+                language: Some("protobuf".into()),
+                size_bytes: 60,
+            },
+        ];
+
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "client/main.go".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "run".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Public,
+                    signature: "func run()".into(),
+                    body: "{}".into(),
+                    start_line: 1,
+                    end_line: 2,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        parse_results.insert(
+            "proto/user.proto".into(),
+            ParseResult {
+                symbols: vec![
+                    Symbol {
+                        name: "UserService".into(),
+                        kind: SymbolKind::Service,
+                        visibility: Visibility::Public,
+                        signature: "service UserService".into(),
+                        body: "{}".into(),
+                        start_line: 1,
+                        end_line: 1,
+                    },
+                    Symbol {
+                        name: "GetUser".into(),
+                        kind: SymbolKind::Method,
+                        visibility: Visibility::Public,
+                        signature: "rpc GetUser".into(),
+                        body: "".into(),
+                        start_line: 1,
+                        end_line: 1,
+                    },
+                ],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+
+        let index = CodebaseIndex::build(files, parse_results, &counter);
+        let edges = detect_grpc_bridges(&index);
+        assert_eq!(
+            edges.len(),
+            1,
+            "expected exactly one GrpcCall edge: {edges:#?}"
+        );
+        let e = &edges[0];
+        assert_eq!(e.bridge_type, BridgeType::GrpcCall);
+        assert_eq!(e.source_file, "client/main.go");
+        assert_eq!(e.source_symbol, "run");
+        assert_eq!(e.source_language, "go");
+        assert_eq!(e.target_file, "proto/user.proto");
+        assert_eq!(e.target_symbol, "UserService.GetUser");
+        assert_eq!(e.target_language, "protobuf");
+    }
+
+    #[test]
+    fn test_detect_graphql_call_with_query_kinded_symbol() {
+        // Unlike `test_detect_graphql_call` (which uses a mis-kinded symbol
+        // and tolerates zero matches), this seeds `SymbolKind::Query` so the
+        // detector must deterministically produce exactly one edge.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let ts = dir.path().join("src/client.ts");
+        std::fs::create_dir_all(ts.parent().unwrap()).unwrap();
+        std::fs::write(&ts, r#"const q = `query GetUser { user { id } }`;"#).unwrap();
+
+        let gql = dir.path().join("schema.graphql");
+        std::fs::write(&gql, "type Query { GetUser: User }\n").unwrap();
+
+        let files = vec![
+            ScannedFile {
+                relative_path: "src/client.ts".into(),
+                absolute_path: ts,
+                language: Some("typescript".into()),
+                size_bytes: 60,
+            },
+            ScannedFile {
+                relative_path: "schema.graphql".into(),
+                absolute_path: gql,
+                language: Some("graphql".into()),
+                size_bytes: 30,
+            },
+        ];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "schema.graphql".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "GetUser".into(),
+                    kind: SymbolKind::Query,
+                    visibility: Visibility::Public,
+                    signature: "GetUser: User".into(),
+                    body: "".into(),
+                    start_line: 1,
+                    end_line: 1,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        parse_results.insert(
+            "src/client.ts".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "<module>".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Private,
+                    signature: "".into(),
+                    body: "".into(),
+                    start_line: 1,
+                    end_line: 1,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let index = CodebaseIndex::build(files, parse_results, &counter);
+        let edges = detect_graphql_bridges(&index);
+        assert_eq!(
+            edges.len(),
+            1,
+            "expected exactly one GraphqlCall edge: {edges:#?}"
+        );
+        let e = &edges[0];
+        assert_eq!(e.bridge_type, BridgeType::GraphqlCall);
+        assert_eq!(e.source_file, "src/client.ts");
+        assert_eq!(e.source_language, "typescript");
+        assert_eq!(e.target_file, "schema.graphql");
+        assert_eq!(e.target_symbol, "GetUser");
+        assert_eq!(e.target_language, "graphql");
+    }
+
+    #[test]
+    fn test_detect_shared_schema_skips_edges_with_missing_or_langless_source() {
+        // Two defensive `continue` branches: an edge keyed by a source_file
+        // string that does not correspond to any file in `index.files`, and
+        // an edge from a file that IS in `index.files` but has `language:
+        // None`. Neither should panic or count as a valid schema toucher.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let py = dir.path().join("known.py");
+        std::fs::write(&py, r#"cursor.execute("SELECT * FROM users")"#).unwrap();
+        let unknown = dir.path().join("unknown.txt");
+        std::fs::write(&unknown, "no language assigned").unwrap();
+
+        let files = vec![
+            ScannedFile {
+                relative_path: "known.py".into(),
+                absolute_path: py,
+                language: Some("python".into()),
+                size_bytes: 40,
+            },
+            ScannedFile {
+                relative_path: "unknown.txt".into(),
+                absolute_path: unknown,
+                language: None,
+                size_bytes: 20,
+            },
+        ];
+        let parse_results = HashMap::new();
+        let mut index = CodebaseIndex::build(files, parse_results, &counter);
+
+        // Source file present in index.files but with no language.
+        index
+            .graph
+            .add_edge("unknown.txt", "db/schema.sql", EdgeType::EmbeddedSql);
+        // Source file string with no corresponding entry in index.files at all.
+        index
+            .graph
+            .add_edge("ghost.py", "db/schema.sql", EdgeType::EmbeddedSql);
+        // One legitimate toucher — without a second, *different-language*
+        // toucher counted alongside it, no pair can form.
+        index
+            .graph
+            .add_edge("known.py", "db/schema.sql", EdgeType::EmbeddedSql);
+
+        let edges = detect_shared_schema_bridges(&index);
+        assert!(
+            edges.is_empty(),
+            "missing-file and langless-file edges must be skipped, leaving only \
+             one (insufficient for a pair) toucher: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn test_detect_command_exec_skips_self_target() {
+        // A file whose content matches its own basename as the command
+        // target must not produce a self-referencing CommandExec edge.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let sh = dir.path().join("bin/my-binary.sh");
+        std::fs::create_dir_all(sh.parent().unwrap()).unwrap();
+        std::fs::write(
+            &sh,
+            "std::process::Command::new(\"my-binary\").spawn().unwrap();\n",
+        )
+        .unwrap();
+
+        let files = vec![ScannedFile {
+            relative_path: "bin/my-binary.sh".into(),
+            absolute_path: sh,
+            language: Some("bash".into()),
+            size_bytes: 60,
+        }];
+        let parse_results = HashMap::new();
+        let index = CodebaseIndex::build(files, parse_results, &counter);
+        let edges = detect_command_exec_bridges(&index);
+        assert!(
+            edges.is_empty(),
+            "a file invoking a command matching its own basename must not self-link: {edges:#?}"
+        );
+    }
+
+    #[test]
+    fn test_guess_containing_symbol_falls_back_to_module_outside_symbol_ranges() {
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let content = "fn foo() {}\n\nfn bar() {}\n";
+        let fp = dir.path().join("a.rs");
+        std::fs::write(&fp, content).unwrap();
+        let scanned = ScannedFile {
+            relative_path: "a.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: content.len() as u64,
+        };
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "a.rs".to_string(),
+            ParseResult {
+                symbols: vec![
+                    Symbol {
+                        name: "foo".into(),
+                        kind: SymbolKind::Function,
+                        visibility: Visibility::Public,
+                        signature: "fn foo()".into(),
+                        body: "{}".into(),
+                        start_line: 1,
+                        end_line: 1,
+                    },
+                    Symbol {
+                        name: "bar".into(),
+                        kind: SymbolKind::Function,
+                        visibility: Visibility::Public,
+                        signature: "fn bar()".into(),
+                        body: "{}".into(),
+                        start_line: 3,
+                        end_line: 3,
+                    },
+                ],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let mut content_map = HashMap::new();
+        content_map.insert("a.rs".to_string(), content.to_string());
+        let index =
+            CodebaseIndex::build_with_content(vec![scanned], parse_results, &counter, content_map);
+        let file = index
+            .files
+            .iter()
+            .find(|f| f.relative_path == "a.rs")
+            .unwrap();
+        // The blank line 2 is covered by neither `foo` (1..1) nor `bar` (3..3).
+        let offset = content.find("\n\nfn bar").unwrap() + 1;
+        assert_eq!(
+            guess_containing_symbol(file, offset),
+            "<module>",
+            "an offset outside every symbol's line range must fall back to <module>"
+        );
+    }
 }

--- a/src/intelligence/data_flow.rs
+++ b/src/intelligence/data_flow.rs
@@ -1004,4 +1004,290 @@ mod tests {
             "deep chain trace must complete in <5s, took {elapsed:?}"
         );
     }
+
+    #[test]
+    fn test_trace_transform_classification() {
+        // A middle hop whose name matches a TRANSFORM_KEYWORD (e.g. "validate")
+        // must classify as FlowNodeType::Transform, not Passthrough or Sink.
+        let mut index = build_index_with_symbols(&[
+            ("src/api.rs", "rust", "fn handle_request(req: Request)"),
+            (
+                "src/validate.rs",
+                "rust",
+                "fn validate_request(req: Request)",
+            ),
+            ("src/db.rs", "rust", "fn save_user(req: Request)"),
+        ]);
+        index.call_graph = CallGraph {
+            edges: vec![
+                CallEdge {
+                    caller_file: "src/api.rs".into(),
+                    caller_symbol: "handle_request".into(),
+                    callee_file: "src/validate.rs".into(),
+                    callee_symbol: "validate_request".into(),
+                    confidence: CallConfidence::Exact,
+                    resolution_note: None,
+                },
+                CallEdge {
+                    caller_file: "src/validate.rs".into(),
+                    caller_symbol: "validate_request".into(),
+                    callee_file: "src/db.rs".into(),
+                    callee_symbol: "save_user".into(),
+                    confidence: CallConfidence::Exact,
+                    resolution_note: None,
+                },
+            ],
+            unresolved: Vec::new(),
+        };
+        let result = trace_data_flow("handle_request", None, 10, &index);
+        let validate_node = result
+            .paths
+            .iter()
+            .flat_map(|p| p.nodes.iter())
+            .find(|n| n.symbol == "validate_request")
+            .expect("validate_request node present");
+        assert_eq!(validate_node.node_type, FlowNodeType::Transform);
+    }
+
+    #[test]
+    fn test_trace_stops_at_user_supplied_sink() {
+        // "route" is a Passthrough by keyword heuristic, but it is named
+        // explicitly as the `sink` argument — the trace must stop there rather
+        // than continuing on to the heuristic sink "save_user".
+        let mut index = build_index_with_symbols(&[
+            ("src/api.rs", "rust", "fn handle_request(req: Request)"),
+            ("src/middle.rs", "rust", "fn route(req: Request)"),
+            ("src/db.rs", "rust", "fn save_user(req: Request)"),
+        ]);
+        index.call_graph = CallGraph {
+            edges: vec![
+                CallEdge {
+                    caller_file: "src/api.rs".into(),
+                    caller_symbol: "handle_request".into(),
+                    callee_file: "src/middle.rs".into(),
+                    callee_symbol: "route".into(),
+                    confidence: CallConfidence::Exact,
+                    resolution_note: None,
+                },
+                CallEdge {
+                    caller_file: "src/middle.rs".into(),
+                    caller_symbol: "route".into(),
+                    callee_file: "src/db.rs".into(),
+                    callee_symbol: "save_user".into(),
+                    confidence: CallConfidence::Exact,
+                    resolution_note: None,
+                },
+            ],
+            unresolved: Vec::new(),
+        };
+        let result = trace_data_flow("handle_request", Some("route"), 10, &index);
+        assert!(
+            result.sink.is_some(),
+            "explicit sink match should populate result.sink"
+        );
+        assert_eq!(result.sink.as_ref().unwrap().symbol, "route");
+        assert!(
+            result
+                .paths
+                .iter()
+                .all(|p| p.nodes.last().unwrap().symbol == "route"),
+            "trace must terminate at the user-supplied sink symbol, never reaching save_user"
+        );
+    }
+
+    #[test]
+    fn test_trace_unresolved_parameter_yields_speculative() {
+        // Source parameter "conn" is not one of INPUT_PARAM_NAMES, so
+        // forward_parameter cannot prove it survives the call boundary. The hop
+        // is marked unresolved and the path confidence must become Speculative.
+        let mut index = build_index_with_symbols(&[
+            ("src/api.rs", "rust", "fn handle_request(conn: Connection)"),
+            ("src/db.rs", "rust", "fn save_user(conn: Connection)"),
+        ]);
+        index.call_graph = CallGraph {
+            edges: vec![CallEdge {
+                caller_file: "src/api.rs".into(),
+                caller_symbol: "handle_request".into(),
+                callee_file: "src/db.rs".into(),
+                callee_symbol: "save_user".into(),
+                confidence: CallConfidence::Exact,
+                resolution_note: None,
+            }],
+            unresolved: Vec::new(),
+        };
+        let result = trace_data_flow("handle_request", None, 10, &index);
+        assert_eq!(result.paths.len(), 1);
+        assert_eq!(result.paths[0].confidence, FlowConfidence::Speculative);
+        assert!(
+            result.paths[0].nodes.last().unwrap().parameter.is_none(),
+            "an unforwardable parameter must be recorded as None on the next hop"
+        );
+    }
+
+    #[test]
+    fn test_trace_source_signature_without_colon_uses_last_word() {
+        // A "Type name" style signature (no colon between type and name, as
+        // produced by some non-Rust parsers) must fall back to the last
+        // whitespace-separated token for the parameter name.
+        let mut index = build_index_with_symbols(&[
+            ("src/Api.java", "java", "void handleRequest(Request req)"),
+            ("src/Db.java", "java", "void saveUser(Request req)"),
+        ]);
+        index.call_graph = CallGraph {
+            edges: vec![CallEdge {
+                caller_file: "src/Api.java".into(),
+                caller_symbol: "handleRequest".into(),
+                callee_file: "src/Db.java".into(),
+                callee_symbol: "saveUser".into(),
+                confidence: CallConfidence::Exact,
+                resolution_note: None,
+            }],
+            unresolved: Vec::new(),
+        };
+        let result = trace_data_flow("handleRequest", None, 10, &index);
+        assert_eq!(result.source.parameter.as_deref(), Some("req"));
+    }
+
+    #[test]
+    fn test_compute_security_file_set_covers_all_categories() {
+        // Independently of the trace path itself, compute_security_file_set
+        // scans every file in the index for all four security-surface
+        // categories. This test proves each of the four insertion loops
+        // (unprotected endpoints, validation gaps, secrets, SQL injection)
+        // actually executes on a real, non-overlapping fixture.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let api_path = dir.path().join("src/api.rs");
+        std::fs::create_dir_all(api_path.parent().unwrap()).unwrap();
+        std::fs::write(&api_path, "fn handle_request(req: Request) {}\n").unwrap();
+        let db_path = dir.path().join("src/db.rs");
+        std::fs::write(&db_path, "fn save_user(req: Request) {}\n").unwrap();
+
+        // Unprotected endpoint: Express route with no auth keyword in the file.
+        let routes_path = dir.path().join("src/routes.js");
+        std::fs::write(
+            &routes_path,
+            "const express = require('express');\napp.get('/api/users', listUsers);\n",
+        )
+        .unwrap();
+
+        // Validation gap: public fn with an unvalidated String param.
+        let user_path = dir.path().join("src/user.rs");
+        std::fs::write(
+            &user_path,
+            "pub fn create_user(name: String) {\n    db.insert(name);\n}\n",
+        )
+        .unwrap();
+
+        // SQL injection: Rust format! with a SELECT and a `{}` placeholder.
+        let repo_path = dir.path().join("src/repo.rs");
+        std::fs::write(
+            &repo_path,
+            "fn find_user(id: &str) -> String { format!(\"SELECT * FROM users WHERE id = '{}'\", id) }\n",
+        )
+        .unwrap();
+
+        let files = vec![
+            ScannedFile {
+                relative_path: "src/api.rs".into(),
+                absolute_path: api_path,
+                language: Some("rust".into()),
+                size_bytes: 40,
+            },
+            ScannedFile {
+                relative_path: "src/db.rs".into(),
+                absolute_path: db_path,
+                language: Some("rust".into()),
+                size_bytes: 30,
+            },
+            ScannedFile {
+                relative_path: "src/routes.js".into(),
+                absolute_path: routes_path,
+                language: Some("javascript".into()),
+                size_bytes: 80,
+            },
+            ScannedFile {
+                relative_path: "src/user.rs".into(),
+                absolute_path: user_path,
+                language: Some("rust".into()),
+                size_bytes: 60,
+            },
+            ScannedFile {
+                relative_path: "src/repo.rs".into(),
+                absolute_path: repo_path,
+                language: Some("rust".into()),
+                size_bytes: 90,
+            },
+        ];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "src/api.rs".to_string(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "handle_request".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Public,
+                    signature: "fn handle_request(req: Request)".into(),
+                    body: "{}".into(),
+                    start_line: 1,
+                    end_line: 1,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        parse_results.insert(
+            "src/db.rs".to_string(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "save_user".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Public,
+                    signature: "fn save_user(req: Request)".into(),
+                    body: "{}".into(),
+                    start_line: 1,
+                    end_line: 1,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+
+        let mut index = CodebaseIndex::build(files, parse_results, &counter);
+        // Ensure validation-gap scanning activates (requires pagerank >= 0.5).
+        index.pagerank.insert("src/user.rs".to_string(), 0.9);
+        index.call_graph = CallGraph {
+            edges: vec![CallEdge {
+                caller_file: "src/api.rs".into(),
+                caller_symbol: "handle_request".into(),
+                callee_file: "src/db.rs".into(),
+                callee_symbol: "save_user".into(),
+                confidence: CallConfidence::Exact,
+                resolution_note: None,
+            }],
+            unresolved: Vec::new(),
+        };
+
+        // The trace itself still works with the extra unrelated files present.
+        let result = trace_data_flow("handle_request", None, 10, &index);
+        assert!(!result.paths.is_empty());
+
+        // Directly verify build_security_surface actually found all four
+        // categories, which is what feeds compute_security_file_set's four
+        // insertion loops.
+        let surface = build_security_surface(&index, DEFAULT_AUTH_PATTERNS, None);
+        assert!(
+            !surface.unprotected_endpoints.is_empty(),
+            "expected an unprotected endpoint finding"
+        );
+        assert!(
+            !surface.input_validation_gaps.is_empty(),
+            "expected a validation-gap finding"
+        );
+        assert!(
+            !surface.sql_injection_surface.is_empty(),
+            "expected a sql-injection finding"
+        );
+    }
 }

--- a/src/intelligence/dead_code.rs
+++ b/src/intelligence/dead_code.rs
@@ -1360,4 +1360,407 @@ mod tests {
             "single-char struct name must be assumed alive (too short to search reliably)"
         );
     }
+
+    // ---- is_entry_point direct branch tests ----
+
+    #[test]
+    fn is_entry_point_true_for_trait_impl_or_override_signature() {
+        let cache = HashMap::new();
+        assert!(
+            is_entry_point("src/foo.rs", "fmt", "impl Display for Foo", false, &cache),
+            "impl Trait for Type signature must be an entry point"
+        );
+        assert!(
+            is_entry_point(
+                "src/foo.rs",
+                "run",
+                "@Override public void run()",
+                false,
+                &cache
+            ),
+            "@Override signature must be an entry point"
+        );
+        assert!(
+            is_entry_point("src/foo.rs", "run", "override fun run()", false, &cache),
+            "Kotlin-style `override ` signature must be an entry point"
+        );
+    }
+
+    #[test]
+    fn is_entry_point_true_for_http_handler_when_file_has_routes() {
+        let mut cache = HashMap::new();
+        cache.insert("src/routes.rs".to_string(), true);
+        assert!(
+            is_entry_point("src/routes.rs", "handler", "pub fn handler()", true, &cache),
+            "public symbol in a file with route registrations must be an entry point"
+        );
+    }
+
+    #[test]
+    fn is_entry_point_false_when_route_cache_has_no_routes_or_not_public() {
+        let mut cache = HashMap::new();
+        cache.insert("src/routes.rs".to_string(), false);
+        assert!(!is_entry_point(
+            "src/routes.rs",
+            "helper",
+            "fn helper()",
+            true,
+            &cache
+        ));
+        cache.insert("src/routes.rs".to_string(), true);
+        assert!(!is_entry_point(
+            "src/routes.rs",
+            "helper",
+            "fn helper()",
+            false,
+            &cache
+        ));
+    }
+
+    // ---- strip_code_noise / strip_strings_and_comments direct tests ----
+
+    #[test]
+    fn strip_code_noise_removes_line_comments_block_comments_and_strings() {
+        let src = "// mentions encode here\nlet x = \"encode\"; /* also encode */ real_encode();";
+        let stripped = strip_code_noise(src);
+        assert!(!stripped.contains("mentions encode here"));
+        assert!(!stripped.contains("\"encode\""));
+        assert!(!stripped.contains("also encode"));
+        assert!(stripped.contains("real_encode"));
+    }
+
+    #[test]
+    fn strip_code_noise_handles_escaped_quote_inside_string() {
+        // The backslash-escape branch: `\"` inside a string must not end it.
+        let src = "let s = \"esc\\\"aped encode\"; keep_this();";
+        let stripped = strip_code_noise(src);
+        assert!(!stripped.contains("encode"));
+        assert!(stripped.contains("keep_this"));
+    }
+
+    #[test]
+    fn strip_strings_and_comments_breaks_on_line_comment_and_toggles_string_state() {
+        let with_comment = strip_strings_and_comments("let x = 1; // trailing comment { }");
+        assert_eq!(with_comment, "let x = 1; ");
+        let with_string = strip_strings_and_comments("if x == \"{ brace }\" { y(); }");
+        // Braces inside the string are stripped (not counted); braces outside remain.
+        assert_eq!(with_string, "if x ==  { y(); }");
+    }
+
+    // ---- has_string_references direct tests ----
+
+    #[test]
+    fn has_string_references_short_name_assumed_alive() {
+        assert!(has_string_references("ab", "def.rs", &[]));
+    }
+
+    // ---- has_receiver_method_reference direct tests ----
+
+    fn make_file(path: &str, content: &str) -> IndexedFile {
+        IndexedFile {
+            relative_path: path.to_string(),
+            language: Some("rust".to_string()),
+            size_bytes: content.len() as u64,
+            token_count: 0,
+            parse_result: None,
+            content: content.to_string(),
+            mtime_secs: None,
+        }
+    }
+
+    #[test]
+    fn has_receiver_method_reference_short_name_returns_false() {
+        let files: Vec<IndexedFile> = vec![make_file("caller.rs", "obj.run(1);")];
+        assert!(!has_receiver_method_reference("def.rs", "run", &files));
+    }
+
+    #[test]
+    fn has_receiver_method_reference_skips_content_shorter_than_needle() {
+        let files = vec![make_file("caller.rs", "x")];
+        assert!(!has_receiver_method_reference(
+            "def.rs",
+            "process_data",
+            &files
+        ));
+    }
+
+    #[test]
+    fn has_receiver_method_reference_finds_dot_call_and_ignores_range_operator() {
+        let files = vec![make_file("caller.rs", "obj.process_data(1);")];
+        assert!(has_receiver_method_reference(
+            "def.rs",
+            "process_data",
+            &files
+        ));
+
+        let range_files = vec![make_file("caller.rs", "arr[0..process_data(1)];")];
+        assert!(!has_receiver_method_reference(
+            "def.rs",
+            "process_data",
+            &range_files
+        ));
+    }
+
+    #[test]
+    fn has_receiver_method_reference_no_match_returns_false() {
+        let files = vec![make_file(
+            "caller.rs",
+            "something_else_entirely_long_enough();",
+        )];
+        assert!(!has_receiver_method_reference(
+            "def.rs",
+            "process_data",
+            &files
+        ));
+    }
+
+    // ---- has_qualified_reference direct tests ----
+
+    #[test]
+    fn has_qualified_reference_false_for_empty_stem() {
+        let files = vec![make_file("other.rs", "some::path::ref_target")];
+        assert!(!has_qualified_reference("", "ref_target", &files));
+    }
+
+    // ---- has_serde_derive_above / has_test_attribute_above start_line=0 ----
+
+    #[test]
+    fn has_serde_derive_above_returns_false_for_start_line_zero() {
+        assert!(!has_serde_derive_above("struct Foo {}", 0));
+    }
+
+    #[test]
+    fn has_test_attribute_above_returns_false_for_start_line_zero() {
+        assert!(!has_test_attribute_above("fn foo(){}", 0));
+    }
+
+    // ---- enclosing_impl / parse_impl_type direct tests ----
+
+    #[test]
+    fn enclosing_impl_returns_none_for_start_line_zero() {
+        assert_eq!(enclosing_impl("impl Foo {}", 0), None);
+    }
+
+    #[test]
+    fn enclosing_impl_counts_closing_braces_from_prior_sibling_method() {
+        // `two`'s own declaration line is start_line=5; scanning backward must
+        // pass over `one`'s complete `{ 1 }` body (a matched brace pair) before
+        // finding the impl block's own opening brace.
+        let content =
+            "impl Foo {\n    fn one() {\n        1\n    }\n    fn two() -> i32 {\n        2\n    }\n}\n";
+        assert_eq!(
+            enclosing_impl(content, 5),
+            Some((false, Some("Foo".to_string())))
+        );
+    }
+
+    #[test]
+    fn enclosing_impl_returns_none_when_opener_is_not_impl() {
+        let content = "if condition {\n    let x = 1;\n}\n";
+        assert_eq!(enclosing_impl(content, 2), None);
+    }
+
+    #[test]
+    fn parse_impl_type_skips_generic_param_prefix() {
+        assert_eq!(
+            parse_impl_type("<T: Clone> Foo<T> {"),
+            Some("Foo".to_string())
+        );
+        assert_eq!(
+            parse_impl_type("<'a, T: Clone + Debug> Bar<'a, T> {"),
+            Some("Bar".to_string())
+        );
+    }
+
+    // ---- detect_dead_code end-to-end branch tests ----
+
+    #[test]
+    fn test_dead_code_skips_function_with_test_attribute_above_regardless_of_name() {
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let content = "#[test]\nfn checks_invariant() {}\n";
+        let fp = dir.path().join("util.rs");
+        std::fs::write(&fp, content).unwrap();
+        let files = vec![ScannedFile {
+            relative_path: "util.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: content.len() as u64,
+        }];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "util.rs".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "checks_invariant".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Private,
+                    signature: "fn checks_invariant()".into(),
+                    body: "{}".into(),
+                    start_line: 2,
+                    end_line: 2,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let mut content_map = HashMap::new();
+        content_map.insert("util.rs".to_string(), content.to_string());
+        let index = CodebaseIndex::build_with_content(files, parse_results, &counter, content_map);
+        let dead = detect_dead_code(&index, None);
+        assert!(
+            !dead.iter().any(|d| d.symbol == "checks_invariant"),
+            "function with #[test] attribute above must be alive regardless of its name"
+        );
+    }
+
+    #[test]
+    fn test_dead_code_treats_trait_impl_method_as_alive() {
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let content =
+            "impl std::fmt::Display for Foo {\n    fn fmt(&self) -> String {\n        String::new()\n    }\n}\n";
+        let fp = dir.path().join("foo.rs");
+        std::fs::write(&fp, content).unwrap();
+        let files = vec![ScannedFile {
+            relative_path: "foo.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: content.len() as u64,
+        }];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "foo.rs".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "fmt".into(),
+                    kind: SymbolKind::Method,
+                    visibility: Visibility::Private,
+                    signature: "fn fmt(&self) -> String".into(),
+                    body: "{}".into(),
+                    start_line: 2,
+                    end_line: 4,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let mut content_map = HashMap::new();
+        content_map.insert("foo.rs".to_string(), content.to_string());
+        let index = CodebaseIndex::build_with_content(files, parse_results, &counter, content_map);
+        let dead = detect_dead_code(&index, None);
+        assert!(
+            !dead.iter().any(|d| d.symbol == "fmt"),
+            "trait-impl method with zero callers must be alive via dynamic dispatch exemption"
+        );
+    }
+
+    #[test]
+    fn test_dead_code_treats_inherent_method_referenced_via_type_path_as_alive() {
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let a_content = "impl Foo {\n    fn helper() -> i32 {\n        1\n    }\n}\n";
+        let b_content = "fn caller() -> i32 { Foo::helper() }\n";
+        let a_path = dir.path().join("a.rs");
+        let b_path = dir.path().join("b.rs");
+        std::fs::write(&a_path, a_content).unwrap();
+        std::fs::write(&b_path, b_content).unwrap();
+
+        let files = vec![
+            ScannedFile {
+                relative_path: "a.rs".into(),
+                absolute_path: a_path,
+                language: Some("rust".into()),
+                size_bytes: a_content.len() as u64,
+            },
+            ScannedFile {
+                relative_path: "b.rs".into(),
+                absolute_path: b_path,
+                language: Some("rust".into()),
+                size_bytes: b_content.len() as u64,
+            },
+        ];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "a.rs".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "helper".into(),
+                    kind: SymbolKind::Method,
+                    visibility: Visibility::Private,
+                    signature: "fn helper() -> i32".into(),
+                    body: "{}".into(),
+                    start_line: 2,
+                    end_line: 4,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        parse_results.insert(
+            "b.rs".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "caller".into(),
+                    kind: SymbolKind::Function,
+                    visibility: Visibility::Private,
+                    signature: "fn caller() -> i32".into(),
+                    body: "{}".into(),
+                    start_line: 1,
+                    end_line: 1,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let mut content_map = HashMap::new();
+        content_map.insert("a.rs".to_string(), a_content.to_string());
+        content_map.insert("b.rs".to_string(), b_content.to_string());
+        let index = CodebaseIndex::build_with_content(files, parse_results, &counter, content_map);
+        let dead = detect_dead_code(&index, None);
+        assert!(
+            !dead.iter().any(|d| d.symbol == "helper"),
+            "inherent method referenced via Type::method in another file must be alive"
+        );
+    }
+
+    #[test]
+    fn test_dead_code_treats_serde_derived_enum_as_alive() {
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let content = "use serde::Deserialize;\n\n#[derive(Debug, Deserialize)]\npub enum Status {\n    Active,\n    Inactive,\n}\n";
+        let fp = dir.path().join("model.rs");
+        std::fs::write(&fp, content).unwrap();
+        let files = vec![ScannedFile {
+            relative_path: "model.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: content.len() as u64,
+        }];
+        let mut parse_results = HashMap::new();
+        parse_results.insert(
+            "model.rs".into(),
+            ParseResult {
+                symbols: vec![Symbol {
+                    name: "Status".into(),
+                    kind: SymbolKind::Enum,
+                    visibility: Visibility::Public,
+                    signature: "pub enum Status".into(),
+                    body: "{}".into(),
+                    start_line: 4,
+                    end_line: 7,
+                }],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let mut content_map = HashMap::new();
+        content_map.insert("model.rs".to_string(), content.to_string());
+        let index = CodebaseIndex::build_with_content(files, parse_results, &counter, content_map);
+        let dead = detect_dead_code(&index, None);
+        assert!(
+            !dead.iter().any(|d| d.symbol == "Status"),
+            "serde-Deserialize-derived enum with zero references must be alive"
+        );
+    }
 }

--- a/src/relevance/signals.rs
+++ b/src/relevance/signals.rs
@@ -1034,6 +1034,150 @@ mod tests {
         assert!(result.score > 0.6);
     }
 
+    // --- symbol_match: symbols with no tokenizable name ---
+
+    #[test]
+    fn test_symbol_match_skips_untokenizable_symbol_name() {
+        // A symbol whose name tokenizes to nothing (a single character) must be
+        // skipped by the `continue` in the scoring loop, while a later, real
+        // symbol still gets scored normally.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let fp = dir.path().join("mixed.rs");
+        std::fs::write(&fp, "fn x() {}\npub fn handle_api_request() {}").unwrap();
+        let files = vec![ScannedFile {
+            relative_path: "mixed.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: 40,
+        }];
+        let mut pr = HashMap::new();
+        pr.insert(
+            "mixed.rs".to_string(),
+            ParseResult {
+                symbols: vec![
+                    Symbol {
+                        name: "x".into(),
+                        kind: SymbolKind::Function,
+                        visibility: Visibility::Private,
+                        signature: "fn x()".into(),
+                        body: "{}".into(),
+                        start_line: 1,
+                        end_line: 1,
+                    },
+                    Symbol {
+                        name: "handle_api_request".into(),
+                        kind: SymbolKind::Function,
+                        visibility: Visibility::Public,
+                        signature: "pub fn handle_api_request()".into(),
+                        body: "{}".into(),
+                        start_line: 2,
+                        end_line: 2,
+                    },
+                ],
+                imports: vec![],
+                exports: vec![],
+            },
+        );
+        let index = CodebaseIndex::build(files, pr, &counter);
+        let result = symbol_match("handle api request", "mixed.rs", &index, None);
+        assert!(
+            result.score > 0.5,
+            "the untokenizable single-char symbol must be skipped, letting the \
+             real symbol win the best-score comparison: {}",
+            result.score
+        );
+        assert!(result.detail.contains("handle_api_request"));
+    }
+
+    // --- term_frequency: tf_map present but empty / all-zero counts ---
+
+    #[test]
+    fn test_term_frequency_empty_tf_map_for_empty_file() {
+        // An indexed empty file gets a present-but-empty term-frequency map
+        // (distinct from "file not found"), which must short-circuit to 0.0.
+        let counter = TokenCounter::new();
+        let dir = tempfile::TempDir::new().unwrap();
+        let fp = dir.path().join("empty.rs");
+        std::fs::write(&fp, "").unwrap();
+        let files = vec![ScannedFile {
+            relative_path: "empty.rs".into(),
+            absolute_path: fp,
+            language: Some("rust".into()),
+            size_bytes: 0,
+        }];
+        let index = CodebaseIndex::build(files, HashMap::new(), &counter);
+        assert!(
+            index.term_frequencies.get("empty.rs").unwrap().is_empty(),
+            "precondition: empty file must produce an empty (not missing) tf map"
+        );
+        let result = term_frequency("anything", "empty.rs", &index, None);
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.detail, "no terms");
+    }
+
+    #[test]
+    fn test_term_frequency_all_zero_counts_treated_as_no_terms() {
+        // A tf map that is non-empty but whose counts all sum to zero (a
+        // degenerate state no real `compute_term_frequencies` output produces,
+        // but one the function must still handle defensively) must be treated
+        // identically to "no terms".
+        let counter = TokenCounter::new();
+        let mut index = CodebaseIndex::build(vec![], HashMap::new(), &counter);
+        let mut zeroed = HashMap::new();
+        zeroed.insert("stale".to_string(), 0u32);
+        index
+            .term_frequencies
+            .insert("weird.rs".to_string(), zeroed);
+        let result = term_frequency("stale", "weird.rs", &index, None);
+        assert_eq!(result.score, 0.0);
+        assert_eq!(result.detail, "no terms");
+    }
+
+    // --- embedding_similarity_signal (feature-gated) ---
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn test_embedding_similarity_no_query_embedding() {
+        let counter = TokenCounter::new();
+        let mut index = CodebaseIndex::build(vec![], HashMap::new(), &counter);
+        index.embedding_index = Some(crate::embeddings::EmbeddingIndex::new(3));
+        let result = embedding_similarity_signal(None, "any.rs", &index);
+        assert_eq!(result.score, 0.5);
+        assert_eq!(result.detail, "no query embedding");
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn test_embedding_similarity_cosine_match_scores_high() {
+        let counter = TokenCounter::new();
+        let mut index = CodebaseIndex::build(vec![], HashMap::new(), &counter);
+        let mut emb = crate::embeddings::EmbeddingIndex::new(3);
+        emb.add("src/api.rs", vec![1.0, 0.0, 0.0]);
+        index.embedding_index = Some(emb);
+        let result = embedding_similarity_signal(Some(&[1.0, 0.0, 0.0]), "src/api.rs", &index);
+        assert_eq!(result.name, "embedding_similarity");
+        assert!(
+            (result.score - 1.0).abs() < 1e-6,
+            "identical vectors should score ~1.0: {}",
+            result.score
+        );
+        assert!(result.detail.starts_with("cosine="), "{}", result.detail);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn test_embedding_similarity_file_not_in_index() {
+        let counter = TokenCounter::new();
+        let mut index = CodebaseIndex::build(vec![], HashMap::new(), &counter);
+        let mut emb = crate::embeddings::EmbeddingIndex::new(3);
+        emb.add("src/other.rs", vec![1.0, 0.0, 0.0]);
+        index.embedding_index = Some(emb);
+        let result = embedding_similarity_signal(Some(&[1.0, 0.0, 0.0]), "src/missing.rs", &index);
+        assert_eq!(result.score, 0.5);
+        assert_eq!(result.detail, "file not in embedding index");
+    }
+
     #[test]
     fn test_recency_boost_signal_in_180d_only() {
         use crate::conventions::git_health::ChurnEntry;

--- a/src/schema/extract.rs
+++ b/src/schema/extract.rs
@@ -1230,4 +1230,182 @@ CREATE TABLE orders (
         assert_eq!(strip_schema_prefix("a.b.c"), "c");
         assert_eq!(strip_schema_prefix(""), "");
     }
+
+    // -----------------------------------------------------------------------
+    // Additional coverage: multi-token paren absorption, malformed
+    // REFERENCES/DEFAULT clauses, table-level constraints parsed directly,
+    // and Cypher/Elasticsearch/Prisma edge branches.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_type_paren_group_split_across_tokens() {
+        // "NUMERIC(10, 2)" has a space after the comma, so split_whitespace
+        // yields two tokens ("NUMERIC(10," and "2)") that collect_type must
+        // re-join by absorbing until the parens balance.
+        let sql = "(price NUMERIC(10, 2) NOT NULL)";
+        let schema = extract_table_schema(sql, "products", "schema.sql", 1);
+        let col = schema.columns.iter().find(|c| c.name == "price").unwrap();
+        assert_eq!(col.data_type, "NUMERIC(10, 2)");
+        assert!(!col.nullable);
+    }
+
+    #[test]
+    fn test_references_with_no_target_table() {
+        // REFERENCES as the final token of a column def has nothing to parse.
+        let sql = "(id INTEGER, user_id INTEGER REFERENCES)";
+        let schema = extract_table_schema(sql, "orders", "schema.sql", 1);
+        let col = schema.columns.iter().find(|c| c.name == "user_id").unwrap();
+        let fk = col.foreign_key.as_ref().unwrap();
+        assert_eq!(fk.target_table, "");
+        assert_eq!(fk.target_column, "");
+    }
+
+    #[test]
+    fn test_references_column_as_separate_token() {
+        // A space between the target table and its column paren group means
+        // the column reference arrives as its own token: `users` `(id)`.
+        let sql = "(id INTEGER, user_id INTEGER REFERENCES users (id))";
+        let schema = extract_table_schema(sql, "orders", "schema.sql", 1);
+        let col = schema.columns.iter().find(|c| c.name == "user_id").unwrap();
+        let fk = col.foreign_key.as_ref().unwrap();
+        assert_eq!(fk.target_table, "users");
+        assert_eq!(fk.target_column, "id");
+    }
+
+    #[test]
+    fn test_default_with_no_value() {
+        // DEFAULT as the final token has no expression to capture.
+        let sql = "(status TEXT DEFAULT)";
+        let schema = extract_table_schema(sql, "items", "schema.sql", 1);
+        let col = schema.columns.iter().find(|c| c.name == "status").unwrap();
+        assert_eq!(col.default, Some(String::new()));
+    }
+
+    #[test]
+    fn test_default_multi_token_paren_expression() {
+        // "DEFAULT (1 + 1)" splits into three tokens; capture_default must
+        // absorb all of them until the parens balance.
+        let sql = "(amount INTEGER DEFAULT (1 + 1))";
+        let schema = extract_table_schema(sql, "ledger", "schema.sql", 1);
+        let col = schema.columns.iter().find(|c| c.name == "amount").unwrap();
+        assert_eq!(col.default, Some("(1 + 1)".to_string()));
+    }
+
+    #[test]
+    fn test_trailing_comma_produces_empty_def_skipped() {
+        // A trailing comma leaves an empty definition after splitting; it
+        // must be skipped rather than producing a phantom column.
+        let sql = "(id INTEGER, name TEXT,)";
+        let schema = extract_table_schema(sql, "items", "schema.sql", 1);
+        assert_eq!(schema.columns.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_column_def_skips_table_level_constraints_directly() {
+        // extract_table_schema already filters these out before calling
+        // parse_column_def, so exercise the function's own guard directly.
+        assert!(parse_column_def("UNIQUE (email)").is_none());
+        assert!(parse_column_def("FOREIGN KEY (x) REFERENCES y(z)").is_none());
+        assert!(parse_column_def("PRIMARY KEY (id)").is_none());
+        assert!(parse_column_def("CHECK (age > 0)").is_none());
+        assert!(parse_column_def("CONSTRAINT chk_age CHECK (age > 0)").is_none());
+    }
+
+    #[test]
+    fn test_explicit_null_keyword() {
+        let sql = "(id INTEGER, email TEXT NULL)";
+        let schema = extract_table_schema(sql, "users", "schema.sql", 1);
+        let col = schema.columns.iter().find(|c| c.name == "email").unwrap();
+        assert!(col.nullable);
+    }
+
+    #[test]
+    fn test_references_on_delete_set_null() {
+        let sql = "(id INTEGER, owner_id INTEGER REFERENCES users(id) ON DELETE SET NULL)";
+        let schema = extract_table_schema(sql, "docs", "schema.sql", 1);
+        // The whole ON DELETE SET NULL clause must be consumed, leaving
+        // exactly the two real columns (no phantom column from "NULL").
+        assert_eq!(schema.columns.len(), 2);
+        let col = schema
+            .columns
+            .iter()
+            .find(|c| c.name == "owner_id")
+            .unwrap();
+        let fk = col.foreign_key.as_ref().unwrap();
+        assert_eq!(fk.target_table, "users");
+        assert_eq!(fk.target_column, "id");
+    }
+
+    #[test]
+    fn test_references_followed_by_non_on_token() {
+        // A constraint keyword directly after the REFERENCES target (no ON
+        // clause at all) must terminate the REFERENCES sub-loop immediately.
+        let sql = "(id INTEGER, code TEXT REFERENCES codes(code) UNIQUE)";
+        let schema = extract_table_schema(sql, "items", "schema.sql", 1);
+        let col = schema.columns.iter().find(|c| c.name == "code").unwrap();
+        let fk = col.foreign_key.as_ref().unwrap();
+        assert_eq!(fk.target_table, "codes");
+        assert_eq!(fk.target_column, "code");
+        assert!(col.constraints.contains(&"UNIQUE".to_string()));
+    }
+
+    #[test]
+    fn test_unrecognized_trailing_token_is_skipped() {
+        // After NOT NULL is consumed, a stray unrecognized token must fall
+        // through the catch-all arm rather than panicking or being parsed
+        // as a new column.
+        let sql = "(id INTEGER, name TEXT NOT NULL GARBAGE)";
+        let schema = extract_table_schema(sql, "items", "schema.sql", 1);
+        assert_eq!(schema.columns.len(), 2);
+        let col = schema.columns.iter().find(|c| c.name == "name").unwrap();
+        assert!(!col.nullable);
+    }
+
+    #[test]
+    fn test_elasticsearch_properties_not_an_object() {
+        let json = r#"{"mappings": {"properties": "not-an-object"}}"#;
+        let result = extract_elasticsearch_schema(json, "index.json");
+        assert!(
+            result.is_none(),
+            "non-object properties value must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_elasticsearch_nested_properties_not_an_object() {
+        // The nested "properties" key for "address" is a string, not an
+        // object, so recursion into it must stop without adding sub-fields.
+        let json = r#"{
+            "mappings": {
+                "properties": {
+                    "address": {
+                        "type": "object",
+                        "properties": "not-an-object"
+                    }
+                }
+            }
+        }"#;
+        let schema = extract_elasticsearch_schema(json, "index.json").unwrap();
+        assert!(schema
+            .fields
+            .iter()
+            .any(|f| f.name == "address" && f.field_type == "object"));
+        assert!(
+            !schema.fields.iter().any(|f| f.name.starts_with("address.")),
+            "malformed nested properties must not produce sub-fields, got {:?}",
+            schema.fields
+        );
+    }
+
+    #[test]
+    fn test_prisma_skips_single_token_lines() {
+        // A stray one-word line (not a comment, not @@, not blank) has fewer
+        // than 2 tokens and must be skipped rather than misparsed as a field.
+        let body = "\n  id     Int    @id\n  orphan\n  name   String\n";
+        let model = extract_prisma_schema(body, "User", "schema.prisma", 1);
+        assert_eq!(model.fields.len(), 2);
+        assert!(!model.fields.iter().any(|f| f.name == "orphan"));
+        assert!(model.fields.iter().any(|f| f.name == "id"));
+        assert!(model.fields.iter().any(|f| f.name == "name"));
+    }
 }


### PR DESCRIPTION
## Problem

The tarpaulin **90% coverage gate went red on `main`** (commit c8cf63a) — the only failing CI job on the 3.1.1 tip. Root cause: the coverage denominator counted code that isn't cxpak's:

- `vendor/esaxx-rs/*` — vendored third-party crate (path-dep, vendored only to fix a Windows C++ flag), **321 uncovered lines**
- `references/*` — untracked reference material present only in local trees

cxpak's real coverage was ~92%, dragged to the 90% boundary where CI (marginally fewer covered lines than local, e.g. the model-download path in `embeddings/local.rs`) tipped **under 90%**. Same class of metric pollution as the #25 health-coverage bug.

## Fix (one commit)

1. **`ci.yml`** — exclude `vendor/*` and `references/*` from tarpaulin (`--exclude-files`). They are not cxpak's code to test.
2. **+87 real unit tests** across the pure-logic gaps — `cross_lang`, `dead_code`, `call_graph`, `data_flow`, `signals`, `degradation`, `index/graph`, `index/mod`, `schema/extract`, `overview` — each driving the exact previously-uncovered branch with synthetic inputs (no cheater tests).

## Result

Coverage **90.19% → 93.48%** (23170/24786), ~3.5% margin over the gate. Remaining uncovered lines in the touched files are provably-unreachable defensive arms (regex-compile fallbacks on fixed literals, parser-timeout guards, dead branches) — documented per file.

Literal 100% is capped by `serve.rs` subprocess-only paths (tarpaulin can't instrument a spawned `cxpak` process), `embeddings/local.rs` (30MB model download), and `embeddings/remote.rs` (live HTTP) — none unit-testable without a design change.

https://claude.ai/code/session_019hJMLmPVoGS2FeUUX4w4Jz