### PR TITLE
docs: encode the review & merge protocol (4 org rules)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,17 @@ Then run `bash scripts/feature-matrix.sh` to confirm the flag composes cleanly.
 Update the language count and list in the README in the same PR (docs land with
 the code that changes them).
 
+## Review & merge protocol
+
+Every repository in the [Barnett Studios](https://github.com/Barnett-Studios) family lands changes
+under the same four rules — maintainers included:
+
+1. **Change via PR.** All changes land through a pull request against `main`; no direct pushes.
+2. **Green CI.** A PR merges only when every required CI check passes.
+3. **A review.** A PR merges only with at least one approving review.
+4. **Reviewer ≠ author.** The approving review must come from someone other than the PR's author —
+   no self-approval, no self-merge.
+
 ## Pull requests
 
 1. Branch off `main` (fetch first — `main` moves).


### PR DESCRIPTION
Encodes the Barnett Studios family's review & merge protocol into CONTRIBUTING.md — the four rules every repo lands changes under (PR-only, green CI, ≥1 approving review, reviewer ≠ author). Docs-only; no code or behavior change. Part of a family-wide rollout so the governance is written down, not just convention.