### PR TITLE
chore(release): bump version to 3.1.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "cxpak",
       "source": "./plugin",
       "description": "Structured codebase context for Claude. Auto-context on every prompt plus an on-demand single-page dashboard with Cmd+K command palette: three modes — Overview (health, top risks, signals, repo-DNA), Explore (dependency + risk lenses), and History (architecture timeline). 5 intent-parameterized MCP tools, 12 HTTP endpoints, 14 LSP custom methods — all wired to real intelligence: health scoring, blast radius, change prediction, drift detection, security surface, data flow tracing, cross-language resolution. tree-sitter across 43 languages. Cross-process deterministic output.",
-      "version": "3.1.2"
+      "version": "3.1.3"
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "cxpak"
-version = "3.1.2"
+version = "3.1.3"
 dependencies = [
  "assert_cmd",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cxpak"
-version = "3.1.2"
+version = "3.1.3"
 edition = "2021"
 rust-version = "1.91"
 description = "Spends CPU cycles so you don't spend tokens. The LLM gets a briefing packet instead of a flashlight in a dark room."

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cxpak",
   "description": "Structured codebase context for Claude. Auto-context on every prompt plus an on-demand single-page dashboard with Cmd+K command palette: three modes — Overview (health, top risks, signals, repo-DNA), Explore (dependency + risk lenses), and History (architecture timeline). 5 intent-parameterized MCP tools, 12 HTTP endpoints, 14 LSP custom methods — all wired to real intelligence: health scoring, blast radius, change prediction, drift detection, security surface, data flow tracing, cross-language resolution. tree-sitter across 43 languages. Cross-process deterministic output.",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "author": {
     "name": "Barnett Studios"
   },

--- a/plugin/lib/ensure-cxpak
+++ b/plugin/lib/ensure-cxpak
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REQUIRED_VERSION="3.1.2"
+REQUIRED_VERSION="3.1.3"
 
 version_matches() {
     local installed


### PR DESCRIPTION
Release bump 3.1.2 → 3.1.3 (the 5 version-identity files, matching the 3.1.1/3.1.2 convention). Ships the #48 watcher memory fix (one clone per batch + Arc-shared embeddings + CoW file storage). No code change beyond the version strings; `cargo check` green.

Merge, then tag `v3.1.3` on main to fire the release pipeline (build matrix + crates.io + ghcr + GH release).