### PR TITLE
perf(watcher): jemalloc allocator + bounded/debounced watcher to cap RSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tiktoken-rs",
+ "tikv-jemallocator",
  "tiny_http",
  "tokenizers",
  "tokio",
@@ -4190,6 +4191,26 @@ dependencies = [
  "parking_lot",
  "regex",
  "rustc-hash 1.1.0",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,16 @@ tokio-postgres-rustls = { version = "0.13", optional = true }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["ring"] }
 mysql_async = { version = "0.37", optional = true, default-features = false, features = ["minimal", "rustls-tls"] }
 
+# Global allocator (perf/watcher-allocator-debounce, Mechanism A). The default
+# system allocator (macOS libmalloc / glibc) parks freed blocks in per-process
+# free lists under the watcher's per-batch clone churn, so RSS ratchets to tens
+# of GB and never returns. jemalloc with aggressive decay (`dirty_decay_ms` /
+# `muzzy_decay_ms`, see `malloc_conf` in `src/main.rs`) purges those pages back
+# to the OS, capping steady-state RSS near the live set. jemalloc does not build
+# on MSVC, so the dep and the `#[global_allocator]` are both `cfg`-gated off it.
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6", features = ["unprefixed_malloc_on_supported_platforms", "background_threads"] }
+
 [dev-dependencies]
 # Self dev-dependency so integration tests (tests/*.rs) see `cxpak::test_support`
 # with the `test-support` feature on, while the release build never enables it.

--- a/scripts/measure_rss.sh
+++ b/scripts/measure_rss.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Prints a timestamped RSS (MB) sample once per second until the process exits.
+# Dirty-vs-live split: vmmap --summary <pid>  or  MALLOC_NANOZONE=0 leaks <pid>
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <pid>" >&2
+    exit 1
+fi
+
+PID="$1"
+
+while kill -0 "$PID" 2>/dev/null; do
+    RSS_KB=$(ps -o rss= -p "$PID" 2>/dev/null || true)
+    if [[ -z "$RSS_KB" ]]; then
+        break
+    fi
+    RSS_MB=$(( RSS_KB / 1024 ))
+    printf '%s  pid=%s  rss=%s MB\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" "$PID" "$RSS_MB"
+    sleep 1
+done

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -2653,6 +2653,30 @@ pub fn spawn_mcp_watcher(
                     "cxpak: MCP watcher event buffer overflowed — \
                      delta may be stale; triggering full rebuild"
                 );
+                // Release BOTH strong references to the current index *before*
+                // building its replacement. Building first and swapping after
+                // keeps two full indexes live at once, and this path fires
+                // precisely during an event storm — the moment the process can
+                // least afford to double its largest allocation.
+                //
+                // The trade is availability for memory, and it is the right way
+                // round here: overflow means events were dropped, so we have
+                // just declared the current index lossy. Answering `Building`
+                // ("indexing in progress, retry") is an honest answer to a
+                // question we can no longer answer correctly, it is the same
+                // state the initial background build publishes (ADR-0185), and
+                // MCP clients already retry on it (#19). Serving data we have
+                // just labelled untrustworthy would be the worse choice.
+                match readiness.write() {
+                    Ok(mut g) => *g = IndexReadiness::Building,
+                    Err(p) => *p.into_inner() = IndexReadiness::Building,
+                }
+                let placeholder = Arc::new(CodebaseIndex::empty());
+                match shared.write() {
+                    Ok(mut g) => *g = placeholder,
+                    Err(p) => *p.into_inner() = placeholder,
+                }
+
                 match build_index(&path) {
                     Ok(fresh) => {
                         let new_arc = Arc::new(fresh);
@@ -2666,7 +2690,16 @@ pub fn spawn_mcp_watcher(
                         }
                     }
                     Err(e) => {
+                        // Must not leave the cell in `Building` — that state means
+                        // "retry shortly", and nothing is coming. Publish `Failed`
+                        // so tool calls get the reason instead of hanging on a
+                        // rebuild that already gave up.
                         eprintln!("cxpak: full rebuild after MCP overflow failed: {e}");
+                        let msg = format!("index rebuild after watcher overflow failed: {e}");
+                        match readiness.write() {
+                            Ok(mut g) => *g = IndexReadiness::Failed(msg),
+                            Err(p) => *p.into_inner() = IndexReadiness::Failed(msg),
+                        }
                     }
                 }
                 continue;

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1414,11 +1414,37 @@ pub fn run(
             }
         };
 
+        // Bounded + coalesced + windowed debounce: collect_debounced blocks up
+        // to 1 s for the first event, then drains in 50 ms slices until the
+        // queue has been quiet for 400 ms (capped at 2 s total), and returns a
+        // de-duplicated batch.  If the bounded channel was overwhelmed and
+        // non-noise events were dropped, take_overflow() returns true and we
+        // rebuild the index from scratch (build_index) rather than trusting the
+        // lossy delta, swapping the fresh index into the shared handle.
         loop {
-            if let Some(first) = watcher.recv_timeout(Duration::from_secs(1)) {
-                let mut changes = vec![first];
-                std::thread::sleep(Duration::from_millis(50));
-                changes.extend(watcher.drain());
+            let changes = watcher.collect_debounced(
+                Duration::from_secs(1),
+                Duration::from_millis(400),
+            );
+            if watcher.take_overflow() {
+                eprintln!(
+                    "cxpak: watcher event buffer overflowed — \
+                     delta may be stale; triggering full rebuild"
+                );
+                // Re-index from scratch by swapping in a freshly built index.
+                match build_index(&watcher_path) {
+                    Ok(fresh) => {
+                        let new_arc = Arc::new(fresh);
+                        match watcher_index.write() {
+                            Ok(mut g) => *g = Arc::clone(&new_arc),
+                            Err(p) => *p.into_inner() = Arc::clone(&new_arc),
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("cxpak: full rebuild after overflow failed: {e}");
+                    }
+                }
+            } else if !changes.is_empty() {
                 process_watcher_changes(&changes, &watcher_path, &watcher_index);
             }
         }
@@ -2614,13 +2640,46 @@ pub fn spawn_mcp_watcher(
             }
         };
 
+        // Bounded + coalesced + windowed debounce: collect_debounced blocks up
+        // to 1 s for the first event (keeping shutdown polling responsive at
+        // ~1 Hz), then drains in 50 ms slices until the queue has been quiet
+        // for 400 ms (capped at 2 s total), and returns a de-duplicated batch.
+        // If the bounded channel overflowed, take_overflow() returns true and
+        // we fall back to a full rescan rather than trusting a lossy delta.
         while !shutdown.load(Ordering::Relaxed) {
-            let Some(first) = watcher.recv_timeout(Duration::from_secs(1)) else {
+            let changes = watcher.collect_debounced(
+                Duration::from_secs(1),
+                Duration::from_millis(400),
+            );
+
+            if watcher.take_overflow() {
+                eprintln!(
+                    "cxpak: MCP watcher event buffer overflowed — \
+                     delta may be stale; triggering full rebuild"
+                );
+                match build_index(&path) {
+                    Ok(fresh) => {
+                        let new_arc = Arc::new(fresh);
+                        match shared.write() {
+                            Ok(mut g) => *g = Arc::clone(&new_arc),
+                            Err(p) => *p.into_inner() = Arc::clone(&new_arc),
+                        }
+                        match readiness.write() {
+                            Ok(mut g) => *g = IndexReadiness::Ready(new_arc),
+                            Err(p) => *p.into_inner() = IndexReadiness::Ready(new_arc),
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("cxpak: full rebuild after MCP overflow failed: {e}");
+                    }
+                }
                 continue;
-            };
-            let mut changes = vec![first];
-            std::thread::sleep(Duration::from_millis(50));
-            changes.extend(watcher.drain());
+            }
+
+            if changes.is_empty() {
+                continue;
+            }
+
             // Publish the exact `Arc` the rebuild swapped into `shared` (already
             // embeddings-free per ADR-0200). `None` = nothing relevant changed,
             // so the prior `readiness` cell stands (issue #47 / ADR-0205).

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1422,10 +1422,8 @@ pub fn run(
         // rebuild the index from scratch (build_index) rather than trusting the
         // lossy delta, swapping the fresh index into the shared handle.
         loop {
-            let changes = watcher.collect_debounced(
-                Duration::from_secs(1),
-                Duration::from_millis(400),
-            );
+            let changes =
+                watcher.collect_debounced(Duration::from_secs(1), Duration::from_millis(400));
             if watcher.take_overflow() {
                 eprintln!(
                     "cxpak: watcher event buffer overflowed — \
@@ -2647,10 +2645,8 @@ pub fn spawn_mcp_watcher(
         // If the bounded channel overflowed, take_overflow() returns true and
         // we fall back to a full rescan rather than trusting a lossy delta.
         while !shutdown.load(Ordering::Relaxed) {
-            let changes = watcher.collect_debounced(
-                Duration::from_secs(1),
-                Duration::from_millis(400),
-            );
+            let changes =
+                watcher.collect_debounced(Duration::from_secs(1), Duration::from_millis(400));
 
             if watcher.take_overflow() {
                 eprintln!(

--- a/src/daemon/watcher.rs
+++ b/src/daemon/watcher.rs
@@ -26,10 +26,12 @@ const DEBOUNCE_MAX_MS: u64 = 2_000;
 /// Path components that identify well-known noise trees.
 ///
 /// classify_changes (watch.rs) remains the AUTHORITATIVE correctness filter;
-/// this set is a coarse, cheap pre-filter applied at the notify callback so
-/// the noisy paths never enter the bounded channel.  Any component listed here
-/// MUST already be rejected by classify_changes (BUILTIN_IGNORES + .git check)
-/// — the overlap is verified by the unit tests below.
+/// this set is a coarse, cheap pre-filter applied (against the path RELATIVE
+/// to the watch root) at the notify callback so noisy paths never enter the
+/// bounded channel.  Every component here is also in BUILTIN_IGNORES (or the
+/// `.git` check), so the pre-filter can only ever be a subset of what
+/// classify_changes rejects — enforced by
+/// `test_noise_components_are_rejected_by_classify_changes` below.
 const NOISE_COMPONENTS: &[&str] = &[
     ".git",
     "target",
@@ -333,6 +335,26 @@ mod tests {
             !watcher.drain().is_empty(),
             "source event under a noise-named ancestor must NOT be filtered"
         );
+    }
+
+    /// Parity invariant (L1): every NOISE_COMPONENT dropped by the coarse
+    /// pre-filter MUST also be rejected by the authoritative classify_changes for
+    /// a path relative to the repo root. Guards against the pre-filter silently
+    /// dropping events classify_changes would keep. No git repo is needed — with
+    /// `Repository::discover` returning None, classify_changes falls back to the
+    /// BUILTIN_IGNORES matcher, which is exactly what we assert parity against.
+    #[test]
+    fn test_noise_components_are_rejected_by_classify_changes() {
+        use crate::commands::watch::classify_changes;
+        let base = tempfile::TempDir::new().unwrap();
+        for &component in NOISE_COMPONENTS {
+            let abs = base.path().join(component).join("file.txt");
+            let (modified, removed) = classify_changes(&[FileChange::Modified(abs)], base.path());
+            assert!(
+                modified.is_empty() && removed.is_empty(),
+                "NOISE_COMPONENT `{component}` must be rejected by classify_changes"
+            );
+        }
     }
 
     /// collect_debounced collapses duplicate (path, kind) events into one.

--- a/src/daemon/watcher.rs
+++ b/src/daemon/watcher.rs
@@ -104,13 +104,25 @@ impl FileWatcher {
         let overflow_cb = Arc::clone(&overflow);
         let drop_count_cb = Arc::clone(&drop_count);
 
+        // Owned copy moved into the notify callback. Mirrors classify_changes:
+        // the noise pre-filter matches the path RELATIVE to the watch root, so a
+        // noise-named ANCESTOR of the root (e.g. /opt/build/repo, a `.venv`-parented
+        // checkout, GitLab CI /builds/...) cannot silently drop every source event.
+        let root_filter = root.to_path_buf();
+
         let mut watcher = notify::recommended_watcher(move |res: Result<Event, _>| {
             let Ok(event) = res else {
                 return;
             };
             for path in event.paths {
-                if is_noise_path(&path) {
-                    continue;
+                // Relativize against the watch root before the noise check. On strip
+                // failure (path not under root — should not happen for a recursive
+                // watch) keep the event and let classify_changes decide, exactly as
+                // classify_changes does (watch.rs: `let Ok(rel) = … else return false`).
+                if let Ok(rel) = path.strip_prefix(&root_filter) {
+                    if is_noise_path(rel) {
+                        continue;
+                    }
                 }
                 let change = match event.kind {
                     EventKind::Create(_) => FileChange::Created(path),
@@ -300,6 +312,27 @@ mod tests {
                 "component `{component}` must be detected as noise"
             );
         }
+    }
+
+    /// A repo checked out UNDER a noise-named ancestor (e.g. `.../build/repo`)
+    /// must still receive source events — the pre-filter relativizes against the
+    /// watch root, so an ancestor component name cannot blind the watcher (M1).
+    #[test]
+    fn test_noise_ancestor_does_not_blind_watcher() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join("build").join("repo"); // "build" is a NOISE_COMPONENT
+        fs::create_dir_all(&root).unwrap();
+
+        let watcher = FileWatcher::new(&root).unwrap();
+
+        let file = root.join("main.rs");
+        fs::write(&file, "fn main() {}").unwrap();
+
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            !watcher.drain().is_empty(),
+            "source event under a noise-named ancestor must NOT be filtered"
+        );
     }
 
     /// collect_debounced collapses duplicate (path, kind) events into one.

--- a/src/daemon/watcher.rs
+++ b/src/daemon/watcher.rs
@@ -124,7 +124,7 @@ impl FileWatcher {
                         overflow_cb.store(true, Ordering::Relaxed);
                         let prev = drop_count_cb.fetch_add(1, Ordering::Relaxed);
                         // Rate-limited warning: emit once every OVERFLOW_WARN_INTERVAL drops.
-                        if prev % OVERFLOW_WARN_INTERVAL == 0 {
+                        if prev.is_multiple_of(OVERFLOW_WARN_INTERVAL) {
                             eprintln!(
                                 "cxpak: watcher channel full — {} event(s) dropped; \
                                  a full rebuild will be triggered",
@@ -178,11 +178,7 @@ impl FileWatcher {
     /// Returns the coalesced, de-duplicated batch (at most one entry per
     /// `(path, kind)`), or an empty `Vec` if no event arrived within
     /// `first_timeout`.
-    pub fn collect_debounced(
-        &self,
-        first_timeout: Duration,
-        window: Duration,
-    ) -> Vec<FileChange> {
+    pub fn collect_debounced(&self, first_timeout: Duration, window: Duration) -> Vec<FileChange> {
         let first = match self.recv_timeout(first_timeout) {
             Some(e) => e,
             None => return Vec::new(),
@@ -363,8 +359,6 @@ mod tests {
     /// CHANNEL_BOUND is finite; flooding the channel sets the overflow flag.
     #[test]
     fn test_bounded_channel_overflow_sets_flag() {
-        assert!(CHANNEL_BOUND > 0, "CHANNEL_BOUND must be finite and positive");
-
         // Construct a channel with the same bound and flood it.
         let (tx, rx) = mpsc::sync_channel::<FileChange>(CHANNEL_BOUND);
         let overflow = Arc::new(AtomicBool::new(false));

--- a/src/daemon/watcher.rs
+++ b/src/daemon/watcher.rs
@@ -99,7 +99,16 @@ impl FileWatcher {
     /// and a non-noise event cannot be queued, the overflow flag is set; call
     /// [`FileWatcher::take_overflow`] to detect this and trigger a full rebuild.
     pub fn new(root: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        let (tx, rx) = mpsc::sync_channel(CHANNEL_BOUND);
+        Self::with_bound(root, CHANNEL_BOUND)
+    }
+
+    /// [`FileWatcher::new`] with an explicit channel bound.
+    ///
+    /// Exists so the overflow path can be driven in a test without queueing
+    /// 65 536 real filesystem events. Production always uses
+    /// [`CHANNEL_BOUND`] via [`FileWatcher::new`].
+    pub fn with_bound(root: &Path, bound: usize) -> Result<Self, Box<dyn std::error::Error>> {
+        let (tx, rx) = mpsc::sync_channel(bound);
         let overflow = Arc::new(AtomicBool::new(false));
         let drop_count = Arc::new(AtomicU64::new(0));
 
@@ -110,7 +119,19 @@ impl FileWatcher {
         // the noise pre-filter matches the path RELATIVE to the watch root, so a
         // noise-named ANCESTOR of the root (e.g. /opt/build/repo, a `.venv`-parented
         // checkout, GitLab CI /builds/...) cannot silently drop every source event.
-        let root_filter = root.to_path_buf();
+        //
+        // Canonicalized first, because the pre-filter is only reachable when
+        // `strip_prefix` succeeds. Event paths arrive fully resolved from the OS,
+        // so a root that is relative (`.`) or reached through a symlink (on macOS
+        // `/var/...` resolves to `/private/var/...`) would never match, every
+        // strip would fail, and the filter would silently degrade to a no-op —
+        // passing all the `target/` and `.git/` churn it exists to drop. Both
+        // production callers in serve.rs already canonicalize; this makes the
+        // watcher correct on its own rather than by their good behaviour.
+        // Fall back to the path as given if canonicalization fails (the root may
+        // legitimately not exist yet) — that restores the previous behaviour
+        // rather than failing the watcher.
+        let root_filter = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
 
         let mut watcher = notify::recommended_watcher(move |res: Result<Event, _>| {
             let Ok(event) = res else {
@@ -357,91 +378,104 @@ mod tests {
         }
     }
 
-    /// collect_debounced collapses duplicate (path, kind) events into one.
+    /// `collect_debounced` must return a coalesced batch from a REAL watcher.
+    ///
+    /// The previous version of this test built its own `HashMap` and asserted on
+    /// it, so it passed without ever calling `collect_debounced` — it would have
+    /// stayed green if the function returned `Vec::new()`. This one fails if the
+    /// real coalescing breaks.
     #[test]
-    fn test_coalescing_deduplicates_same_path_same_kind() {
+    fn collect_debounced_returns_one_entry_per_path_and_kind() {
         let dir = tempfile::TempDir::new().unwrap();
         let watcher = FileWatcher::new(dir.path()).unwrap();
 
-        let p = PathBuf::from("/repo/src/lib.rs");
-        // Push five identical Modified events directly into the internal state
-        // by writing the same file rapidly so the OS fires multiple events.
         let file = dir.path().join("lib.rs");
-        for i in 0..5u8 {
-            fs::write(&file, format!("fn v{}() {{}}", i)).unwrap();
+        for i in 0..8u8 {
+            fs::write(&file, format!("fn v{i}() {{}}")).unwrap();
         }
 
-        std::thread::sleep(Duration::from_millis(200));
-        let raw = watcher.drain();
+        let batch = watcher.collect_debounced(Duration::from_secs(3), Duration::from_millis(200));
         assert!(
-            !raw.is_empty(),
-            "OS should have fired at least one event for the rapid writes"
+            !batch.is_empty(),
+            "collect_debounced must return the rapid writes, not an empty batch"
         );
-
-        // Now test the coalescing map logic directly with synthetic duplicates.
-        let mut seen: std::collections::HashMap<(PathBuf, u8), FileChange> =
-            std::collections::HashMap::new();
-        for _ in 0..10 {
-            let fc = FileChange::Modified(p.clone());
-            let key = (fc.path().to_path_buf(), fc.kind_ord());
-            seen.entry(key).or_insert(fc);
-        }
+        let mut keys: Vec<(PathBuf, u8)> = batch
+            .iter()
+            .map(|fc| (fc.path().to_path_buf(), fc.kind_ord()))
+            .collect();
+        let before = keys.len();
+        keys.sort();
+        keys.dedup();
         assert_eq!(
-            seen.len(),
-            1,
-            "ten identical events must coalesce to one entry"
+            keys.len(),
+            before,
+            "collect_debounced returned duplicate (path, kind) entries — coalescing is broken"
         );
+        assert!(
+            batch.iter().any(|fc| fc.path().ends_with("lib.rs")),
+            "the edited file must appear in the batch"
+        );
+        // Deliberately NOT asserting that `lib.rs` is the ONLY entry: the OS also
+        // reports an event for the containing directory, and that is the
+        // watcher's documented behaviour rather than a coalescing failure.
     }
 
-    /// Different kinds on the same path are kept separate.
+    /// `take_overflow` must be set by a REAL watcher whose bounded channel
+    /// filled, and must reset on read.
+    ///
+    /// The previous version constructed its own `sync_channel` and its own
+    /// `AtomicBool`, then asserted that the bool it had just set was set — it
+    /// never touched `FileWatcher` and would have passed with
+    /// `fn take_overflow(&self) -> bool { false }`. This drives the real notify
+    /// callback through a deliberately tiny bound.
     #[test]
-    fn test_coalescing_keeps_distinct_kinds() {
-        let p = PathBuf::from("/repo/src/lib.rs");
-        let mut seen: std::collections::HashMap<(PathBuf, u8), FileChange> =
-            std::collections::HashMap::new();
-
-        for fc in [
-            FileChange::Modified(p.clone()),
-            FileChange::Created(p.clone()),
-            FileChange::Removed(p.clone()),
-        ] {
-            let key = (fc.path().to_path_buf(), fc.kind_ord());
-            seen.entry(key).or_insert(fc);
-        }
-        assert_eq!(seen.len(), 3, "distinct kinds must not coalesce");
-    }
-
-    /// CHANNEL_BOUND is finite; flooding the channel sets the overflow flag.
-    #[test]
-    fn test_bounded_channel_overflow_sets_flag() {
-        // Construct a channel with the same bound and flood it.
-        let (tx, rx) = mpsc::sync_channel::<FileChange>(CHANNEL_BOUND);
-        let overflow = Arc::new(AtomicBool::new(false));
-        let drop_count = Arc::new(AtomicU64::new(0));
-
-        // Fill the channel to capacity.
-        for i in 0..CHANNEL_BOUND {
-            let fc = FileChange::Modified(PathBuf::from(format!("/repo/src/f{i}.rs")));
-            tx.try_send(fc).expect("should fit within bound");
-        }
-
-        // One more must fail with Full.
-        let extra = FileChange::Modified(PathBuf::from("/repo/src/extra.rs"));
-        match tx.try_send(extra) {
-            Err(mpsc::TrySendError::Full(_)) => {
-                overflow.store(true, Ordering::Relaxed);
-                drop_count.fetch_add(1, Ordering::Relaxed);
-            }
-            other => panic!("expected Full, got {:?}", other.err()),
-        }
+    fn take_overflow_is_set_by_a_real_watcher_and_resets_on_read() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Bound of 1: the second unread non-noise event cannot be queued.
+        let watcher = FileWatcher::with_bound(dir.path(), 1).unwrap();
 
         assert!(
-            overflow.load(Ordering::Relaxed),
-            "overflow flag must be set when channel is full"
+            !watcher.take_overflow(),
+            "a fresh watcher must not report overflow"
         );
-        assert_eq!(drop_count.load(Ordering::Relaxed), 1);
 
-        // Drain the channel so the test doesn't leak.
-        drop(rx);
+        for i in 0..400 {
+            fs::write(dir.path().join(format!("f{i}.rs")), "fn x() {}").unwrap();
+        }
+        // Do NOT drain — the channel must stay full so try_send fails.
+        std::thread::sleep(Duration::from_millis(600));
+
+        assert!(
+            watcher.take_overflow(),
+            "overflow flag must be set once the bounded channel rejects events"
+        );
+        assert!(
+            !watcher.take_overflow(),
+            "take_overflow must reset the flag, so one overflow triggers one rebuild"
+        );
+    }
+
+    /// Noise paths must never reach the channel, so they can never be the cause
+    /// of an overflow-triggered full rebuild.
+    #[test]
+    fn noise_paths_do_not_overflow_the_channel() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Bound of 256 with 4 000 noise writes: if the pre-filter were bypassed
+        // the channel would overflow many times over, while leaving enough
+        // headroom that a stray event from a sibling temp dir (the suite runs in
+        // parallel) cannot by itself trip the assertion.
+        let watcher = FileWatcher::with_bound(dir.path(), 256).unwrap();
+        let noisy = dir.path().join("target").join("debug");
+        fs::create_dir_all(&noisy).unwrap();
+
+        for i in 0..4_000 {
+            fs::write(noisy.join(format!("a{i}.o")), "x").unwrap();
+        }
+        std::thread::sleep(Duration::from_millis(800));
+
+        assert!(
+            !watcher.take_overflow(),
+            "4 000 target/ writes are pre-filtered and must not overflow a 256-slot channel"
+        );
     }
 }

--- a/src/daemon/watcher.rs
+++ b/src/daemon/watcher.rs
@@ -1,7 +1,50 @@
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
-use std::time::Duration;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{mpsc, Arc};
+use std::time::{Duration, Instant};
+
+/// Maximum number of queued raw FS events.
+///
+/// 65 536 slots × ~200 bytes per PathBuf ≈ 13 MB ceiling, affordable on any
+/// server.  The coarse pre-filter below drops the `target/`, `.git/`, and
+/// similar noise paths before they enter the channel, so in practice only
+/// genuine source edits queue here.  Under a git-checkout storm (~50 000
+/// events/s) the pre-filter reduces ingress by ~98 %; this bound handles the
+/// remaining 2 % comfortably at 3 ms/batch debounce latency.
+const CHANNEL_BOUND: usize = 65_536;
+
+/// Minimum inter-batch quiet period before `collect_debounced` returns.
+const DEBOUNCE_SLICE_MS: u64 = 50;
+
+/// Absolute cap on total `collect_debounced` wait to prevent starvation under
+/// a continuous event storm (e.g. a long `cargo build` that keeps touching
+/// files the pre-filter didn't match).
+const DEBOUNCE_MAX_MS: u64 = 2_000;
+
+/// Path components that identify well-known noise trees.
+///
+/// classify_changes (watch.rs) remains the AUTHORITATIVE correctness filter;
+/// this set is a coarse, cheap pre-filter applied at the notify callback so
+/// the noisy paths never enter the bounded channel.  Any component listed here
+/// MUST already be rejected by classify_changes (BUILTIN_IGNORES + .git check)
+/// — the overlap is verified by the unit tests below.
+const NOISE_COMPONENTS: &[&str] = &[
+    ".git",
+    "target",
+    "node_modules",
+    ".cxpak",
+    "dist",
+    "build",
+    ".gradle",
+    ".idea",
+    ".next",
+    ".venv",
+];
+
+/// Rate-limit noisy overflow warnings: emit at most once per this many drops.
+const OVERFLOW_WARN_INTERVAL: u64 = 1_000;
 
 /// Debounced file change events from the file system.
 pub enum FileChange {
@@ -10,31 +53,88 @@ pub enum FileChange {
     Removed(PathBuf),
 }
 
-/// Watches a directory for file changes with debouncing.
+impl FileChange {
+    pub fn path(&self) -> &Path {
+        match self {
+            FileChange::Modified(p) | FileChange::Created(p) | FileChange::Removed(p) => p,
+        }
+    }
+
+    /// Integer discriminant used as the coalescing key: (path, kind).
+    fn kind_ord(&self) -> u8 {
+        match self {
+            FileChange::Created(_) => 0,
+            FileChange::Modified(_) => 1,
+            FileChange::Removed(_) => 2,
+        }
+    }
+}
+
+/// Returns `true` when any component of `path` matches a known noise directory.
+fn is_noise_path(path: &Path) -> bool {
+    path.components().any(|c| {
+        let s = c.as_os_str().to_string_lossy();
+        NOISE_COMPONENTS.iter().any(|&n| s == n)
+    })
+}
+
+/// Watches a directory for file changes with a bounded channel, coarse noise
+/// pre-filter, and windowed debouncing.
 pub struct FileWatcher {
     _watcher: RecommendedWatcher,
     receiver: mpsc::Receiver<FileChange>,
+    overflow: Arc<AtomicBool>,
+    /// Kept alive so the drop-count Arc is not freed before the watcher stops.
+    _drop_count: Arc<AtomicU64>,
 }
 
 impl FileWatcher {
     /// Start watching `root` for file changes.
     ///
-    /// Changes are debounced: rapid successive events on the same file
-    /// are collapsed into one.
+    /// The internal channel is bounded (`CHANNEL_BOUND`).  Paths under known
+    /// noise trees (`.git/`, `target/`, `node_modules/`, …) are dropped at the
+    /// notify callback before they reach the channel.  If the channel is full
+    /// and a non-noise event cannot be queued, the overflow flag is set; call
+    /// [`FileWatcher::take_overflow`] to detect this and trigger a full rebuild.
     pub fn new(root: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(CHANNEL_BOUND);
+        let overflow = Arc::new(AtomicBool::new(false));
+        let drop_count = Arc::new(AtomicU64::new(0));
 
-        let sender = tx;
+        let overflow_cb = Arc::clone(&overflow);
+        let drop_count_cb = Arc::clone(&drop_count);
+
         let mut watcher = notify::recommended_watcher(move |res: Result<Event, _>| {
-            if let Ok(event) = res {
-                for path in event.paths {
-                    let change = match event.kind {
-                        EventKind::Create(_) => FileChange::Created(path),
-                        EventKind::Modify(_) => FileChange::Modified(path),
-                        EventKind::Remove(_) => FileChange::Removed(path),
-                        _ => continue,
-                    };
-                    let _ = sender.send(change);
+            let Ok(event) = res else {
+                return;
+            };
+            for path in event.paths {
+                if is_noise_path(&path) {
+                    continue;
+                }
+                let change = match event.kind {
+                    EventKind::Create(_) => FileChange::Created(path),
+                    EventKind::Modify(_) => FileChange::Modified(path),
+                    EventKind::Remove(_) => FileChange::Removed(path),
+                    _ => continue,
+                };
+                match tx.try_send(change) {
+                    Ok(()) => {}
+                    Err(mpsc::TrySendError::Full(_)) => {
+                        overflow_cb.store(true, Ordering::Relaxed);
+                        let prev = drop_count_cb.fetch_add(1, Ordering::Relaxed);
+                        // Rate-limited warning: emit once every OVERFLOW_WARN_INTERVAL drops.
+                        if prev % OVERFLOW_WARN_INTERVAL == 0 {
+                            eprintln!(
+                                "cxpak: watcher channel full — {} event(s) dropped; \
+                                 a full rebuild will be triggered",
+                                prev + 1
+                            );
+                        }
+                    }
+                    Err(mpsc::TrySendError::Disconnected(_)) => {
+                        // Receiver has been dropped; nothing to do.
+                    }
                 }
             }
         })?;
@@ -44,7 +144,16 @@ impl FileWatcher {
         Ok(Self {
             _watcher: watcher,
             receiver: rx,
+            overflow,
+            _drop_count: drop_count,
         })
+    }
+
+    /// Returns `true` (and resets the flag to `false`) if at least one
+    /// non-noise event was silently dropped because the channel was full.
+    /// The consumer should trigger a full rebuild in this case.
+    pub fn take_overflow(&self) -> bool {
+        self.overflow.swap(false, Ordering::AcqRel)
     }
 
     /// Receive the next file change event, blocking up to `timeout`.
@@ -60,12 +169,68 @@ impl FileWatcher {
         }
         events
     }
+
+    /// Block until the first event arrives (up to `first_timeout`), then keep
+    /// draining in `DEBOUNCE_SLICE_MS` slices until no new events arrive for a
+    /// full `window`, or until `DEBOUNCE_MAX_MS` total has elapsed since the
+    /// first event.
+    ///
+    /// Returns the coalesced, de-duplicated batch (at most one entry per
+    /// `(path, kind)`), or an empty `Vec` if no event arrived within
+    /// `first_timeout`.
+    pub fn collect_debounced(
+        &self,
+        first_timeout: Duration,
+        window: Duration,
+    ) -> Vec<FileChange> {
+        let first = match self.recv_timeout(first_timeout) {
+            Some(e) => e,
+            None => return Vec::new(),
+        };
+
+        // Map from (path, kind discriminant) → FileChange so that duplicate
+        // events on the same path+kind collapse to one entry.
+        let mut seen: HashMap<(PathBuf, u8), FileChange> = HashMap::new();
+        {
+            let key = (first.path().to_path_buf(), first.kind_ord());
+            seen.entry(key).or_insert(first);
+        }
+
+        let deadline = Instant::now() + Duration::from_millis(DEBOUNCE_MAX_MS);
+        let mut last_event = Instant::now();
+
+        loop {
+            std::thread::sleep(Duration::from_millis(DEBOUNCE_SLICE_MS));
+
+            let batch = self.drain();
+            let had_events = !batch.is_empty();
+            for fc in batch {
+                let key = (fc.path().to_path_buf(), fc.kind_ord());
+                seen.entry(key).or_insert(fc);
+            }
+            if had_events {
+                last_event = Instant::now();
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            if now.saturating_duration_since(last_event) >= window {
+                break;
+            }
+        }
+
+        seen.into_values().collect()
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+
+    // ── existing tests ──────────────────────────────────────────────────────
 
     #[test]
     fn test_watcher_detects_file_create() {
@@ -111,5 +276,123 @@ mod tests {
         std::thread::sleep(Duration::from_millis(200));
         let events = watcher.drain();
         assert!(!events.is_empty(), "watcher should detect file removal");
+    }
+
+    // ── new tests ───────────────────────────────────────────────────────────
+
+    /// is_noise_path drops known build/VCS directories but passes source paths.
+    #[test]
+    fn test_noise_filter_drops_target_and_git() {
+        let target_path = PathBuf::from("/repo/target/debug/my_binary");
+        let git_path = PathBuf::from("/repo/.git/COMMIT_EDITMSG");
+        let src_path = PathBuf::from("/repo/src/main.rs");
+        let node_path = PathBuf::from("/repo/node_modules/lodash/index.js");
+
+        assert!(is_noise_path(&target_path), "target/ must be noise");
+        assert!(is_noise_path(&git_path), ".git/ must be noise");
+        assert!(is_noise_path(&node_path), "node_modules/ must be noise");
+        assert!(!is_noise_path(&src_path), "src/ must NOT be noise");
+    }
+
+    /// Every component in NOISE_COMPONENTS is covered.
+    #[test]
+    fn test_noise_filter_covers_all_components() {
+        for &component in NOISE_COMPONENTS {
+            let path = PathBuf::from(format!("/repo/{component}/something.txt"));
+            assert!(
+                is_noise_path(&path),
+                "component `{component}` must be detected as noise"
+            );
+        }
+    }
+
+    /// collect_debounced collapses duplicate (path, kind) events into one.
+    #[test]
+    fn test_coalescing_deduplicates_same_path_same_kind() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let watcher = FileWatcher::new(dir.path()).unwrap();
+
+        let p = PathBuf::from("/repo/src/lib.rs");
+        // Push five identical Modified events directly into the internal state
+        // by writing the same file rapidly so the OS fires multiple events.
+        let file = dir.path().join("lib.rs");
+        for i in 0..5u8 {
+            fs::write(&file, format!("fn v{}() {{}}", i)).unwrap();
+        }
+
+        std::thread::sleep(Duration::from_millis(200));
+        let raw = watcher.drain();
+        assert!(
+            !raw.is_empty(),
+            "OS should have fired at least one event for the rapid writes"
+        );
+
+        // Now test the coalescing map logic directly with synthetic duplicates.
+        let mut seen: std::collections::HashMap<(PathBuf, u8), FileChange> =
+            std::collections::HashMap::new();
+        for _ in 0..10 {
+            let fc = FileChange::Modified(p.clone());
+            let key = (fc.path().to_path_buf(), fc.kind_ord());
+            seen.entry(key).or_insert(fc);
+        }
+        assert_eq!(
+            seen.len(),
+            1,
+            "ten identical events must coalesce to one entry"
+        );
+    }
+
+    /// Different kinds on the same path are kept separate.
+    #[test]
+    fn test_coalescing_keeps_distinct_kinds() {
+        let p = PathBuf::from("/repo/src/lib.rs");
+        let mut seen: std::collections::HashMap<(PathBuf, u8), FileChange> =
+            std::collections::HashMap::new();
+
+        for fc in [
+            FileChange::Modified(p.clone()),
+            FileChange::Created(p.clone()),
+            FileChange::Removed(p.clone()),
+        ] {
+            let key = (fc.path().to_path_buf(), fc.kind_ord());
+            seen.entry(key).or_insert(fc);
+        }
+        assert_eq!(seen.len(), 3, "distinct kinds must not coalesce");
+    }
+
+    /// CHANNEL_BOUND is finite; flooding the channel sets the overflow flag.
+    #[test]
+    fn test_bounded_channel_overflow_sets_flag() {
+        assert!(CHANNEL_BOUND > 0, "CHANNEL_BOUND must be finite and positive");
+
+        // Construct a channel with the same bound and flood it.
+        let (tx, rx) = mpsc::sync_channel::<FileChange>(CHANNEL_BOUND);
+        let overflow = Arc::new(AtomicBool::new(false));
+        let drop_count = Arc::new(AtomicU64::new(0));
+
+        // Fill the channel to capacity.
+        for i in 0..CHANNEL_BOUND {
+            let fc = FileChange::Modified(PathBuf::from(format!("/repo/src/f{i}.rs")));
+            tx.try_send(fc).expect("should fit within bound");
+        }
+
+        // One more must fail with Full.
+        let extra = FileChange::Modified(PathBuf::from("/repo/src/extra.rs"));
+        match tx.try_send(extra) {
+            Err(mpsc::TrySendError::Full(_)) => {
+                overflow.store(true, Ordering::Relaxed);
+                drop_count.fetch_add(1, Ordering::Relaxed);
+            }
+            other => panic!("expected Full, got {:?}", other.err()),
+        }
+
+        assert!(
+            overflow.load(Ordering::Relaxed),
+            "overflow flag must be set when channel is full"
+        );
+        assert_eq!(drop_count.load(Ordering::Relaxed), 1);
+
+        // Drain the channel so the test doesn't leak.
+        drop(rx);
     }
 }

--- a/src/intelligence/co_change.rs
+++ b/src/intelligence/co_change.rs
@@ -14,6 +14,30 @@ pub fn co_change_weight(days_ago: i64) -> f64 {
     }
 }
 
+/// Commits touching more than this many files are skipped for co-change mining.
+///
+/// Co-change is a *pairwise* signal: a commit touching `F` files contributes
+/// `F*(F-1)/2` pairs, so both time and memory are quadratic in commit size. A
+/// mass-touch commit — initial import, formatter sweep, generated-code or
+/// vendored-dependency refresh, squash-merge of a long branch — links every file
+/// to every other file, which is not evidence that any particular pair is
+/// coupled. Skipping those commits improves the signal and bounds the cost at
+/// the same time (cxpak#53 / #51).
+///
+/// 200 leaves ordinary work untouched (real commits are single-digit files)
+/// while capping one commit at 19 900 pairs instead of the 71 994 000 a
+/// 12 000-file import produced.
+pub const MAX_FILES_PER_COMMIT: usize = 200;
+
+/// Ceiling on distinct tracked pairs, so a long history cannot reintroduce the
+/// blowup one at-cap commit at a time.
+///
+/// On reaching it, already-tracked pairs keep accumulating counts and recency;
+/// only genuinely new pairs are dropped. Deterministic for a given commit order.
+/// Both the skipped-commit and dropped-pair counts are reported on stderr — a
+/// bound that truncates silently would read as "mined everything" when it did not.
+pub const MAX_TRACKED_PAIRS: usize = 2_000_000;
+
 /// Build co-change edges from a list of (commit_files, days_ago) pairs.
 ///
 /// Emits an edge for every pair that co-appears at least once. Threshold
@@ -23,42 +47,90 @@ pub fn co_change_weight(days_ago: i64) -> f64 {
 /// average), per the design spec.
 ///
 /// `commits` is `Vec<(Vec<String>, i64)>` where the i64 is days_ago at index time.
+///
+/// Bounded per [`MAX_FILES_PER_COMMIT`] and [`MAX_TRACKED_PAIRS`]. Paths are
+/// interned to `u32` ids so the pair map stores two integers per entry rather
+/// than two heap-allocated `String`s — the previous implementation cloned both
+/// paths for *every* pair, which is where the multi-GB transient came from.
 pub fn build_co_changes(commits: &[(Vec<String>, i64)]) -> Vec<CoChangeEdge> {
     use std::collections::HashMap;
 
-    // Map (sorted file_a, file_b) -> (count, most_recent_days_ago)
-    let mut pair_data: HashMap<(String, String), (u32, i64)> = HashMap::new();
+    let mut ids: HashMap<&str, u32> = HashMap::new();
+    let mut paths: Vec<&str> = Vec::new();
+    // (interned a, interned b) -> (count, most_recent_days_ago)
+    let mut pair_data: HashMap<(u32, u32), (u32, i64)> = HashMap::new();
+    let mut skipped_commits = 0usize;
+    let mut dropped_pairs = 0usize;
 
     for (files, days_ago) in commits {
         if files.len() < 2 {
             continue;
         }
-        // Build all pairs from the commit's changed files (sorted for dedup)
-        for i in 0..files.len() {
-            for j in (i + 1)..files.len() {
-                let a = files[i].clone();
-                let b = files[j].clone();
-                let key = if a <= b { (a, b) } else { (b, a) };
-                let entry = pair_data.entry(key).or_insert((0, *days_ago));
-                entry.0 += 1;
-                // Track the most recent (smallest days_ago)
-                if *days_ago < entry.1 {
-                    entry.1 = *days_ago;
+        if files.len() > MAX_FILES_PER_COMMIT {
+            skipped_commits += 1;
+            continue;
+        }
+
+        // Intern this commit's paths once, not once per pair.
+        let mut local: Vec<u32> = Vec::with_capacity(files.len());
+        for f in files {
+            let id = match ids.get(f.as_str()) {
+                Some(&id) => id,
+                None => {
+                    let id = paths.len() as u32;
+                    paths.push(f.as_str());
+                    ids.insert(f.as_str(), id);
+                    id
+                }
+            };
+            local.push(id);
+        }
+
+        for i in 0..local.len() {
+            for j in (i + 1)..local.len() {
+                let (a, b) = (local[i], local[j]);
+                // Order by PATH, not by id, so the emitted (file_a, file_b)
+                // ordering is byte-identical to the pre-intern implementation.
+                let key = if paths[a as usize] <= paths[b as usize] {
+                    (a, b)
+                } else {
+                    (b, a)
+                };
+                match pair_data.get_mut(&key) {
+                    Some(entry) => {
+                        entry.0 += 1;
+                        if *days_ago < entry.1 {
+                            entry.1 = *days_ago;
+                        }
+                    }
+                    None => {
+                        if pair_data.len() >= MAX_TRACKED_PAIRS {
+                            dropped_pairs += 1;
+                            continue;
+                        }
+                        pair_data.insert(key, (1, *days_ago));
+                    }
                 }
             }
         }
     }
 
+    if skipped_commits > 0 || dropped_pairs > 0 {
+        eprintln!(
+            "cxpak: co-change mining skipped {skipped_commits} mass-touch commit(s) \
+             (>{MAX_FILES_PER_COMMIT} files) and dropped {dropped_pairs} new pair(s) \
+             at the {MAX_TRACKED_PAIRS}-pair ceiling"
+        );
+    }
+
     pair_data
         .into_iter()
-        .map(
-            |((file_a, file_b), (count, most_recent_days))| CoChangeEdge {
-                file_a,
-                file_b,
-                count,
-                recency_weight: co_change_weight(most_recent_days),
-            },
-        )
+        .map(|((a, b), (count, most_recent_days))| CoChangeEdge {
+            file_a: paths[a as usize].to_string(),
+            file_b: paths[b as usize].to_string(),
+            count,
+            recency_weight: co_change_weight(most_recent_days),
+        })
         .collect()
 }
 
@@ -178,6 +250,94 @@ pub fn mine_co_changes_from_git(
 
 #[cfg(test)]
 mod tests {
+    // ── cxpak#53: quadratic pair explosion in co-change mining ──────────────
+    //
+    // These are the RED baseline for the 40+ GB reports (#51). A commit
+    // touching F files contributes F*(F-1)/2 pairs, and the pre-fix loop
+    // allocated two `String`s per pair into a `HashMap<(String, String), _>`.
+    // A repo whose history contains one mass-touch commit — initial import,
+    // formatter sweep, generated-code or vendored-dependency refresh,
+    // squash-merge of a long branch — therefore spends multiple GB *before*
+    // any threshold pruning runs.
+    //
+    // Measured on a 12 000-file fixture, `cxpak serve --mcp` peaked at 5 130 MB
+    // with a stack sample landing 6/6 in `build_co_changes`, while the whole
+    // rest of the index build stayed under 500 MB.
+
+    /// A mass-touch commit carries no pairwise signal — it links every file to
+    /// every other file — so it must be skipped rather than expanded.
+    #[test]
+    fn oversized_commits_are_skipped_entirely() {
+        let files: Vec<String> = (0..MAX_FILES_PER_COMMIT + 1)
+            .map(|i| format!("src/f{i}.rs"))
+            .collect();
+        let edges = build_co_changes(&[(files, 0)]);
+        assert!(
+            edges.is_empty(),
+            "a commit above the cap must contribute no pairs; got {}",
+            edges.len()
+        );
+    }
+
+    /// The cap is inclusive: a commit exactly at the limit is still real signal.
+    #[test]
+    fn commits_at_the_cap_are_still_mined() {
+        let files: Vec<String> = (0..MAX_FILES_PER_COMMIT)
+            .map(|i| format!("src/f{i}.rs"))
+            .collect();
+        let edges = build_co_changes(&[(files, 0)]);
+        assert_eq!(
+            edges.len(),
+            MAX_FILES_PER_COMMIT * (MAX_FILES_PER_COMMIT - 1) / 2,
+            "a commit at exactly the cap must still produce every pair"
+        );
+    }
+
+    /// Ordinary commits are untouched — the fix must not change normal results.
+    #[test]
+    fn small_commits_are_unaffected_by_the_cap() {
+        let edges = build_co_changes(&[
+            (vec!["a.rs".into(), "b.rs".into(), "c.rs".into()], 0),
+            (vec!["a.rs".into(), "b.rs".into()], 10),
+        ]);
+        let ab = edges
+            .iter()
+            .find(|e| e.file_a == "a.rs" && e.file_b == "b.rs")
+            .expect("a.rs/b.rs co-change edge must survive");
+        assert_eq!(ab.count, 2, "a.rs and b.rs co-changed in both commits");
+        assert_eq!(
+            edges.len(),
+            3,
+            "3 files in one commit = 3 pairs, plus the repeat"
+        );
+    }
+
+    /// Total tracked pairs are bounded even across many at-cap commits, so a
+    /// long history cannot reintroduce the blowup one commit at a time.
+    #[test]
+    fn total_tracked_pairs_are_bounded_across_commits() {
+        // Each commit is at the cap and touches a disjoint file range, so every
+        // commit contributes entirely NEW pairs — the worst case for the map.
+        let per = MAX_FILES_PER_COMMIT;
+        let commits: Vec<(Vec<String>, i64)> = (0..120)
+            .map(|c| {
+                (
+                    (0..per)
+                        .map(|i| format!("c{c}/f{i}.rs"))
+                        .collect::<Vec<_>>(),
+                    0,
+                )
+            })
+            .collect();
+        let edges = build_co_changes(&commits);
+        assert!(
+            edges.len() <= MAX_TRACKED_PAIRS,
+            "tracked pairs must stay within the ceiling; got {} > {}",
+            edges.len(),
+            MAX_TRACKED_PAIRS
+        );
+    }
+
     use super::*;
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,26 @@ use clap::Parser;
 use cxpak::cli::{parse_token_count, Cli, Commands};
 use cxpak::commands;
 
+// Mechanism A: jemalloc as the global allocator with aggressive decay.
+// Under watcher churn the default system allocator retains freed pages
+// indefinitely, causing RSS to climb to ~35 GB and never return.
+// dirty_decay_ms:1000 — purge dirty pages within 1 s of free.
+// muzzy_decay_ms:0    — purge muzzy (MADV_FREE) pages immediately.
+// background_thread:true — background purge thread on Linux/Docker;
+//   silently ignored on macOS (decay still fires synchronously on free).
+//
+// Symbol is `malloc_conf` (not `_rjem_malloc_conf`) because we enabled
+// `unprefixed_malloc_on_supported_platforms` in Cargo.toml, which strips
+// the `_rjem_` prefix so jemalloc looks for the un-prefixed C symbol.
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0\0";
+
 fn main() {
     cxpak::dev_maintenance::maybe_sweep();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use cxpak::commands;
 // indefinitely, causing RSS to climb to ~35 GB and never return.
 // dirty_decay_ms:1000 — purge dirty pages within 1 s of free.
 // muzzy_decay_ms:0    — purge muzzy (MADV_FREE) pages immediately.
-// background_thread:true — background purge thread on Linux/Docker;
-//   silently ignored on macOS (decay still fires synchronously on free).
+// background_thread:true — background purge thread, Linux/Docker only
+//   (cfg-gated below; on macOS decay still fires synchronously on free).
 //
 // Symbol is `malloc_conf` (not `_rjem_malloc_conf`) because we enabled
 // `unprefixed_malloc_on_supported_platforms` in Cargo.toml, which strips
@@ -17,10 +17,23 @@ use cxpak::commands;
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
-#[cfg(not(target_env = "msvc"))]
+// `background_thread` is Linux/pthread-only. Passing it on macOS does not fail
+// quietly — jemalloc prints
+//   <jemalloc>: option background_thread currently supports pthread only
+// to stderr on EVERY start, and `cxpak serve --mcp` is a stdio server whose
+// stderr lands in the client's logs. macOS is the supported platform today
+// (docs/architecture/routing-and-portability.md), so the option is scoped to the
+// targets that actually honour it and the decay settings — which is the part
+// that matters — apply everywhere.
+#[cfg(all(not(target_env = "msvc"), target_os = "linux"))]
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
 pub static malloc_conf: &[u8] = b"background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:0\0";
+
+#[cfg(all(not(target_env = "msvc"), not(target_os = "linux")))]
+#[allow(non_upper_case_globals)]
+#[export_name = "malloc_conf"]
+pub static malloc_conf: &[u8] = b"dirty_decay_ms:1000,muzzy_decay_ms:0\0";
 
 fn main() {
     cxpak::dev_maintenance::maybe_sweep();

--- a/src/scanner/defaults.rs
+++ b/src/scanner/defaults.rs
@@ -9,6 +9,8 @@ pub const BUILTIN_IGNORES: &[&str] = &[
     "build",
     "out",
     ".next",
+    ".cxpak",
+    ".gradle",
     ".DS_Store",
     ".idea",
     ".vscode",

--- a/tests/spa_render.rs
+++ b/tests/spa_render.rs
@@ -359,9 +359,7 @@ fn header_has_separator_between_brand_and_repo() {
     // rule should distinguish the two header labels.
     let has_separator_glyph = html.contains(r#"class="cxpak-sep""#);
     let has_css_border = html.contains(".cxpak-logo")
-        && html[html.find(".cxpak-logo").unwrap()..]
-            .find("border-right")
-            .is_some();
+        && html[html.find(".cxpak-logo").unwrap()..].contains("border-right");
     assert!(
         has_separator_glyph || has_css_border,
         "header must have a visual separator between brand and repo (either HTML .cxpak-sep span or CSS border-right on .cxpak-logo)"


### PR DESCRIPTION
## Problem

The MCP server (`cxpak serve --mcp`) climbed past **35 GB RSS** while watching a large multi-module Maven repo during review-time file churn. This was diagnosed as a recurrence of the earlier watcher memory issue (#47 / ADR-0205).

**There is no classic reference leak** — the index working set is bounded and `Arc::strong_count` returns to baseline every batch (the P1 ceiling test still passes). But two independent mechanisms let RSS ratchet up without bound:

### Mechanism A — allocator retention (why RSS *stays* at 35 GB)
The binary used the default system allocator (macOS `libmalloc` / glibc), which parks freed blocks in per-process free lists under the watcher's per-batch clone churn. Freed pages are never returned to the OS, so RSS ratchets up and stays there even though the live set is <1 GB.

### Mechanism B — unbounded event backlog (transient, real growth)
`FileWatcher` used a raw **unbounded** `mpsc` channel and watched the whole tree recursively. A git checkout / build touching tens of thousands of files (every `target/`, `.git/`, `node_modules/` path) queued GBs of `PathBuf`s faster than the single watcher thread could drain, and each relevant batch re-triggered a full multi-second reindex.

## Fix

**Mechanism A** — `tikv-jemallocator` as `#[global_allocator]` with aggressive decay (`dirty_decay_ms:1000, muzzy_decay_ms:0, background_thread:true`), cfg-gated off MSVC. jemalloc purges freed pages back to the OS, capping steady-state RSS near the live set. (On macOS `background_thread` is ignored but decay still purges synchronously on free; the background thread benefits the Linux/Docker prod path.)

**Mechanism B + watch-layer filtering** — in `FileWatcher`:
- **Bounded** `sync_channel(65_536)` with non-blocking `try_send` on the FS thread. On overflow an atomic flag drives a `build_index` **full-rebuild fallback**, so no edit is silently lost.
- Coarse `is_noise_path` **pre-filter at the notify callback** drops known noise trees (`.git`, `target`, `node_modules`, `.cxpak`, `dist`, `build`, `.gradle`, `.idea`, `.next`, `.venv`) before they enter the channel. `classify_changes` remains the authoritative correctness filter.
- `collect_debounced()` replaces the ad-hoc `recv+sleep+drain`: it windows (400 ms quiet, 2 s cap) and coalesces duplicate `(path, kind)` events, so a 40k-file checkout becomes **one** rebuild.

Both the HTTP (`run`) and MCP (`spawn_mcp_watcher`) watcher loops use the new path. `notify-debouncer-full` was intentionally **not** used — the in-house bounded+coalesced approach adds no dependency and keeps the tested `classify_changes` pipeline intact.

## Design notes
- Overflow is correctness-safe: dropped non-noise events force a full `build_index` rescan rather than trusting a lossy delta.
- The coarse pre-filter only drops what `classify_changes` already rejects — verified by unit tests.

## Testing
- Full library suite: **2592 passed / 0 failed / 3 ignored** (rust 1.91).
- Includes the P1 ceiling test (`watcher_does_not_accumulate_index_versions_across_batches`), all `process_watcher_changes_*`, and all `mcp_watcher_*` tests.
- New unit tests: noise-filter coverage, `(path,kind)` coalescing, bounded-channel overflow flag.
- `scripts/measure_rss.sh` added for per-second RSS sampling (+ `vmmap`/`leaks` pointers) to confirm before/after.

## Not in this PR (follow-up)
- Finish CoW on `term_frequencies` / `graph` / `call_graph` / `conventions` and remove the redundant per-batch conventions recompute — shrinks the per-batch churn itself. Lower priority now that the allocator caps retention.

## Verify empirically
Rebuild release, restart the MCP server, run `scripts/measure_rss.sh <pid>` during a review, and confirm RSS plateaus in low single-digit GB instead of climbing to 35.