### PR TITLE
docs(#42): SECURITY.md advertised a sandbox for a loader that cannot run plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 ![Downloads](https://img.shields.io/crates/d/cxpak)
 ![License](https://img.shields.io/badge/License-MIT-green.svg)
 
+**Context plane · Active** — under development; the surface still moves.
+See the [component map](https://github.com/Barnett-Studios) for how this fits the rest.
+
 **Spends CPU cycles so you don't spend tokens.**
 
 cxpak indexes your codebase using tree-sitter across 43 languages, builds a typed dependency graph, and produces token-budgeted context bundles that give LLMs a briefing packet instead of a flashlight in a dark room. It understands your code's architecture, conventions, risk profile, and data layer -- then packs exactly what the LLM needs, nothing more.
@@ -315,13 +318,19 @@ Minimal local config:
 { "embeddings": { "provider": "local" } }
 ```
 
-## WASM Plugin SDK
+## WASM plugin loader — a skeleton, not a working SDK
 
-Extend cxpak with custom analyzers and detectors:
+**You cannot extend cxpak with a WASM plugin today.** `PluginLoader::load()` verifies the module's
+checksum, compiles it, instantiates it, and then returns `guest function binding not yet
+implemented`. The WIT bridge that would make a guest function callable does not exist, so no plugin
+code has ever run.
 
-- Plugin manifest with SHA-256 checksum verification before WASM compilation
-- wasmtime sandbox: epoch interruption (CPU), 64 MB memory cap, capability enforcement
-- File pattern scoping and content access control
+The `plugins` feature is therefore excluded from `default` — a stock `cargo install cxpak` does not
+build it, and the plugin management commands are behind the same gate. What is built out is the
+loading path: a manifest with SHA-256 verification before compilation, a 10 MiB module cap, a 64 MiB
+memory limiter, and a 10 s epoch deadline. Treat none of it as a security boundary until the bridge
+lands and the gaps in [`SECURITY.md`](SECURITY.md#the-wasm-plugin-loader-does-not-run-plugins) are
+closed — [#42](https://github.com/Barnett-Studios/cxpak/issues/42).
 
 ## Workspace support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -47,17 +47,46 @@ surfaces worth a security researcher's attention:
   to a running Postgres/MySQL over rustls (no OpenSSL), issues a **read-only**
   session, and **never logs or persists the DSN**. Off unless explicitly built
   with the feature.
-- **WASM plugin SDK (`plugins`, off by default)** — plugins run in a wasmtime
-  sandbox with a SHA-256 checksum verified before compilation, plus memory and
-  CPU (epoch-interruption) caps. Only load plugins you trust; the checksum pins
-  what you approved, it does not vouch for the author.
+- **WASM plugin loader (`plugins`, off by default and non-functional)** — see
+  below. It is listed here to be explicit that it is *not* a security surface
+  yet, because it cannot execute plugin code at all.
+
+## The WASM plugin loader does not run plugins
+
+`PluginLoader::load()` reads the module, enforces a 10 MiB size cap, verifies a
+SHA-256 checksum in constant time, compiles it, instantiates it — and then
+returns `Err("WASM plugin loaded (N bytes) but guest function binding not yet
+implemented")`. There is no WIT bridge, so **no guest function has ever been
+callable**. A test asserts exactly that error.
+
+The feature is excluded from `default`, so a stock `cargo install cxpak` cannot
+reach this code path at all.
+
+**Do not read the wasmtime configuration as a security control.** Some of it is
+real — memory growth is capped at 64 MiB by a `ResourceLimiter`, and
+epoch-interruption is enabled with a 10 s deadline. But it has never guarded
+anything, and it is incomplete in ways that matter before it could:
+
+- `table_growing` returns `Ok(true)` unconditionally — table growth is unbounded.
+- Fuel metering is explicitly disabled (`consume_fuel(false)`); the only CPU
+  bound is the epoch deadline.
+- The 1 MiB cap on a plugin's returned value is applied *after* `serde_json`
+  deserialization, so the allocation it is meant to bound has already happened.
+
+Earlier revisions of this document described the sandbox as an active control.
+That was wrong: it described the intended design of a code path that cannot run.
+Those three gaps must be closed, and the guest bridge built, before any of this
+is a control worth reasoning about — tracked in
+[#42](https://github.com/Barnett-Studios/cxpak/issues/42).
 
 ## What is not a vulnerability
 
-- Running an untrusted third-party WASM plugin and having it access repository
-  content — that's the plugin's declared capability; vet plugins before loading.
 - Pointing cxpak at a repository you don't control and disliking what it emits —
   cxpak reports what it finds; it doesn't run the analyzed code.
+- A finding against the `plugins` loader that depends on executing guest code.
+  It cannot execute guest code. Findings about the *loading* path — the size cap,
+  the checksum comparison, module compilation, instantiation — are in scope, and
+  a report there is welcome, because those steps do run.
 
 ## Dependencies
 


### PR DESCRIPTION
Closes #42. Also carries A2 of Barnett-Studios/dotclaude#124 (plane + status line).

## The finding, re-verified on `main` at 3.1.4

`src/plugin/loader.rs:85-127` — `load()` ends unconditionally in:

```
Err("WASM plugin loaded ({} bytes) but guest function binding not yet implemented")
```

There is no WIT bridge. No guest function has ever been callable, and a test pins that error.

`SECURITY.md:50-53` nevertheless listed the wasmtime sandbox under **security-relevant surfaces**. That is the worst shape a security document can take — not an overstatement of a weak control, but a description of a control with nothing running behind it. A researcher reads it and calibrates against a boundary that has never been exercised.

## What changed

- **`SECURITY.md`** — the plugin bullet now says the loader is non-functional, with a dedicated section explaining why the wasmtime configuration should not be read as a control. It names the three gaps verified in the source: `table_growing` returns `Ok(true)` unconditionally (`loader.rs:33-39`), `consume_fuel(false)` (`:53`), and the 1 MiB return cap applied post-deserialization.
- **`README.md`** — "WASM Plugin SDK / Extend cxpak with custom analyzers and detectors" was the same claim aimed at users. Rewritten to state plainly that you cannot extend cxpak with a plugin today.
- The **"not a vulnerability"** bullet about an untrusted plugin accessing repo content is removed. It presumed execution. In its place: findings against the *loading* path — size cap, checksum comparison, compilation, instantiation — are explicitly in scope, because those steps do run.

## What this does not do

It does not build the sandbox, per the brief. Acceptance criterion 2 of #42 ("SECURITY.md describes only controls that execute") is met by correcting the doc; criterion 1 was already met by `Cargo.toml`, which excludes `plugins` from `default` with a comment saying why.

No behaviour change, no code touched.