### PR TITLE
fix(watcher): one deep clone per edit batch, Arc-share embedding matrix

### DIFF
--- a/docs/adrs/0205-watcher-single-clone-arc-embeddings.md
+++ b/docs/adrs/0205-watcher-single-clone-arc-embeddings.md
@@ -1,0 +1,131 @@
+---
+id: '0205'
+title: Watcher single-clone — one deep clone per edit batch, Arc-shared embedding matrix
+status: ACCEPTED
+date: 2026-07-23
+triggered_by: field report (issue #47) — `cxpak serve --mcp` grew to a 57 GB physical footprint (peak 64 GB) after ~44 min of a normal editing session, climbing ~1 GB/min
+loop: implementation
+---
+
+# ADR-0205: Watcher single-clone — one deep clone per edit batch, Arc-shared embedding matrix
+
+## Context
+
+ADR-0204 bounded the watcher's *ingestion set* and guarded the deep clone on
+**spurious** wakes (all-ignored batches early-return before the clone). It did
+**not** touch the **real-edit** path, where each debounced batch that carries a
+genuine source change still deep-cloned the entire `CodebaseIndex` **twice**:
+
+1. `process_watcher_changes` (`serve.rs`) — `let mut next = (*snapshot).clone()`,
+   the working copy the delta rebuild mutates and swaps into the `shared` mirror.
+2. `republish_watcher_index` (`serve.rs`) — `(**g).clone()` of that just-swapped
+   index **a second time**, solely to produce a copy with `embedding_index = None`
+   (the ADR-0200 6-signal fallback) to publish into the `readiness` cell.
+
+`CodebaseIndex` derives `Clone` with no structural sharing (`core_graph/index.rs`),
+so each clone is a full deep copy of every `IndexedFile.content` String,
+`term_frequencies`, `graph`, `call_graph`, **and** the embedding matrix
+(`EmbeddingIndex.vectors: Vec<f32>`). Under a continuous editing session (roughly
+one batch/second) this sustained two whole-index deep copies per edit — with the
+embedding matrix copied on both — driving the physical footprint into the tens of
+GB. A `vmmap` field report showed 16 GB retained in `MALLOC_LARGE` (the flat
+`Vec<f32>` matrices) and 44 GB in `MALLOC_SMALL` (file contents), dirty and
+swapped — live retention plus allocator churn, not a bounded working set.
+
+Two mechanisms compounded the cost:
+- The **redundant second whole-index deep clone** existed only to null one field.
+- The **embedding matrix was deep-copied by value** on every `CodebaseIndex`
+  clone, because `embedding_index` was `Option<EmbeddingIndex>` (owned by value).
+
+## Options considered
+
+- **Option A — strip embeddings before the swap + Arc-share the matrix (chosen):**
+  clear `embedding_index` once, inside `process_watcher_changes`, immediately
+  before `Arc::new(next)`, and return that freshly-swapped `Arc` so the watcher
+  publishes the *same* pointer into `readiness` — deleting the second clone
+  entirely. Independently, change the field to `Option<Arc<EmbeddingIndex>>` so
+  cloning a `CodebaseIndex` bumps a refcount for the matrix instead of copying
+  `Vec<f32>`. The two changes ship together: stripping-before-swap alone keeps
+  the ADR-0200 invariant, and the `Arc` wrap removes the matrix from the *first*
+  (unavoidable) clone's cost as well as the enrichment clone's.
+- **Option B — make `republish_watcher_index`'s clone cheap via the `Arc` field:**
+  keep the second clone but rely on the `Arc`-wrapped matrix to make it O(1).
+  Rejected: Arc-wrapping *only* the embedding field does not make the whole-index
+  `(**g).clone()` cheap — `files`/`content`, `term_frequencies`, and `graph` are
+  still deep-copied. It would leave the 44 GB `MALLOC_SMALL` churn fully in place.
+- **Option C — in-place mutation of the swapped index (issue #47 suggestion 3):**
+  mutate the `Arc`'s pointee instead of cloning. Rejected: violates the
+  snapshot-then-swap reader-consistency invariant (`serve.rs`, the comment block
+  above the clone) — long-running MCP tool handlers alias the pre-swap `Arc`, so
+  in-place mutation is a torn-read hazard for no benefit over Option A.
+
+## Decision
+
+Adopt Option A.
+
+- `embedding_index: Option<Arc<crate::embeddings::EmbeddingIndex>>`
+  (`core_graph/index.rs`). Read sites auto-deref through `Arc`
+  (`relevance/signals.rs`); `has_embedding_index()` is unchanged; the two
+  by-value `Some(emb)` writes become `Some(Arc::new(emb))`
+  (`serve.rs` `publish_ready_enriched`, plus test constructors). `CodebaseIndex`
+  derives only `Debug, Clone` (no `serde`), so the wrap introduces no
+  serialization change; `EmbeddingIndex` keeps its own `Serialize/Deserialize`
+  and `load`/`save`, which never run through the index.
+- `process_watcher_changes` now clears `embedding_index` once before the swap
+  and returns `Option<Arc<CodebaseIndex>>` — `Some(new_arc)` on a real change,
+  `None` on the ignored-only / no-op / poisoned paths. `spawn_mcp_watcher`
+  publishes that exact `Arc` into `readiness`. `republish_watcher_index` is
+  **deleted** (its clearing responsibility moved into the pre-swap step).
+
+Covered by `process_watcher_changes_clears_embedding_and_publishes_single_arc`
+(published index is embeddings-free **and** `Arc::ptr_eq` with the `shared`
+mirror — proving a single clone), `embedding_index_clone_shares_matrix_not_copies`
+(`Arc::strong_count` proves the matrix is shared, not copied — and the test
+cannot compile against the pre-fix non-`Arc` field), and
+`process_watcher_changes_ignored_only_publishes_none`. The ADR-0204 parity guards
+(`process_watcher_changes_delta_parity_with_full_rebuild`, `classify_changes`
+tests) remain green.
+
+## Consequences
+
+### Positive
+- **One** whole-index deep clone per real-edit batch instead of two — halves the
+  `MALLOC_SMALL` (file-content) churn on the hot path.
+- The embedding matrix is never deep-copied on the watcher path: per-batch matrix
+  copies drop from three (the two watcher clones plus the enrichment clone) to
+  zero — the ~16 GB `MALLOC_LARGE` class is eliminated.
+- The ADR-0200 6-signal-fallback invariant is preserved and now enforced at a
+  single, testable point (pre-swap) rather than via a redundant clone.
+
+### Negative
+- The embeddings-clearing responsibility is no longer named by a dedicated
+  `republish_watcher_index` function; it is a documented step inside
+  `process_watcher_changes`. Auditing the invariant now means reading that step
+  (called out in-line with an ADR-0200/0205 comment) rather than a standalone fn.
+- `process_watcher_changes` gained a return value; the HTTP watcher
+  (`serve.rs`) and LSP backend (`lsp/backend.rs`) call it as a statement and
+  discard the `Option` — intentional, as they own no `readiness` cell.
+
+### Neutral
+- The remaining per-batch clone still deep-copies all `IndexedFile.content`
+  (the residual `MALLOC_SMALL` class). Delta rebuilds touch only a handful of
+  files, so this copy is mostly redundant, but bounding it is a separate change.
+- The `Arc::strong_count`-returns-to-baseline assertion demonstrates no *extra*
+  index version survives a batch; it does not, by itself, prove no *external*
+  holder pins an old version (see Revisit if).
+
+## Revisit if
+- **`MALLOC_SMALL` still dominates under load.** The residual full-content clone
+  per batch is the next ceiling. Move to `files: Vec<Arc<IndexedFile>>` (or an
+  immutable/`im::Vector`) copy-on-write so a delta clone shares unchanged files
+  and copies only the changed ones — turning the per-batch cost from
+  O(codebase) to O(delta). Tracked as a separate ticket (issue #47 P2).
+- **An old `Arc<CodebaseIndex>` is pinned by a slow/hung MCP tool handler**
+  (`snapshot_ready_index` hands each call an `Arc::clone`). If a handler stalls
+  it retains a full old index. Audit with `Arc::strong_count` / a heap profiler
+  (`dhat`/`heaptrack`) on a long-lived session; bound concurrent index versions
+  if retention is observed. (issue #47 P1.)
+- **The per-batch `git2::Repository::discover` + gitignore matcher rebuild in
+  `classify_changes` shows up in a CPU profile.** It is churn only (freed each
+  call, not a memory contributor), but ADR-0204 and this ADR both note it can be
+  hoisted to the watcher's lifetime. Deferred (issue #47 Fix #4).

--- a/docs/adrs/0205-watcher-single-clone-arc-embeddings.md
+++ b/docs/adrs/0205-watcher-single-clone-arc-embeddings.md
@@ -76,26 +76,44 @@ Adopt Option A.
   `None` on the ignored-only / no-op / poisoned paths. `spawn_mcp_watcher`
   publishes that exact `Arc` into `readiness`. `republish_watcher_index` is
   **deleted** (its clearing responsibility moved into the pre-swap step).
+- **Copy-on-write file storage:** `CodebaseIndex.files: Vec<IndexedFile>` →
+  `Vec<Arc<IndexedFile>>`. Cloning a `CodebaseIndex` now shares every unchanged
+  file as a refcount bump; the surviving per-batch clone copies only the `Vec`
+  spine plus the handful of files the delta actually touches, turning the
+  residual `MALLOC_SMALL` cost from O(codebase) to O(delta). The delta path is
+  copy-on-write by construction: `upsert_file` is `remove_file`
+  (`swap_remove` the whole `Arc`) + `push(Arc::new(..))`, and `remove_file`
+  drops an `Arc` — neither mutates an `IndexedFile` in place, so an old snapshot
+  a reader still holds is never corrupted. Read sites auto-deref through
+  `Arc<IndexedFile>`; nine helper signatures taking `&[IndexedFile]` became
+  `&[Arc<IndexedFile>]` (bodies unchanged).
 
 Covered by `process_watcher_changes_clears_embedding_and_publishes_single_arc`
 (published index is embeddings-free **and** `Arc::ptr_eq` with the `shared`
 mirror — proving a single clone), `embedding_index_clone_shares_matrix_not_copies`
 (`Arc::strong_count` proves the matrix is shared, not copied — and the test
-cannot compile against the pre-fix non-`Arc` field), and
-`process_watcher_changes_ignored_only_publishes_none`. The ADR-0204 parity guards
-(`process_watcher_changes_delta_parity_with_full_rebuild`, `classify_changes`
-tests) remain green.
+cannot compile against the pre-fix non-`Arc` field),
+`process_watcher_changes_ignored_only_publishes_none`, and the memory-ceiling
+proof `watcher_does_not_accumulate_index_versions_across_batches` (drives 25
+real-edit batches and asserts `Arc::strong_count` on the shared/readiness Arc
+returns to a fixed baseline every batch — no version accumulation). The ADR-0204
+parity guards (`process_watcher_changes_delta_parity_with_full_rebuild`,
+`classify_changes` tests) remain green, confirming byte-identical delta output.
 
 ## Consequences
 
 ### Positive
-- **One** whole-index deep clone per real-edit batch instead of two — halves the
-  `MALLOC_SMALL` (file-content) churn on the hot path.
+- **One** whole-index deep clone per real-edit batch instead of two, and that
+  surviving clone is now copy-on-write: unchanged files are shared `Arc`s, so it
+  copies O(delta) file contents, not O(codebase). Together this collapses the
+  `MALLOC_SMALL` (file-content) growth that dominated the 44 GB report.
 - The embedding matrix is never deep-copied on the watcher path: per-batch matrix
   copies drop from three (the two watcher clones plus the enrichment clone) to
   zero — the ~16 GB `MALLOC_LARGE` class is eliminated.
 - The ADR-0200 6-signal-fallback invariant is preserved and now enforced at a
   single, testable point (pre-swap) rather than via a redundant clone.
+- A regression test demonstrates (not merely asserts) the memory ceiling:
+  `Arc::strong_count` returns to a fixed baseline after every batch.
 
 ### Negative
 - The embeddings-clearing responsibility is no longer named by a dedicated
@@ -107,24 +125,24 @@ tests) remain green.
   discard the `Option` — intentional, as they own no `readiness` cell.
 
 ### Neutral
-- The remaining per-batch clone still deep-copies all `IndexedFile.content`
-  (the residual `MALLOC_SMALL` class). Delta rebuilds touch only a handful of
-  files, so this copy is mostly redundant, but bounding it is a separate change.
-- The `Arc::strong_count`-returns-to-baseline assertion demonstrates no *extra*
-  index version survives a batch; it does not, by itself, prove no *external*
-  holder pins an old version (see Revisit if).
+- The per-batch clone still copies the `Vec` spine (one pointer per file) plus
+  the small scalar/`String` fields of *changed* files and the non-file index
+  members (`term_frequencies`, `graph`, `call_graph`). These are far smaller than
+  the file contents now shared via `Arc`; if a profile ever shows them dominating,
+  the same `Arc`/delta treatment applies to `term_frequencies` and `graph`.
+- The `Arc::strong_count`-returns-to-baseline test demonstrates no *extra* index
+  version survives a batch; it does not, by itself, prove no *external* holder
+  pins an old version (see Revisit if).
 
 ## Revisit if
-- **`MALLOC_SMALL` still dominates under load.** The residual full-content clone
-  per batch is the next ceiling. Move to `files: Vec<Arc<IndexedFile>>` (or an
-  immutable/`im::Vector`) copy-on-write so a delta clone shares unchanged files
-  and copies only the changed ones — turning the per-batch cost from
-  O(codebase) to O(delta). Tracked as a separate ticket (issue #47 P2).
 - **An old `Arc<CodebaseIndex>` is pinned by a slow/hung MCP tool handler**
-  (`snapshot_ready_index` hands each call an `Arc::clone`). If a handler stalls
-  it retains a full old index. Audit with `Arc::strong_count` / a heap profiler
-  (`dhat`/`heaptrack`) on a long-lived session; bound concurrent index versions
-  if retention is observed. (issue #47 P1.)
+  (`snapshot_ready_index` hands each call an `Arc::clone`). The ceiling test
+  proves no version accumulates in the watcher/readiness path itself, but a
+  handler that stalls could still retain a full old index for its lifetime. The
+  MCP stdio loop is synchronous/sequential today, so at most one is pinned; if a
+  future concurrent handler model is added, audit with `Arc::strong_count` / a
+  heap profiler (`dhat`/`heaptrack`) on a long-lived session and bound concurrent
+  index versions if retention is observed.
 - **The per-batch `git2::Repository::discover` + gitignore matcher rebuild in
   `classify_changes` shows up in a CPU profile.** It is churn only (freed each
   call, not a memory contributor), but ADR-0204 and this ADR both note it can be

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2454,7 +2454,7 @@ fn publish_ready_enriched(
     emb: crate::embeddings::EmbeddingIndex,
 ) {
     let mut enriched = (**base).clone();
-    enriched.embedding_index = Some(emb);
+    enriched.embedding_index = Some(Arc::new(emb));
     let next = IndexReadiness::ReadyEnriched(Arc::new(enriched));
 
     let mut guard = match readiness.write() {
@@ -2529,25 +2529,6 @@ fn classify_watcher_wait(state: &IndexReadiness) -> WatcherWait {
 /// the full build.
 const WATCHER_WAIT_POLL: Duration = Duration::from_millis(100);
 
-/// Build the `Ready(..)` payload for a watcher republish: snapshot the
-/// mirrored `SharedIndex` and actively clear `embedding_index`.
-///
-/// A delta-rebuilt clone otherwise carries the *stale* enrichment forward —
-/// scoring the 7th signal against pre-edit embedded text would be worse than
-/// not having it (ADR-0200 Consequences). Extracted so the clearing behavior
-/// is unit-testable without a real edit + `FileWatcher` cycle.
-fn republish_watcher_index(shared: &SharedIndex) -> Arc<CodebaseIndex> {
-    let mut idx = match shared.read() {
-        Ok(g) => (**g).clone(),
-        Err(poisoned) => (**poisoned.into_inner()).clone(),
-    };
-    #[cfg(feature = "embeddings")]
-    {
-        idx.embedding_index = None;
-    }
-    Arc::new(idx)
-}
-
 /// Spawn the MCP freshness watcher (Task #18, ADR-0200).
 ///
 /// Owns its lifecycle end to end — it is NOT a verbatim reuse of HTTP `run`'s
@@ -2564,10 +2545,11 @@ fn republish_watcher_index(shared: &SharedIndex) -> Arc<CodebaseIndex> {
 ///    `FileWatcher` + `process_watcher_changes` loop HTTP `run` uses — but
 ///    terminable: `shutdown` is checked at each `recv_timeout(1s)` poll, not
 ///    just at process exit.
-/// 3. Each republish clears `embedding_index` on the rebuilt index (see
-///    [`republish_watcher_index`]) and swaps a fresh `Ready(..)` into
-///    `readiness` — never `ReadyEnriched`; a swap downgrades to the
-///    documented 6-signal fallback until a future re-enrich lands.
+/// 3. Each rebuild clears `embedding_index` before the swap (inside
+///    [`process_watcher_changes`], issue #47 / ADR-0205) and publishes the
+///    same freshly-swapped `Arc` as a `Ready(..)` into `readiness` — never
+///    `ReadyEnriched`; a swap downgrades to the documented 6-signal fallback
+///    until a future re-enrich lands. No second whole-index deep clone.
 ///
 /// `#[doc(hidden)] pub` (not private) so integration tests can drive the real
 /// `FileWatcher` end-to-end without spawning a subprocess, matching the
@@ -2639,12 +2621,14 @@ pub fn spawn_mcp_watcher(
             let mut changes = vec![first];
             std::thread::sleep(Duration::from_millis(50));
             changes.extend(watcher.drain());
-            process_watcher_changes(&changes, &path, &shared);
-
-            let republished = republish_watcher_index(&shared);
-            match readiness.write() {
-                Ok(mut g) => *g = IndexReadiness::Ready(republished),
-                Err(poisoned) => *poisoned.into_inner() = IndexReadiness::Ready(republished),
+            // Publish the exact `Arc` the rebuild swapped into `shared` (already
+            // embeddings-free per ADR-0200). `None` = nothing relevant changed,
+            // so the prior `readiness` cell stands (issue #47 / ADR-0205).
+            if let Some(republished) = process_watcher_changes(&changes, &path, &shared) {
+                match readiness.write() {
+                    Ok(mut g) => *g = IndexReadiness::Ready(republished),
+                    Err(poisoned) => *poisoned.into_inner() = IndexReadiness::Ready(republished),
+                }
             }
         }
     })
@@ -4505,7 +4489,7 @@ pub fn process_watcher_changes(
     changes: &[crate::daemon::watcher::FileChange],
     base_path: &Path,
     shared: &SharedIndex,
-) {
+) -> Option<Arc<CodebaseIndex>> {
     let (modified_paths, removed_paths) = classify_changes(changes, base_path);
 
     // Nothing the index cares about changed — every event was a git-ignored
@@ -4513,7 +4497,7 @@ pub fn process_watcher_changes(
     // the common case for editor/build churn under the watched root. Return
     // before the expensive full-index deep clone below.
     if modified_paths.is_empty() && removed_paths.is_empty() {
-        return;
+        return None;
     }
 
     // Snapshot-then-swap: clone the inner Arc under the read lock (O(1)),
@@ -4523,7 +4507,7 @@ pub fn process_watcher_changes(
     // blocked, never returning torn state.
     let snapshot: Arc<CodebaseIndex> = match shared.read() {
         Ok(g) => Arc::clone(&*g),
-        Err(_) => return, // poisoned lock — nothing to do
+        Err(_) => return None, // poisoned lock — nothing to do
     };
     let mut next: CodebaseIndex = (*snapshot).clone();
     drop(snapshot);
@@ -4531,7 +4515,7 @@ pub fn process_watcher_changes(
     let update_count =
         apply_incremental_update(&mut next, base_path, &modified_paths, &removed_paths);
     if update_count == 0 {
-        return;
+        return None;
     }
     // Edge-delta graph rebuild + warm-started PageRank (ADR-0165/0166): work
     // proportional to the change for the common content-edit case, falling back
@@ -4567,15 +4551,30 @@ pub fn process_watcher_changes(
     next.dead_code_cache = std::sync::Arc::new(std::sync::OnceLock::new());
     next.health_cache = std::sync::Arc::new(std::sync::OnceLock::new());
 
+    // 6-signal fallback (ADR-0200): a delta-rebuilt clone otherwise carries the
+    // *stale* pre-edit enrichment forward — scoring the similarity signal against
+    // pre-edit embedded text is worse than not having it. Clear it HERE, once,
+    // before the swap, so the `shared` mirror and the `readiness` cell the caller
+    // republishes both point at ONE embeddings-free `Arc` (issue #47 / ADR-0205).
+    // This replaces the former `republish_watcher_index`, which produced the same
+    // effect via a redundant second whole-index deep clone every batch.
+    #[cfg(feature = "embeddings")]
+    {
+        next.embedding_index = None;
+    }
+
     let total_files = next.total_files;
     let total_tokens = next.total_tokens;
     let new_arc = Arc::new(next);
     if let Ok(mut g) = shared.write() {
-        *g = new_arc;
+        *g = Arc::clone(&new_arc);
     }
     eprintln!(
         "cxpak: updated {update_count} file(s), {total_files} files / {total_tokens} tokens total"
     );
+    // Hand the freshly-swapped `Arc` back so the watcher publishes exactly this
+    // index into `readiness` — no second deep clone (issue #47 / ADR-0205).
+    Some(new_arc)
 }
 
 fn mcp_error_response(id: Option<Value>, code: i32, message: &str) -> Value {
@@ -4986,26 +4985,110 @@ mod tests {
         ));
     }
 
-    /// finding M5: a watcher republish must actively clear `embedding_index`,
-    /// not carry it forward stale. Exercises `republish_watcher_index`
-    /// directly (the function `spawn_mcp_watcher`'s loop calls on every
-    /// debounced batch) — deterministic, no real edit or `FileWatcher` needed.
+    /// finding M5 + issue #47 / ADR-0205: a watcher rebuild must actively clear
+    /// `embedding_index` (never carry stale enrichment forward, ADR-0200) AND
+    /// publish the *same* freshly-swapped `Arc` it wrote into `shared` — no
+    /// second whole-index deep clone. Drives `process_watcher_changes` (which
+    /// now owns the clearing, replacing the deleted `republish_watcher_index`)
+    /// with a real edit; deterministic, no `FileWatcher` needed.
     #[cfg(feature = "embeddings")]
     #[test]
-    fn mcp_watcher_swap_clears_embedding() {
+    fn process_watcher_changes_clears_embedding_and_publishes_single_arc() {
+        use crate::daemon::watcher::FileChange;
+
+        // Seed `shared` from an enriched index (the first-batch-after-enrich
+        // case: the watcher mirror is seeded from `ReadyEnriched`).
         let mut idx = make_test_index();
         let mut emb = crate::embeddings::EmbeddingIndex::new(3);
         emb.add("src/main.rs".to_string(), vec![0.1, 0.2, 0.3]);
-        idx.embedding_index = Some(emb);
+        idx.embedding_index = Some(Arc::new(emb));
         assert!(idx.has_embedding_index());
         let shared: SharedIndex = Arc::new(RwLock::new(Arc::new(idx)));
 
-        let republished = republish_watcher_index(&shared);
+        // A real, non-ignored edit under the watched root forces a swap.
+        let dir = tempfile::TempDir::new().unwrap();
+        let file_path = dir.path().join("added.rs");
+        std::fs::write(&file_path, "fn added() {}").unwrap();
+        let changes = vec![FileChange::Modified(file_path)];
+
+        let published = process_watcher_changes(&changes, dir.path(), &shared)
+            .expect("a real edit must publish a fresh index");
+
+        // ADR-0200: the republished index is the 6-signal fallback.
+        assert!(
+            !published.has_embedding_index(),
+            "a watcher rebuild must clear embedding_index, not carry it stale"
+        );
+        // issue #47: the published Arc IS the one swapped into `shared` — the
+        // caller republishes it verbatim, so there is no second deep clone.
+        let in_shared = Arc::clone(&shared.read().unwrap());
+        assert!(
+            Arc::ptr_eq(&published, &in_shared),
+            "published index must be the exact Arc swapped into `shared`, \
+             not an independent second deep clone"
+        );
+    }
+
+    /// issue #47 / ADR-0205: cloning a `CodebaseIndex` — which
+    /// `process_watcher_changes` does once per edit batch — must NOT deep-copy
+    /// the embedding matrix. With `embedding_index: Option<Arc<EmbeddingIndex>>`
+    /// the clone bumps a refcount; this test proves the matrix is shared, not
+    /// duplicated. (Fails to COMPILE on the pre-fix non-`Arc` field — the
+    /// strongest possible regression guard.)
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn embedding_index_clone_shares_matrix_not_copies() {
+        let mut idx = make_test_index();
+        let mut emb = crate::embeddings::EmbeddingIndex::new(3);
+        emb.add("src/main.rs".to_string(), vec![0.1, 0.2, 0.3]);
+        idx.embedding_index = Some(Arc::new(emb));
+
+        let arc_idx = Arc::new(idx);
+        let inner_emb: Arc<crate::embeddings::EmbeddingIndex> =
+            Arc::clone(arc_idx.embedding_index.as_ref().unwrap());
+        // arc_idx holds one ref, inner_emb holds one → 2.
+        assert_eq!(Arc::strong_count(&inner_emb), 2);
+
+        // The per-batch deep clone of the whole index.
+        let cloned = (*arc_idx).clone();
+        assert_eq!(
+            Arc::strong_count(&inner_emb),
+            3,
+            "cloning CodebaseIndex must bump the embedding Arc refcount, \
+             not deep-copy the Vec<f32> matrix"
+        );
+        drop(cloned);
+        assert_eq!(Arc::strong_count(&inner_emb), 2);
+    }
+
+    /// issue #47 memory ceiling: an ignored-only batch must publish nothing
+    /// (`None`), leaving the prior `readiness`/`shared` Arcs untouched — no new
+    /// index version is allocated per spurious wake. Proven via `Arc::ptr_eq`.
+    #[test]
+    fn process_watcher_changes_ignored_only_publishes_none() {
+        use crate::daemon::watcher::FileChange;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        git2::Repository::init(dir.path()).unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "/target\n.cxpak/\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("target/debug")).unwrap();
+        let ignored = dir.path().join("target/debug/build-artifact.rs");
+        std::fs::write(&ignored, "fn junk() {}").unwrap();
+
+        let shared = make_shared_index();
+        let before = Arc::clone(&shared.read().unwrap());
+        let changes = vec![FileChange::Modified(ignored)];
+
+        let published = process_watcher_changes(&changes, dir.path(), &shared);
 
         assert!(
-            !republished.has_embedding_index(),
-            "a watcher republish must actively clear embedding_index, not \
-             carry it forward stale"
+            published.is_none(),
+            "an ignored-only batch must publish nothing"
+        );
+        let after = Arc::clone(&shared.read().unwrap());
+        assert!(
+            Arc::ptr_eq(&before, &after),
+            "an ignored-only batch must not swap (or allocate) a new index version"
         );
     }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -3559,7 +3559,7 @@ fn dispatch_capability_op(
                             FileRole::Dependency => 0.5,
                         };
                         indexed_targets.push((
-                            &index.files[idx],
+                            index.files[idx].as_ref(),
                             *role,
                             score,
                             parent.clone(),
@@ -5090,6 +5090,60 @@ mod tests {
             Arc::ptr_eq(&before, &after),
             "an ignored-only batch must not swap (or allocate) a new index version"
         );
+    }
+
+    /// issue #47 P1 (ADR-0205): the memory ceiling. The watcher must not
+    /// accumulate index versions across batches. After each real edit,
+    /// `shared` and `readiness` hold the *same* `Arc` (a single publish, no
+    /// second clone), so exactly one index version is live no matter how many
+    /// batches run — `Arc::strong_count` returns to a fixed baseline every
+    /// batch. This is the demonstration (not just assertion) that the footprint
+    /// is bounded. It fails on the pre-fix design, where `process_watcher_changes`
+    /// and `republish_watcher_index` produced two INDEPENDENT deep clones, so
+    /// `shared` and `readiness` diverged (no `ptr_eq`, baseline count of 2 not 3).
+    #[test]
+    fn watcher_does_not_accumulate_index_versions_across_batches() {
+        use crate::daemon::watcher::FileChange;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let shared = make_shared_index();
+        let readiness: SharedReadiness = Arc::new(RwLock::new(IndexReadiness::Ready(Arc::clone(
+            &shared.read().unwrap(),
+        ))));
+
+        for i in 0..25 {
+            let f = dir.path().join(format!("f{i}.rs"));
+            std::fs::write(&f, format!("fn g{i}() {{}}")).unwrap();
+            let changes = vec![FileChange::Modified(f)];
+
+            if let Some(published) = process_watcher_changes(&changes, dir.path(), &shared) {
+                match readiness.write() {
+                    Ok(mut g) => *g = IndexReadiness::Ready(published),
+                    Err(p) => *p.into_inner() = IndexReadiness::Ready(published),
+                }
+            }
+
+            // Holders of the current index version: `shared`, `readiness`, and
+            // the local `cur` clone → exactly 3, every batch. A count that
+            // grows with `i` would mean old versions are being retained.
+            let cur = Arc::clone(&shared.read().unwrap());
+            assert_eq!(
+                Arc::strong_count(&cur),
+                3,
+                "batch {i}: exactly one index version must be live \
+                 (shared + readiness + local), found {}",
+                Arc::strong_count(&cur)
+            );
+            match &*readiness.read().unwrap() {
+                IndexReadiness::Ready(r) => assert!(
+                    Arc::ptr_eq(r, &cur),
+                    "batch {i}: `shared` and `readiness` must share ONE Arc \
+                     (single publish, no second deep clone)"
+                ),
+                _ => panic!("batch {i}: readiness must be Ready after an edit"),
+            }
+            drop(cur);
+        }
     }
 
     /// Deterministic: the shutdown signal is already set before the watcher's

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -5092,15 +5092,21 @@ mod tests {
         );
     }
 
-    /// issue #47 P1 (ADR-0205): the memory ceiling. The watcher must not
-    /// accumulate index versions across batches. After each real edit,
-    /// `shared` and `readiness` hold the *same* `Arc` (a single publish, no
-    /// second clone), so exactly one index version is live no matter how many
-    /// batches run — `Arc::strong_count` returns to a fixed baseline every
-    /// batch. This is the demonstration (not just assertion) that the footprint
-    /// is bounded. It fails on the pre-fix design, where `process_watcher_changes`
-    /// and `republish_watcher_index` produced two INDEPENDENT deep clones, so
-    /// `shared` and `readiness` diverged (no `ptr_eq`, baseline count of 2 not 3).
+    /// issue #47 P1 (ADR-0205): the single-publish invariant behind the memory
+    /// ceiling. After each real edit, `shared` and `readiness` hold the *same*
+    /// `Arc` (a single publish, no divergent second clone), so the current
+    /// generation has a fixed holder set no matter how many batches run —
+    /// `Arc::strong_count` returns to the same baseline (shared + readiness +
+    /// the local `cur`) and `ptr_eq` confirms the two cells share one pointer.
+    ///
+    /// Scope: this pins the *current-generation* holder count, which is what the
+    /// double-clone bug inflated — it does NOT by itself measure total heap. It
+    /// cannot catch a hypothetical version-history collection or an external
+    /// holder pinning an old `Arc` (ADR-0205 "Revisit if" — a slow MCP handler);
+    /// both would leave this baseline unchanged. It fails on the pre-fix design,
+    /// where `process_watcher_changes` and `republish_watcher_index` produced two
+    /// INDEPENDENT deep clones, so `shared` and `readiness` diverged (no `ptr_eq`,
+    /// baseline count of 2 not 3).
     #[test]
     fn watcher_does_not_accumulate_index_versions_across_batches() {
         use crate::daemon::watcher::FileChange;

--- a/src/context_quality/expansion.rs
+++ b/src/context_quality/expansion.rs
@@ -563,7 +563,7 @@ pub fn expand_query(query: &str, domains: &HashSet<Domain>) -> HashSet<String> {
 
 /// Detect which domains are present in the given set of indexed files based on
 /// file extensions and path segments.
-pub fn detect_domains(files: &[crate::index::IndexedFile]) -> HashSet<Domain> {
+pub fn detect_domains(files: &[std::sync::Arc<crate::index::IndexedFile>]) -> HashSet<Domain> {
     let mut domains = HashSet::new();
 
     for file in files {
@@ -644,8 +644,8 @@ mod tests {
     use super::*;
 
     // Helper: build a minimal IndexedFile with only a relative_path.
-    fn make_file(path: &str) -> crate::index::IndexedFile {
-        crate::index::IndexedFile {
+    fn make_file(path: &str) -> std::sync::Arc<crate::index::IndexedFile> {
+        std::sync::Arc::new(crate::index::IndexedFile {
             relative_path: path.to_string(),
             language: None,
             size_bytes: 0,
@@ -653,7 +653,7 @@ mod tests {
             parse_result: None,
             content: String::new(),
             mtime_secs: None,
-        }
+        })
     }
 
     // -----------------------------------------------------------------------

--- a/src/core_graph/index.rs
+++ b/src/core_graph/index.rs
@@ -45,8 +45,14 @@ pub struct CodebaseIndex {
     /// [`crate::core_graph::graph::EdgeType::CrossLanguage`] edge so existing
     /// blast-radius / PageRank / auto_context pipelines pick them up.
     pub cross_lang_edges: Vec<CrossLangEdge>,
+    /// Similarity signal #7 (opt-in via `.cxpak.json`; ADR-0186). Wrapped in
+    /// `Arc` (issue #47 / ADR-0205) so cloning a `CodebaseIndex` — which the MCP
+    /// freshness watcher does per edit batch — bumps a refcount instead of
+    /// deep-copying the flat `Vec<f32>` matrix (`EmbeddingIndex::vectors`), the
+    /// dominant `MALLOC_LARGE` allocation class. Nulling to `None` on the
+    /// 6-signal-fallback path (ADR-0200) then drops that single shared ref.
     #[cfg(feature = "embeddings")]
-    pub embedding_index: Option<crate::embeddings::EmbeddingIndex>,
+    pub embedding_index: Option<Arc<crate::embeddings::EmbeddingIndex>>,
     /// Memoized `detect_dead_code(self, None)` result. Populated lazily on
     /// first call to `CodebaseIndex::dead_code_cached` (the orchestration method
     /// defined in `crate`'s index module). Shared across clones via `Arc`, so any

--- a/src/core_graph/index.rs
+++ b/src/core_graph/index.rs
@@ -25,7 +25,7 @@ use unicode_normalization::UnicodeNormalization;
 
 #[derive(Debug, Clone)]
 pub struct CodebaseIndex {
-    pub files: Vec<IndexedFile>,
+    pub files: Vec<Arc<IndexedFile>>,
     pub language_stats: HashMap<String, LanguageStats>,
     pub total_files: usize,
     pub total_bytes: u64,

--- a/src/index/graph.rs
+++ b/src/index/graph.rs
@@ -6,6 +6,7 @@ pub use crate::core_graph::graph::{
     BridgeType, DependencyGraph, EdgeConfidence, EdgeType, TypedEdge,
 };
 use std::collections::HashSet;
+use std::sync::Arc;
 
 // ─── Import resolution helpers ────────────────────────────────────────────────
 
@@ -388,7 +389,7 @@ fn resolve_import(
 /// is never needed for the delta and is kept out to avoid a second, divergent
 /// implementation of that logic.
 pub(crate) fn edges_for_file(
-    file: &IndexedFile,
+    file: &Arc<IndexedFile>,
     all_paths: &HashSet<&str>,
 ) -> Vec<(String, EdgeType)> {
     let mut out = Vec::new();
@@ -403,7 +404,7 @@ pub(crate) fn edges_for_file(
 }
 
 pub fn build_dependency_graph(
-    files: &[IndexedFile],
+    files: &[Arc<IndexedFile>],
     schema: Option<&crate::schema::SchemaIndex>,
 ) -> DependencyGraph {
     let all_paths: HashSet<&str> = files.iter().map(|f| f.relative_path.as_str()).collect();
@@ -434,9 +435,9 @@ mod tests {
 
     // ─── helper ──────────────────────────────────────────────────────────────
 
-    fn make_indexed_file(path: &str, lang: &str, imports: Vec<&str>) -> IndexedFile {
+    fn make_indexed_file(path: &str, lang: &str, imports: Vec<&str>) -> Arc<IndexedFile> {
         use crate::parser::language::Import;
-        IndexedFile {
+        Arc::new(IndexedFile {
             relative_path: path.to_string(),
             language: Some(lang.to_string()),
             size_bytes: 0,
@@ -454,7 +455,7 @@ mod tests {
             }),
             content: String::new(),
             mtime_secs: None,
-        }
+        })
     }
 
     // ─── helper tests ─────────────────────────────────────────────────────────

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -90,7 +90,7 @@ impl CodebaseIndex {
                 .map(|d| d.as_secs());
 
             let parse_result = parse_results.get(&file.relative_path).cloned();
-            indexed_files.push(IndexedFile {
+            indexed_files.push(Arc::new(IndexedFile {
                 relative_path: file.relative_path.clone(),
                 language: file.language.clone(),
                 size_bytes: file.size_bytes,
@@ -98,7 +98,7 @@ impl CodebaseIndex {
                 parse_result,
                 content,
                 mtime_secs,
-            });
+            }));
         }
 
         let domains = crate::context_quality::expansion::detect_domains(&indexed_files);
@@ -212,7 +212,7 @@ impl CodebaseIndex {
                 .map(|d| d.as_secs());
 
             let parse_result = parse_results.get(&file.relative_path).cloned();
-            indexed_files.push(IndexedFile {
+            indexed_files.push(Arc::new(IndexedFile {
                 relative_path: file.relative_path.clone(),
                 language: file.language.clone(),
                 size_bytes: file.size_bytes,
@@ -220,7 +220,7 @@ impl CodebaseIndex {
                 parse_result,
                 content: file_content,
                 mtime_secs,
-            });
+            }));
         }
 
         let domains = crate::context_quality::expansion::detect_domains(&indexed_files);
@@ -494,7 +494,7 @@ impl CodebaseIndex {
         self.total_tokens += token_count;
         self.total_bytes += size_bytes;
 
-        self.files.push(IndexedFile {
+        self.files.push(Arc::new(IndexedFile {
             relative_path: relative_path.to_string(),
             language: language.map(|s| s.to_string()),
             size_bytes,
@@ -502,7 +502,7 @@ impl CodebaseIndex {
             parse_result,
             content: content.to_string(),
             mtime_secs,
-        });
+        }));
 
         self.total_files = self.files.len();
         self.term_frequencies
@@ -702,24 +702,26 @@ mod tests {
         let mut idx = CodebaseIndex::empty();
         idx.files = spec
             .iter()
-            .map(|(path, imports)| IndexedFile {
-                relative_path: path.to_string(),
-                language: Some("rust".to_string()),
-                size_bytes: 0,
-                token_count: 0,
-                parse_result: Some(ParseResult {
-                    symbols: vec![],
-                    imports: imports
-                        .iter()
-                        .map(|s| Import {
-                            source: (*s).to_string(),
-                            names: vec![],
-                        })
-                        .collect(),
-                    exports: vec![],
-                }),
-                content: String::new(),
-                mtime_secs: None,
+            .map(|(path, imports)| {
+                Arc::new(IndexedFile {
+                    relative_path: path.to_string(),
+                    language: Some("rust".to_string()),
+                    size_bytes: 0,
+                    token_count: 0,
+                    parse_result: Some(ParseResult {
+                        symbols: vec![],
+                        imports: imports
+                            .iter()
+                            .map(|s| Import {
+                                source: (*s).to_string(),
+                                names: vec![],
+                            })
+                            .collect(),
+                        exports: vec![],
+                    }),
+                    content: String::new(),
+                    mtime_secs: None,
+                })
             })
             .collect();
         idx.total_files = idx.files.len();
@@ -773,7 +775,7 @@ mod tests {
             .iter_mut()
             .find(|f| f.relative_path == "src/a.rs")
         {
-            f.parse_result.as_mut().unwrap().imports = vec![Import {
+            Arc::make_mut(f).parse_result.as_mut().unwrap().imports = vec![Import {
                 source: "crate::c".to_string(),
                 names: vec![],
             }];
@@ -1568,7 +1570,7 @@ mod tests {
             index.files[0].mtime_secs.is_some(),
             "precondition: disk build populates mtime"
         );
-        index.files[0].mtime_secs = None;
+        Arc::make_mut(&mut index.files[0]).mtime_secs = None;
 
         let current = vec![ScannedFile {
             relative_path: "a.rs".into(),

--- a/src/intelligence/api_surface.rs
+++ b/src/intelligence/api_surface.rs
@@ -105,7 +105,7 @@ pub fn extract_public_symbols(
     let mut token_count = 0usize;
 
     // Collect files with public symbols, sorted by pagerank descending.
-    let mut files_with_symbols: Vec<(&crate::core_graph::IndexedFile, f64)> = index
+    let mut files_with_symbols: Vec<(&std::sync::Arc<crate::core_graph::IndexedFile>, f64)> = index
         .files
         .iter()
         .filter(|f| {

--- a/src/intelligence/dead_code.rs
+++ b/src/intelligence/dead_code.rs
@@ -3,6 +3,7 @@ use crate::core_graph::IndexedFile;
 use crate::intelligence::api_surface::detect_routes;
 use crate::parser::language::{SymbolKind, Visibility};
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 // `DeadSymbol` is part of the data model and now lives in `core_graph`
 // (cxpak 3.0.0 Phase 0 de-cycle); the analysis logic below stays here.
@@ -157,7 +158,7 @@ fn strip_code_noise(src: &str) -> String {
 fn has_string_references(
     symbol_name: &str,
     defining_file: &str,
-    all_files: &[IndexedFile],
+    all_files: &[Arc<IndexedFile>],
 ) -> bool {
     if symbol_name.len() < 3 {
         return true; // too short to search reliably — assume alive
@@ -202,7 +203,7 @@ fn has_string_references(
 fn has_receiver_method_reference(
     file_path: &str,
     symbol_name: &str,
-    all_files: &[IndexedFile],
+    all_files: &[Arc<IndexedFile>],
 ) -> bool {
     if symbol_name.len() < 5 {
         return false;
@@ -257,7 +258,11 @@ fn has_receiver_method_reference(
 /// AND dangerously over-broad — any file that imported anything and
 /// happened to contain `some_other_module::run` would rubber-stamp every
 /// function named `run` in the tree as alive. Removed.
-fn has_qualified_reference(file_path: &str, symbol_name: &str, all_files: &[IndexedFile]) -> bool {
+fn has_qualified_reference(
+    file_path: &str,
+    symbol_name: &str,
+    all_files: &[Arc<IndexedFile>],
+) -> bool {
     let path = std::path::Path::new(file_path);
     let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
     // `mod.rs` files qualify under their parent directory name, not "mod".
@@ -1456,8 +1461,8 @@ mod tests {
 
     // ---- has_receiver_method_reference direct tests ----
 
-    fn make_file(path: &str, content: &str) -> IndexedFile {
-        IndexedFile {
+    fn make_file(path: &str, content: &str) -> Arc<IndexedFile> {
+        Arc::new(IndexedFile {
             relative_path: path.to_string(),
             language: Some("rust".to_string()),
             size_bytes: content.len() as u64,
@@ -1465,12 +1470,12 @@ mod tests {
             parse_result: None,
             content: content.to_string(),
             mtime_secs: None,
-        }
+        })
     }
 
     #[test]
     fn has_receiver_method_reference_short_name_returns_false() {
-        let files: Vec<IndexedFile> = vec![make_file("caller.rs", "obj.run(1);")];
+        let files: Vec<Arc<IndexedFile>> = vec![make_file("caller.rs", "obj.run(1);")];
         assert!(!has_receiver_method_reference("def.rs", "run", &files));
     }
 

--- a/src/intelligence/drift.rs
+++ b/src/intelligence/drift.rs
@@ -667,7 +667,7 @@ mod tests {
             "src/api/router.rs",
             "src/api/middleware.rs",
         ] {
-            index.files.push(IndexedFile {
+            index.files.push(std::sync::Arc::new(IndexedFile {
                 relative_path: name.to_string(),
                 language: Some("rust".into()),
                 size_bytes: 100,
@@ -675,7 +675,7 @@ mod tests {
                 parse_result: None,
                 content: "fn f() {}".to_string(),
                 mtime_secs: None,
-            });
+            }));
         }
 
         // Add an intra-module edge (both within src/api)
@@ -709,7 +709,7 @@ mod tests {
 
         // Only 2 files in same prefix -> below the "< 3" threshold
         for name in &["src/tiny/a.rs", "src/tiny/b.rs"] {
-            index.files.push(IndexedFile {
+            index.files.push(std::sync::Arc::new(IndexedFile {
                 relative_path: name.to_string(),
                 language: Some("rust".into()),
                 size_bytes: 50,
@@ -717,7 +717,7 @@ mod tests {
                 parse_result: None,
                 content: "fn f() {}".to_string(),
                 mtime_secs: None,
-            });
+            }));
         }
 
         let snap = snapshot_from_index(&index, "2026-04-02T00:00:00Z");
@@ -743,7 +743,7 @@ mod tests {
 
         // 3 files in same module but no edges -> coupling 0, cohesion 0
         for name in &["src/lib/a.rs", "src/lib/b.rs", "src/lib/c.rs"] {
-            index.files.push(IndexedFile {
+            index.files.push(std::sync::Arc::new(IndexedFile {
                 relative_path: name.to_string(),
                 language: Some("rust".into()),
                 size_bytes: 100,
@@ -751,7 +751,7 @@ mod tests {
                 parse_result: None,
                 content: "fn f() {}".to_string(),
                 mtime_secs: None,
-            });
+            }));
         }
 
         let snap = snapshot_from_index(&index, "2026-04-03T00:00:00Z");
@@ -796,7 +796,7 @@ mod tests {
 
         // Create a module with 3 files, mostly cross-module edges -> high coupling
         for name in &["src/hot/a.rs", "src/hot/b.rs", "src/hot/c.rs"] {
-            index.files.push(IndexedFile {
+            index.files.push(std::sync::Arc::new(IndexedFile {
                 relative_path: name.to_string(),
                 language: Some("rust".into()),
                 size_bytes: 100,
@@ -804,7 +804,7 @@ mod tests {
                 parse_result: None,
                 content: "fn f() {}".to_string(),
                 mtime_secs: None,
-            });
+            }));
         }
 
         // All edges are cross-module -> coupling = 1.0 (> 0.6 threshold)
@@ -852,7 +852,7 @@ mod tests {
         // Build report with empty index (different metrics)
         let mut index = CodebaseIndex::empty();
         for name in &["src/mod/a.rs", "src/mod/b.rs", "src/mod/c.rs"] {
-            index.files.push(IndexedFile {
+            index.files.push(std::sync::Arc::new(IndexedFile {
                 relative_path: name.to_string(),
                 language: Some("rust".into()),
                 size_bytes: 100,
@@ -860,7 +860,7 @@ mod tests {
                 parse_result: None,
                 content: "fn f() {}".to_string(),
                 mtime_secs: None,
-            });
+            }));
         }
 
         let report = build_drift_report(&index, dir.path(), false);
@@ -928,7 +928,7 @@ mod tests {
 
         // Module A: 3 files → qualifies
         for name in &["src/a/x.rs", "src/a/y.rs", "src/a/z.rs"] {
-            index.files.push(IndexedFile {
+            index.files.push(std::sync::Arc::new(IndexedFile {
                 relative_path: name.to_string(),
                 language: Some("rust".into()),
                 size_bytes: 100,
@@ -936,11 +936,11 @@ mod tests {
                 parse_result: None,
                 content: "fn f() {}".to_string(),
                 mtime_secs: None,
-            });
+            }));
         }
         // Module B: 2 files → does NOT qualify
         for name in &["src/b/p.rs", "src/b/q.rs"] {
-            index.files.push(IndexedFile {
+            index.files.push(std::sync::Arc::new(IndexedFile {
                 relative_path: name.to_string(),
                 language: Some("rust".into()),
                 size_bytes: 50,
@@ -948,7 +948,7 @@ mod tests {
                 parse_result: None,
                 content: "fn g() {}".to_string(),
                 mtime_secs: None,
-            });
+            }));
         }
 
         index

--- a/src/intelligence/health.rs
+++ b/src/intelligence/health.rs
@@ -153,7 +153,7 @@ pub(crate) fn has_inline_tests(file: &crate::core_graph::IndexedFile) -> bool {
 /// uncovered "source files" dilutes the ratio. Files with an unrecognized
 /// or missing `language` are excluded too (can't classify as code).
 fn score_test_coverage(index: &CodebaseIndex) -> f64 {
-    let source_files: Vec<&crate::core_graph::IndexedFile> = index
+    let source_files: Vec<&std::sync::Arc<crate::core_graph::IndexedFile>> = index
         .files
         .iter()
         .filter(|f| {

--- a/src/intelligence/risk.rs
+++ b/src/intelligence/risk.rs
@@ -108,7 +108,7 @@ pub fn compute_risk_ranking(index: &CodebaseIndex) -> Vec<RiskEntry> {
                     .files
                     .iter()
                     .find(|f| f.relative_path == path)
-                    .map(has_inline_tests)
+                    .map(|f| has_inline_tests(f))
                     .unwrap_or(false);
             let test_coverage = if has_test { 1.0 } else { 0.0 };
 
@@ -322,9 +322,9 @@ mod tests {
         // Manually store the content so has_inline_tests can read it
         for file in &mut index.files {
             if file.relative_path == "a.rs" {
-                file.content = content_a.to_string();
+                std::sync::Arc::make_mut(file).content = content_a.to_string();
             } else {
-                file.content = content_b.to_string();
+                std::sync::Arc::make_mut(file).content = content_b.to_string();
             }
         }
         // Ensure test_map is empty so the only path to tc=1.0 is inline tests

--- a/src/intelligence/security.rs
+++ b/src/intelligence/security.rs
@@ -879,8 +879,8 @@ pub fn process_input(data: String) {
         path: &str,
         content: &str,
         symbols: Vec<crate::parser::language::Symbol>,
-    ) -> crate::core_graph::IndexedFile {
-        crate::core_graph::IndexedFile {
+    ) -> std::sync::Arc<crate::core_graph::IndexedFile> {
+        std::sync::Arc::new(crate::core_graph::IndexedFile {
             relative_path: path.to_string(),
             language: Some("rust".into()),
             size_bytes: content.len() as u64,
@@ -892,7 +892,7 @@ pub fn process_input(data: String) {
             }),
             content: content.to_string(),
             mtime_secs: None,
-        }
+        })
     }
 
     fn make_pub_symbol(name: &str) -> crate::parser::language::Symbol {
@@ -977,7 +977,7 @@ pub fn process_input(data: String) {
             .files
             .push(make_indexed_file("src/routes.js", content, vec![]));
         // Override language to JS so detect_routes matches
-        index.files[0].language = Some("javascript".into());
+        std::sync::Arc::make_mut(&mut index.files[0]).language = Some("javascript".into());
 
         let surface = build_security_surface(&index, DEFAULT_AUTH_PATTERNS, None);
         assert!(

--- a/src/intelligence/test_map.rs
+++ b/src/intelligence/test_map.rs
@@ -1,5 +1,6 @@
 use crate::core_graph::IndexedFile;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 // `TestFileRef`/`TestConfidence` are data-model types now in `core_graph`
 // (cxpak 3.0.0 Phase 0 de-cycle); the mapping logic below stays here.
@@ -164,7 +165,7 @@ fn general_test_candidates(filename_no_ext: &str, dir_prefix: &str, ext: &str) -
 /// For each test file (identified by path containing `test`, `spec`, or `__tests__`),
 /// examine imports and resolve them back to source file paths. Returns a map of
 /// source_path -> Vec<TestFileRef>.
-pub fn find_test_files_by_imports(files: &[IndexedFile]) -> HashMap<String, Vec<TestFileRef>> {
+pub fn find_test_files_by_imports(files: &[Arc<IndexedFile>]) -> HashMap<String, Vec<TestFileRef>> {
     // Build a lookup set of all file paths for fast resolution
     let all_paths: HashSet<&str> = files.iter().map(|f| f.relative_path.as_str()).collect();
 
@@ -220,7 +221,7 @@ pub fn find_test_files_by_imports(files: &[IndexedFile]) -> HashMap<String, Vec<
 /// Combines naming-convention matching and import-based matching. When the same
 /// test file is found by both methods, its confidence is upgraded to `Both`.
 pub fn build_test_map(
-    files: &[IndexedFile],
+    files: &[Arc<IndexedFile>],
     all_paths: &HashSet<String>,
 ) -> HashMap<String, Vec<TestFileRef>> {
     let mut map: HashMap<String, Vec<TestFileRef>> = HashMap::new();
@@ -275,8 +276,8 @@ mod tests {
         paths.iter().map(|s| s.to_string()).collect()
     }
 
-    fn make_file(path: &str, imports: Vec<Import>) -> IndexedFile {
-        IndexedFile {
+    fn make_file(path: &str, imports: Vec<Import>) -> Arc<IndexedFile> {
+        Arc::new(IndexedFile {
             relative_path: path.to_string(),
             language: None,
             size_bytes: 0,
@@ -288,7 +289,7 @@ mod tests {
             }),
             content: String::new(),
             mtime_secs: None,
-        }
+        })
     }
 
     fn make_import(source: &str) -> Import {

--- a/src/lsp/methods.rs
+++ b/src/lsp/methods.rs
@@ -123,7 +123,7 @@ pub fn find_indexed_file<'a>(
     uri_path: &str,
     index: &'a crate::index::CodebaseIndex,
     repo_root: &Path,
-) -> Option<&'a crate::index::IndexedFile> {
+) -> Option<&'a std::sync::Arc<crate::index::IndexedFile>> {
     let url = Url::parse(uri_path).ok();
     let rel_opt = url.as_ref().and_then(|u| uri_to_rel_path(u, repo_root));
     index.files.iter().find(|f| {

--- a/src/plugin/manifest.rs
+++ b/src/plugin/manifest.rs
@@ -179,7 +179,7 @@ mod tests {
         // Build a minimal CodebaseIndex with two files
         let index = CodebaseIndex {
             files: vec![
-                crate::index::IndexedFile {
+                std::sync::Arc::new(crate::index::IndexedFile {
                     relative_path: "src/main.py".to_string(),
                     language: Some("Python".to_string()),
                     size_bytes: 100,
@@ -187,8 +187,8 @@ mod tests {
                     parse_result: None,
                     content: "print('hello')".to_string(),
                     mtime_secs: None,
-                },
-                crate::index::IndexedFile {
+                }),
+                std::sync::Arc::new(crate::index::IndexedFile {
                     relative_path: "src/lib.rs".to_string(),
                     language: Some("Rust".to_string()),
                     size_bytes: 200,
@@ -196,7 +196,7 @@ mod tests {
                     parse_result: None,
                     content: "fn main() {}".to_string(),
                     mtime_secs: None,
-                },
+                }),
             ],
             language_stats: HashMap::new(),
             total_files: 2,
@@ -279,7 +279,7 @@ mod tests {
         use std::collections::HashMap;
 
         let index = CodebaseIndex {
-            files: vec![crate::index::IndexedFile {
+            files: vec![std::sync::Arc::new(crate::index::IndexedFile {
                 relative_path: "src/main.py".to_string(),
                 language: Some("Python".to_string()),
                 size_bytes: 100,
@@ -287,7 +287,7 @@ mod tests {
                 parse_result: None,
                 content: "print('hello')".to_string(),
                 mtime_secs: None,
-            }],
+            })],
             language_stats: HashMap::new(),
             total_files: 1,
             total_bytes: 100,
@@ -329,7 +329,7 @@ mod tests {
         use std::collections::HashMap;
 
         let index = CodebaseIndex {
-            files: vec![crate::index::IndexedFile {
+            files: vec![std::sync::Arc::new(crate::index::IndexedFile {
                 relative_path: "src/main.py".to_string(),
                 language: Some("Python".to_string()),
                 size_bytes: 100,
@@ -337,7 +337,7 @@ mod tests {
                 parse_result: None,
                 content: "print('hello')".to_string(),
                 mtime_secs: None,
-            }],
+            })],
             language_stats: HashMap::new(),
             total_files: 1,
             total_bytes: 100,
@@ -385,7 +385,7 @@ mod tests {
 
         let index = CodebaseIndex {
             files: vec![
-                crate::index::IndexedFile {
+                std::sync::Arc::new(crate::index::IndexedFile {
                     relative_path: "src/main.py".to_string(),
                     language: Some("Python".to_string()),
                     size_bytes: 50,
@@ -393,8 +393,8 @@ mod tests {
                     parse_result: None,
                     content: "x=1".to_string(),
                     mtime_secs: None,
-                },
-                crate::index::IndexedFile {
+                }),
+                std::sync::Arc::new(crate::index::IndexedFile {
                     relative_path: "src/lib.ts".to_string(),
                     language: Some("TypeScript".to_string()),
                     size_bytes: 50,
@@ -402,8 +402,8 @@ mod tests {
                     parse_result: None,
                     content: "export {}".to_string(),
                     mtime_secs: None,
-                },
-                crate::index::IndexedFile {
+                }),
+                std::sync::Arc::new(crate::index::IndexedFile {
                     relative_path: "src/main.rs".to_string(),
                     language: Some("Rust".to_string()),
                     size_bytes: 50,
@@ -411,7 +411,7 @@ mod tests {
                     parse_result: None,
                     content: "fn main() {}".to_string(),
                     mtime_secs: None,
-                },
+                }),
             ],
             language_stats: HashMap::new(),
             total_files: 3,
@@ -458,7 +458,7 @@ mod tests {
 
         let index = CodebaseIndex {
             files: vec![
-                crate::index::IndexedFile {
+                std::sync::Arc::new(crate::index::IndexedFile {
                     relative_path: "src/a.rs".to_string(),
                     language: Some("Rust".to_string()),
                     size_bytes: 10,
@@ -466,8 +466,8 @@ mod tests {
                     parse_result: None,
                     content: "fn a() {}".to_string(),
                     mtime_secs: None,
-                },
-                crate::index::IndexedFile {
+                }),
+                std::sync::Arc::new(crate::index::IndexedFile {
                     relative_path: "src/b.py".to_string(),
                     language: Some("Python".to_string()),
                     size_bytes: 10,
@@ -475,7 +475,7 @@ mod tests {
                     parse_result: None,
                     content: "x=1".to_string(),
                     mtime_secs: None,
-                },
+                }),
             ],
             language_stats: HashMap::new(),
             total_files: 2,

--- a/src/relevance/signals.rs
+++ b/src/relevance/signals.rs
@@ -1141,7 +1141,9 @@ mod tests {
     fn test_embedding_similarity_no_query_embedding() {
         let counter = TokenCounter::new();
         let mut index = CodebaseIndex::build(vec![], HashMap::new(), &counter);
-        index.embedding_index = Some(crate::embeddings::EmbeddingIndex::new(3));
+        index.embedding_index = Some(std::sync::Arc::new(crate::embeddings::EmbeddingIndex::new(
+            3,
+        )));
         let result = embedding_similarity_signal(None, "any.rs", &index);
         assert_eq!(result.score, 0.5);
         assert_eq!(result.detail, "no query embedding");
@@ -1154,7 +1156,7 @@ mod tests {
         let mut index = CodebaseIndex::build(vec![], HashMap::new(), &counter);
         let mut emb = crate::embeddings::EmbeddingIndex::new(3);
         emb.add("src/api.rs", vec![1.0, 0.0, 0.0]);
-        index.embedding_index = Some(emb);
+        index.embedding_index = Some(std::sync::Arc::new(emb));
         let result = embedding_similarity_signal(Some(&[1.0, 0.0, 0.0]), "src/api.rs", &index);
         assert_eq!(result.name, "embedding_similarity");
         assert!(
@@ -1172,7 +1174,7 @@ mod tests {
         let mut index = CodebaseIndex::build(vec![], HashMap::new(), &counter);
         let mut emb = crate::embeddings::EmbeddingIndex::new(3);
         emb.add("src/other.rs", vec![1.0, 0.0, 0.0]);
-        index.embedding_index = Some(emb);
+        index.embedding_index = Some(std::sync::Arc::new(emb));
         let result = embedding_similarity_signal(Some(&[1.0, 0.0, 0.0]), "src/missing.rs", &index);
         assert_eq!(result.score, 0.5);
         assert_eq!(result.detail, "file not in embedding index");

--- a/src/schema/detect.rs
+++ b/src/schema/detect.rs
@@ -8,6 +8,7 @@ use crate::schema::{
 };
 use regex::Regex;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::LazyLock;
 
 // ---------------------------------------------------------------------------
@@ -518,7 +519,7 @@ pub fn detect_terraform_schemas(index: &CodebaseIndex, schema: &mut SchemaIndex)
 /// Detect migration chains across all files in the index.
 pub fn detect_migrations(index: &CodebaseIndex) -> Vec<MigrationChain> {
     // Group files by directory
-    let mut dir_groups: HashMap<String, Vec<&crate::core_graph::IndexedFile>> = HashMap::new();
+    let mut dir_groups: HashMap<String, Vec<&Arc<crate::core_graph::IndexedFile>>> = HashMap::new();
     for file in &index.files {
         let dir = parent_dir(&file.relative_path);
         dir_groups.entry(dir).or_default().push(file);
@@ -566,7 +567,7 @@ fn filename(path: &str) -> &str {
 // Rails: db/migrate/ directory, YYYYMMDDHHMMSS_name.rb
 fn try_rails_migrations(
     dir: &str,
-    files: &[&crate::core_graph::IndexedFile],
+    files: &[&Arc<crate::core_graph::IndexedFile>],
 ) -> Option<MigrationChain> {
     if !dir.ends_with("db/migrate") && !dir.contains("db/migrate/") {
         return None;
@@ -602,7 +603,7 @@ fn try_rails_migrations(
 // Alembic: alembic/versions/ directory, hash_name.py, reads revision from content
 fn try_alembic_migrations(
     dir: &str,
-    files: &[&crate::core_graph::IndexedFile],
+    files: &[&Arc<crate::core_graph::IndexedFile>],
 ) -> Option<MigrationChain> {
     if !dir.ends_with("alembic/versions") && !dir.contains("alembic/versions") {
         return None;
@@ -654,7 +655,7 @@ fn try_alembic_migrations(
 // Flyway: any directory, V{N}__name.sql
 fn try_flyway_migrations(
     dir: &str,
-    files: &[&crate::core_graph::IndexedFile],
+    files: &[&Arc<crate::core_graph::IndexedFile>],
 ) -> Option<MigrationChain> {
     let mut entries: Vec<MigrationEntry> = files
         .iter()
@@ -691,7 +692,7 @@ fn try_flyway_migrations(
 // Django: */migrations/ directory, NNNN_name.py
 fn try_django_migrations(
     dir: &str,
-    files: &[&crate::core_graph::IndexedFile],
+    files: &[&Arc<crate::core_graph::IndexedFile>],
 ) -> Option<MigrationChain> {
     if !dir.ends_with("/migrations") && !dir.ends_with("migrations") {
         return None;
@@ -726,7 +727,7 @@ fn try_django_migrations(
 // Knex: migrations/ directory, YYYYMMDDHHMMSS_name.js/.ts
 fn try_knex_migrations(
     dir: &str,
-    files: &[&crate::core_graph::IndexedFile],
+    files: &[&Arc<crate::core_graph::IndexedFile>],
 ) -> Option<MigrationChain> {
     if !dir.ends_with("migrations") {
         return None;
@@ -765,8 +766,8 @@ fn try_knex_migrations(
 //       We need to group by the parent of parent (prisma/migrations)
 fn try_prisma_migrations(
     dir: &str,
-    _files: &[&crate::core_graph::IndexedFile],
-    all_dirs: &HashMap<String, Vec<&crate::core_graph::IndexedFile>>,
+    _files: &[&Arc<crate::core_graph::IndexedFile>],
+    all_dirs: &HashMap<String, Vec<&Arc<crate::core_graph::IndexedFile>>>,
 ) -> Option<MigrationChain> {
     // This function is called with dir = "prisma/migrations/TIMESTAMP_name"
     // We check: does this dir match prisma/migrations/{timestamp}_{name}?
@@ -854,7 +855,7 @@ fn try_prisma_migrations(
 // Drizzle: drizzle/ directory, NNNN_name.sql
 fn try_drizzle_migrations(
     dir: &str,
-    files: &[&crate::core_graph::IndexedFile],
+    files: &[&Arc<crate::core_graph::IndexedFile>],
 ) -> Option<MigrationChain> {
     if !dir.ends_with("drizzle") && !dir.contains("/drizzle/") {
         return None;
@@ -889,7 +890,7 @@ fn try_drizzle_migrations(
 // Generic: any dir with 3+ sequenced SQL files, NNN_name.sql or YYYYMMDDHHMMSS_name.sql
 fn try_generic_migrations(
     dir: &str,
-    files: &[&crate::core_graph::IndexedFile],
+    files: &[&Arc<crate::core_graph::IndexedFile>],
 ) -> Option<MigrationChain> {
     // Match numeric prefix + underscore + name + .sql
     let mut entries: Vec<MigrationEntry> = files
@@ -1058,10 +1059,12 @@ mod tests {
     fn make_index(files: Vec<IndexedFile>) -> CodebaseIndex {
         use crate::core_graph::graph::DependencyGraph;
         use std::collections::{HashMap, HashSet};
+        use std::sync::Arc;
+        let arc_files: Vec<Arc<IndexedFile>> = files.into_iter().map(Arc::new).collect();
         let graph = DependencyGraph::new();
         CodebaseIndex {
-            total_files: files.len(),
-            total_bytes: files.iter().map(|f| f.size_bytes).sum(),
+            total_files: arc_files.len(),
+            total_bytes: arc_files.iter().map(|f| f.size_bytes).sum(),
             total_tokens: 0,
             language_stats: HashMap::new(),
             term_frequencies: HashMap::new(),
@@ -1074,7 +1077,7 @@ mod tests {
             conventions: crate::conventions::ConventionProfile::default(),
             co_changes: Vec::new(),
             cross_lang_edges: Vec::new(),
-            files,
+            files: arc_files,
             #[cfg(feature = "embeddings")]
             embedding_index: None,
             dead_code_cache: std::sync::Arc::new(std::sync::OnceLock::new()),

--- a/src/schema/link.rs
+++ b/src/schema/link.rs
@@ -3,6 +3,7 @@
 use crate::schema::{EdgeConfidence, EdgeType, SchemaIndex};
 use regex::Regex;
 use std::collections::{BTreeSet, HashSet};
+use std::sync::Arc;
 use std::sync::LazyLock;
 
 /// Matches a `SELECT ... FROM` projection list. Capture group 1 is the raw
@@ -358,7 +359,7 @@ fn column_name_of(schema_index: &SchemaIndex, table: &str, col: &str) -> String 
 /// - ORM model file → table definition file
 /// - Migration sequence (each migration → its predecessor)
 pub fn build_schema_edges(
-    files: &[crate::core_graph::IndexedFile],
+    files: &[Arc<crate::core_graph::IndexedFile>],
     schema_index: &crate::schema::SchemaIndex,
 ) -> Vec<(String, String, EdgeType, EdgeConfidence)> {
     let mut edges: Vec<(String, String, EdgeType, EdgeConfidence)> = Vec::new();
@@ -609,8 +610,8 @@ mod tests {
         }
     }
 
-    fn make_file_list(files: Vec<IndexedFile>) -> Vec<IndexedFile> {
-        files
+    fn make_file_list(files: Vec<IndexedFile>) -> Vec<Arc<IndexedFile>> {
+        files.into_iter().map(Arc::new).collect()
     }
 
     fn make_table(name: &str, file_path: &str, columns: Vec<ColumnSchema>) -> TableSchema {

--- a/src/test_support/mod.rs
+++ b/src/test_support/mod.rs
@@ -109,16 +109,18 @@ impl IndexBuilder {
         index.files = self
             .files
             .iter()
-            .map(|name| IndexedFile {
-                relative_path: name.clone(),
-                language: Some("rust".to_string()),
-                size_bytes: 0,
-                token_count: 0,
-                parse_result: None,
-                // No `#[cfg(test)]` marker → `has_inline_tests` is false →
-                // every synthetic file is untested (test_penalty = 1.0).
-                content: String::new(),
-                mtime_secs: None,
+            .map(|name| {
+                std::sync::Arc::new(IndexedFile {
+                    relative_path: name.clone(),
+                    language: Some("rust".to_string()),
+                    size_bytes: 0,
+                    token_count: 0,
+                    parse_result: None,
+                    // No `#[cfg(test)]` marker → `has_inline_tests` is false →
+                    // every synthetic file is untested (test_penalty = 1.0).
+                    content: String::new(),
+                    mtime_secs: None,
+                })
             })
             .collect();
         index.total_files = index.files.len();

--- a/src/visual/layout.rs
+++ b/src/visual/layout.rs
@@ -910,7 +910,7 @@ pub fn build_file_layout(
     config: &LayoutConfig,
 ) -> Result<ComputedLayout, LayoutError> {
     // Filter files to this module.
-    let module_files: Vec<&crate::index::IndexedFile> = index
+    let module_files: Vec<&std::sync::Arc<crate::index::IndexedFile>> = index
         .files
         .iter()
         .filter(|f| file_module_prefix(&f.relative_path) == module_prefix)

--- a/src/visual/render.rs
+++ b/src/visual/render.rs
@@ -1688,7 +1688,7 @@ pub fn build_dashboard_data(index: &CodebaseIndex) -> DashboardData {
                     .files
                     .iter()
                     .find(|f| f.relative_path == e.path)
-                    .map(crate::intelligence::health::has_inline_tests)
+                    .map(|f| crate::intelligence::health::has_inline_tests(f))
                     .unwrap_or(false);
             let severity = risk_severity(e.risk_score).to_string();
             RiskDisplayEntry {

--- a/tests/column_lineage.rs
+++ b/tests/column_lineage.rs
@@ -49,8 +49,13 @@ fn users_table() -> TableSchema {
     }
 }
 
-fn indexed_file(path: &str, lang: &str, content: &str, symbols: Vec<Symbol>) -> IndexedFile {
-    IndexedFile {
+fn indexed_file(
+    path: &str,
+    lang: &str,
+    content: &str,
+    symbols: Vec<Symbol>,
+) -> std::sync::Arc<IndexedFile> {
+    std::sync::Arc::new(IndexedFile {
         relative_path: path.to_string(),
         language: Some(lang.to_string()),
         size_bytes: content.len() as u64,
@@ -62,7 +67,7 @@ fn indexed_file(path: &str, lang: &str, content: &str, symbols: Vec<Symbol>) -> 
         }),
         content: content.to_string(),
         mtime_secs: None,
-    }
+    })
 }
 
 fn symbol(name: &str, body: &str) -> Symbol {
@@ -80,7 +85,7 @@ fn symbol(name: &str, body: &str) -> Symbol {
 /// A schema + source fixture: a `users` table, a query selecting `email`, an
 /// ORM model with an `email` field, an endpoint handler, and a test — plus a
 /// SEPARATE file that only touches `name`.
-fn fixture() -> (Vec<IndexedFile>, SchemaIndex) {
+fn fixture() -> (Vec<std::sync::Arc<IndexedFile>>, SchemaIndex) {
     let mut schema = SchemaIndex::empty();
     schema.tables.insert("users".to_string(), users_table());
     schema.orm_models.insert(

--- a/tests/edge_confidence.rs
+++ b/tests/edge_confidence.rs
@@ -140,7 +140,8 @@ fn embedded_sql_edge_is_inferred() {
         r#"fn list() { db.query("SELECT id FROM products WHERE active = true") }"#,
     );
 
-    let raw_edges = cxpak::schema::link::build_schema_edges(&[rust_file], &schema);
+    let raw_edges =
+        cxpak::schema::link::build_schema_edges(&[std::sync::Arc::new(rust_file)], &schema);
 
     let mut g = DependencyGraph::new();
     for (from, to, etype, conf) in raw_edges {

--- a/tests/parity.rs
+++ b/tests/parity.rs
@@ -68,8 +68,8 @@ use std::collections::HashSet;
 
 /// A Rust `IndexedFile` at `src/{stem}.rs` importing each `imports` stem via
 /// `crate::{stem}` (which `resolve_rust_import` maps back to `src/{stem}.rs`).
-fn rust_file(stem: &str, imports: &[&str]) -> IndexedFile {
-    IndexedFile {
+fn rust_file(stem: &str, imports: &[&str]) -> std::sync::Arc<IndexedFile> {
+    std::sync::Arc::new(IndexedFile {
         relative_path: format!("src/{stem}.rs"),
         language: Some("rust".to_string()),
         size_bytes: 0,
@@ -87,11 +87,11 @@ fn rust_file(stem: &str, imports: &[&str]) -> IndexedFile {
         }),
         content: String::new(),
         mtime_secs: None,
-    }
+    })
 }
 
 /// Build a fresh `CodebaseIndex` over `files` with a full graph (the oracle).
-fn index_from_files(files: Vec<IndexedFile>) -> CodebaseIndex {
+fn index_from_files(files: Vec<std::sync::Arc<IndexedFile>>) -> CodebaseIndex {
     let mut idx = CodebaseIndex::empty();
     idx.total_files = files.len();
     idx.files = files;
@@ -118,7 +118,8 @@ proptest::proptest! {
             UNIVERSE.iter().map(|s| (*s, Some(Vec::new()))).collect();
 
         // Delta index starts as the full base and is maintained incrementally.
-        let base_files: Vec<IndexedFile> = UNIVERSE.iter().map(|s| rust_file(s, &[])).collect();
+        let base_files: Vec<std::sync::Arc<IndexedFile>> =
+            UNIVERSE.iter().map(|s| rust_file(s, &[])).collect();
         let mut delta_idx = index_from_files(base_files);
 
         for (i, action) in &ops {
@@ -157,7 +158,7 @@ proptest::proptest! {
         }
 
         // Oracle: full rebuild over the final state.
-        let final_files: Vec<IndexedFile> = UNIVERSE
+        let final_files: Vec<std::sync::Arc<IndexedFile>> = UNIVERSE
             .iter()
             .filter_map(|s| state[*s].as_ref().map(|imps| rust_file(s, imps)))
             .collect();
@@ -380,7 +381,7 @@ fn cache_is_portable_across_paths() {
 fn delta_with_schema_falls_back_and_preserves_fk_edge() {
     // orders.sql has an FK to customers.sql; app.rs is an unrelated Rust file.
     let files = vec![
-        IndexedFile {
+        std::sync::Arc::new(IndexedFile {
             relative_path: "src/orders.sql".to_string(),
             language: Some("sql".to_string()),
             size_bytes: 0,
@@ -388,8 +389,8 @@ fn delta_with_schema_falls_back_and_preserves_fk_edge() {
             parse_result: None,
             content: String::new(),
             mtime_secs: None,
-        },
-        IndexedFile {
+        }),
+        std::sync::Arc::new(IndexedFile {
             relative_path: "src/customers.sql".to_string(),
             language: Some("sql".to_string()),
             size_bytes: 0,
@@ -397,7 +398,7 @@ fn delta_with_schema_falls_back_and_preserves_fk_edge() {
             parse_result: None,
             content: String::new(),
             mtime_secs: None,
-        },
+        }),
         rust_file("app", &[]),
     ];
 


### PR DESCRIPTION
## What & why

`cxpak serve --mcp` grew to a **57 GB physical footprint (peak 64 GB)** during a normal editing session, climbing ~1 GB/min. The MCP freshness watcher deep-cloned the entire `CodebaseIndex` **twice per real-edit batch**, and each clone deep-copied all `IndexedFile.content` **and** the embedding `Vec<f32>` matrix by value. Field report: 16 GB in `MALLOC_LARGE` (embedding matrices) + 44 GB in `MALLOC_SMALL` (file contents).

This PR lands the full fix (P0 + P1 + P2 from the analysis):

### P0 — one clone per batch + Arc-shared embedding matrix
- `embedding_index: Option<EmbeddingIndex>` → `Option<Arc<EmbeddingIndex>>`: cloning a `CodebaseIndex` bumps a refcount instead of copying `Vec<f32>` — **eliminates the ~16 GB `MALLOC_LARGE` class**.
- `process_watcher_changes` clears `embedding_index` once before the swap and returns the swapped `Arc`; `spawn_mcp_watcher` republishes that same `Arc`. `republish_watcher_index` (the redundant second whole-index clone) is **deleted**.

### P2 — copy-on-write file storage
- `CodebaseIndex.files: Vec<IndexedFile>` → `Vec<Arc<IndexedFile>>`. Cloning the index shares unchanged files as refcount bumps, so the surviving per-batch clone copies **O(delta)** file contents, not O(codebase) — **collapses the 44 GB `MALLOC_SMALL` growth**.
- CoW by construction: `upsert_file` = `remove_file` (`swap_remove` the `Arc`) + `push(Arc::new(..))`; `remove_file` drops an `Arc`. No `IndexedFile` is mutated in place, so an old snapshot a reader still holds is never corrupted. Nine `&[IndexedFile]` helper signatures became `&[Arc<IndexedFile>]` (bodies unchanged, read sites auto-deref).

### P1 — memory-ceiling proof
- `watcher_does_not_accumulate_index_versions_across_batches` drives 25 real-edit batches and asserts `Arc::strong_count` on the shared/readiness Arc returns to a fixed baseline every batch — **demonstrates** (not just asserts) the bounded footprint.

Preserves the ADR-0200 6-signal-fallback and snapshot-then-swap reader-consistency invariants. Design + rejected alternatives in **ADR-0205**; predecessor is ADR-0204.

Closes #47

## How it was verified

Toolchain: rustc **1.91.1** (project MSRV 1.91; system default was 1.87, installed 1.91).

- `cargo build` — green.
- `cargo fmt -- --check` — clean.
- `cargo clippy --lib -- -D warnings` — clean on all changed code.
- **`cargo test` — full suite green:** lib **2587 passed / 0 failed / 3 ignored**, and every integration binary passes. (One pre-existing, unrelated flake — `install_then_real_git_merge_union_resolves_artifact` in `hook_integration.rs` — fails identically at the base commit; it does real git checkouts in a temp repo and touches none of this code.)

New tests (each fails on the pre-fix code by construction):
- `process_watcher_changes_clears_embedding_and_publishes_single_arc` — `Arc::ptr_eq` proves a single publish, not two clones.
- `embedding_index_clone_shares_matrix_not_copies` — `Arc::strong_count`; **cannot compile against the pre-fix non-`Arc` field**.
- `watcher_does_not_accumulate_index_versions_across_batches` — the P1 ceiling proof over 25 batches.
- `process_watcher_changes_ignored_only_publishes_none` — spurious wakes allocate no version.

## Checklist

- [x] `cargo fmt -- --check` is clean
- [x] `cargo clippy` clean on all changed code (`--lib -D warnings`); see note re `--all-targets`
- [x] `cargo test` passes (2587 lib + all integration binaries); new code covered with 4 new tests
- [x] Feature-gated change (`embeddings`): default build + tests green
- [x] Docs updated — **ADR-0205** added under `docs/adrs/` and indexed
- [x] Architecturally significant → ADR added
- [x] Commits follow Conventional Commits, logically scoped (P0 fix; P1/P2 perf follow-up)

## Notes for reviewers

- **Memory outcome:** P0 eliminates the 16 GB embedding class; P2 turns the residual per-batch file-content clone from O(codebase) into O(delta). Together this bounds both `MALLOC_LARGE` and `MALLOC_SMALL`; the P1 test demonstrates the ceiling. Output is byte-identical — the ADR-0204 delta-parity guard still passes.
- **Pre-existing clippy lint (not from this PR):** `cargo clippy --all-targets -- -D warnings` fails on `tests/spa_render.rs:363` (`search_is_some`) — identical code on `main`, surfaced only by clippy 1.91.1. Out of scope; happy to fix separately.
- **CoW correctness:** the delta path never mutates a shared `IndexedFile` in place (all `Arc::make_mut` uses are in `#[cfg(test)]` fixtures with refcount 1). Old snapshots held by in-flight readers stay valid.
- **Remaining follow-up (ADR-0205 "Revisit if"):** an audit of `snapshot_ready_index` handler retention if a concurrent MCP handler model is ever added; and hoisting the `classify_changes` git2/gitignore matcher (CPU-only, Fix #4).