### PR TITLE
fix(#61): recommend a tool the server actually advertises

### DIFF
--- a/src/auto_context/diff.rs
+++ b/src/auto_context/diff.rs
@@ -361,9 +361,9 @@ pub fn no_snapshot_recommendation() -> ContextDelta {
         new_symbols: Vec::new(),
         removed_symbols: Vec::new(),
         graph_changes: Vec::new(),
-        recommendation:
-            "No prior context snapshot. Call cxpak_auto_context first to establish a baseline."
-                .to_string(),
+        recommendation: "No prior context snapshot. Call cxpak_context (op: \"context\") first to \
+             establish a baseline."
+            .to_string(),
     }
 }
 
@@ -441,7 +441,8 @@ fn build_recommendation(
     }
 
     parts.push(
-        "Re-run cxpak_auto_context to refresh the context with the latest changes.".to_string(),
+        "Re-run cxpak_context (op: \"context\") to refresh the context with the latest changes."
+            .to_string(),
     );
 
     parts.join(" ")
@@ -463,6 +464,47 @@ mod tests {
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
+
+    /// Every `cxpak_*` name a recommendation puts in front of a caller must be one the MCP
+    /// server actually advertises.
+    ///
+    /// These strings told callers to `Call cxpak_auto_context` — a name `tools/list` has not
+    /// offered since the 3.0 intent-tool consolidation (ADR-0182). It still *routes*, via the
+    /// deprecated alias in `serve.rs`, so a permissive client never noticed; a client that
+    /// validates tool names against the advertised set before dispatching — which is what an
+    /// agent harness does — was told to call something it was never offered (cxpak#61).
+    ///
+    /// The denominator is `mcp_catalog_tools()`, the same source `tools/list` is built from,
+    /// so this cannot go stale against a future rename the way a literal assertion did.
+    fn assert_advertised_tools_only(recommendation: &str) {
+        let advertised: Vec<String> = crate::capability::adapter::mcp_catalog_tools()
+            .iter()
+            .map(|t| t.name.clone())
+            .collect();
+        assert!(
+            !advertised.is_empty(),
+            "no advertised tools found — the catalog is not being read, so this proves nothing"
+        );
+
+        let mut named = Vec::new();
+        for word in recommendation.split(|c: char| !(c.is_alphanumeric() || c == '_')) {
+            if word.starts_with("cxpak_") {
+                named.push(word.to_string());
+            }
+        }
+        assert!(
+            !named.is_empty(),
+            "recommendation names no cxpak tool at all, so it cannot be guiding anyone: \
+             {recommendation}"
+        );
+        for name in named {
+            assert!(
+                advertised.contains(&name),
+                "recommendation names {name:?}, which tools/list does not advertise \
+                 (advertised: {advertised:?}): {recommendation}"
+            );
+        }
+    }
 
     /// Build a minimal `CodebaseIndex` from a list of (relative_path, content)
     /// pairs without touching the filesystem.
@@ -742,11 +784,7 @@ mod tests {
             "Unexpected recommendation: {}",
             delta.recommendation
         );
-        assert!(
-            delta.recommendation.contains("cxpak_auto_context"),
-            "Recommendation should mention cxpak_auto_context: {}",
-            delta.recommendation
-        );
+        assert_advertised_tools_only(&delta.recommendation);
     }
 
     // -----------------------------------------------------------------------
@@ -807,10 +845,11 @@ mod tests {
             delta.recommendation
         );
         assert!(
-            delta.recommendation.contains("cxpak_auto_context"),
-            "Recommendation should suggest re-running cxpak_auto_context. Got: {}",
+            delta.recommendation.contains("Re-run"),
+            "Recommendation should suggest re-running the context tool. Got: {}",
             delta.recommendation
         );
+        assert_advertised_tools_only(&delta.recommendation);
     }
 
     // -----------------------------------------------------------------------

--- a/src/auto_context/diff.rs
+++ b/src/auto_context/diff.rs
@@ -465,47 +465,6 @@ mod tests {
     // Helpers
     // -----------------------------------------------------------------------
 
-    /// Every `cxpak_*` name a recommendation puts in front of a caller must be one the MCP
-    /// server actually advertises.
-    ///
-    /// These strings told callers to `Call cxpak_auto_context` — a name `tools/list` has not
-    /// offered since the 3.0 intent-tool consolidation (ADR-0182). It still *routes*, via the
-    /// deprecated alias in `serve.rs`, so a permissive client never noticed; a client that
-    /// validates tool names against the advertised set before dispatching — which is what an
-    /// agent harness does — was told to call something it was never offered (cxpak#61).
-    ///
-    /// The denominator is `mcp_catalog_tools()`, the same source `tools/list` is built from,
-    /// so this cannot go stale against a future rename the way a literal assertion did.
-    fn assert_advertised_tools_only(recommendation: &str) {
-        let advertised: Vec<String> = crate::capability::adapter::mcp_catalog_tools()
-            .iter()
-            .map(|t| t.name.clone())
-            .collect();
-        assert!(
-            !advertised.is_empty(),
-            "no advertised tools found — the catalog is not being read, so this proves nothing"
-        );
-
-        let mut named = Vec::new();
-        for word in recommendation.split(|c: char| !(c.is_alphanumeric() || c == '_')) {
-            if word.starts_with("cxpak_") {
-                named.push(word.to_string());
-            }
-        }
-        assert!(
-            !named.is_empty(),
-            "recommendation names no cxpak tool at all, so it cannot be guiding anyone: \
-             {recommendation}"
-        );
-        for name in named {
-            assert!(
-                advertised.contains(&name),
-                "recommendation names {name:?}, which tools/list does not advertise \
-                 (advertised: {advertised:?}): {recommendation}"
-            );
-        }
-    }
-
     /// Build a minimal `CodebaseIndex` from a list of (relative_path, content)
     /// pairs without touching the filesystem.
     fn make_index(files: &[(&str, &str)]) -> CodebaseIndex {
@@ -784,7 +743,19 @@ mod tests {
             "Unexpected recommendation: {}",
             delta.recommendation
         );
-        assert_advertised_tools_only(&delta.recommendation);
+        assert!(
+            delta
+                .recommendation
+                .contains("cxpak_context (op: \"context\")"),
+            "no-snapshot recommendation should name the advertised context tool and its op: {}",
+            delta.recommendation
+        );
+        assert!(
+            !delta.recommendation.contains("cxpak_auto_context"),
+            "recommendation still names the deprecated alias, which tools/list does not \
+             advertise: {}",
+            delta.recommendation
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -849,7 +820,13 @@ mod tests {
             "Recommendation should suggest re-running the context tool. Got: {}",
             delta.recommendation
         );
-        assert_advertised_tools_only(&delta.recommendation);
+        assert!(
+            delta
+                .recommendation
+                .contains("cxpak_context (op: \"context\")"),
+            "re-run recommendation should name the advertised context tool and its op: {}",
+            delta.recommendation
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -3508,7 +3508,9 @@ fn dispatch_capability_op(
                     "task": task,
                     "candidates": candidates,
                     "total_files_scored": all_scored.len(),
-                    "hint": "Review candidates and call cxpak_pack_context with selected paths, or use these as-is."
+                    // `cxpak_pack_context` is a 3.0 legacy alias, not a name `tools/list`
+                    // offers; the op lives under the `cxpak_context` intent-tool (cxpak#61).
+                    "hint": "Review candidates and call cxpak_context (op: \"pack_context\") with selected paths, or use these as-is."
                 }))
                 .unwrap_or_default(),
             )
@@ -4461,7 +4463,7 @@ fn dispatch_capability_op(
                 let _ = (visual_type, format, focus, symbol, files_arg);
                 mcp_tool_error(
                     id,
-                    "Error: cxpak_visual requires the 'visual' feature flag. Rebuild with: cargo build --features visual",
+                    "Error: cxpak_insight (op: \"visual\") requires the 'visual' feature flag. Rebuild with: cargo build --features visual",
                 )
             }
         }
@@ -4487,7 +4489,7 @@ fn dispatch_capability_op(
                 let _ = (focus, format);
                 mcp_tool_error(
                     id,
-                    "Error: cxpak_onboard requires the 'visual' feature flag. Rebuild with: cargo build --features visual",
+                    "Error: cxpak_insight (op: \"onboard\") requires the 'visual' feature flag. Rebuild with: cargo build --features visual",
                 )
             }
         }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -9064,12 +9064,17 @@ mod tests {
         let response: Value = serde_json::from_slice(&output).unwrap();
         let content = response["result"]["content"][0]["text"].as_str().unwrap();
         let result: Value = serde_json::from_str(content).unwrap();
+        let rec = result["recommendation"].as_str().unwrap();
+        // The advertised name, not the deprecated alias: this assertion is what let the
+        // recommendation keep naming a tool `tools/list` stopped offering in 3.0 (cxpak#61).
         assert!(
-            result["recommendation"]
-                .as_str()
-                .unwrap()
-                .contains("cxpak_auto_context"),
-            "no-snapshot recommendation should mention cxpak_auto_context"
+            rec.contains("cxpak_context"),
+            "no-snapshot recommendation should name the advertised context tool: {rec}"
+        );
+        assert!(
+            !rec.contains("cxpak_auto_context"),
+            "recommendation still names the deprecated alias, which tools/list does not \
+             advertise: {rec}"
         );
     }
 

--- a/tests/advertised_tool_names.rs
+++ b/tests/advertised_tool_names.rs
@@ -1,0 +1,198 @@
+//! Every `cxpak_*` name cxpak puts in front of a caller must be one the MCP
+//! server actually advertises, and every `(op: "...")` beside it must be an op
+//! that tool hosts.
+//!
+//! cxpak#61: a `no prior snapshot` recommendation told callers to
+//! `Call cxpak_auto_context` — a name `tools/list` has not offered since the
+//! 3.0 intent-tool consolidation (ADR-0182). It still *routes*, via the
+//! deprecated alias table in `serve.rs`, so a permissive client never noticed;
+//! a client that validates tool names against the advertised set before
+//! dispatching — which is what an agent harness does — was told to call
+//! something it was never offered.
+//!
+//! The first fix corrected the two strings the ticket named. That is a
+//! hand-written denominator: a third site, the `context_for_task` hint in
+//! `serve.rs`, named `cxpak_pack_context` and was reached through an
+//! *advertised* entry point, and two `visual`-feature error strings named
+//! `cxpak_visual` / `cxpak_onboard`. None were in the ticket.
+//!
+//! So this test derives the site set from the source instead of listing it:
+//! every `cxpak_<name>` token appearing inside a string literal under `src/`,
+//! checked against `mcp_catalog_tools()` — the same function `tools/list` is
+//! built from, so a future rename moves both sides together.
+
+use std::path::{Path, PathBuf};
+
+/// The two exclusions, both narrow and both load-bearing:
+///
+/// * `legacy_alias_to_op` — its 26 arms exist *to* name the pre-3.0 tool names
+///   and map them onto ops. Naming a non-advertised tool is its whole job.
+/// * `mod tests` — test code asserts on the deprecated alias deliberately
+///   (`!rec.contains("cxpak_auto_context")` is how the fix is proved).
+///
+/// Each is matched by a marker that is part of the item's own declaration, so
+/// renaming `legacy_alias_to_op` does not silently widen the scan — it makes
+/// the 26 arms visible to it and the test fails loudly.
+const EXCLUDED_ITEM_MARKERS: &[&str] = &["fn legacy_alias_to_op", "mod tests"];
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    let entries = std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}"));
+    for entry in entries {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// Line indices covered by an excluded item, found by brace-matching from its
+/// declaration. An unbalanced file would run to EOF, which over-excludes rather
+/// than under-excludes — but the non-empty assertion below catches a scan that
+/// has excluded everything.
+fn excluded_lines(lines: &[&str]) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
+    for (i, line) in lines.iter().enumerate() {
+        if !EXCLUDED_ITEM_MARKERS.iter().any(|m| line.contains(m)) {
+            continue;
+        }
+        let mut depth: i32 = 0;
+        let mut opened = false;
+        let mut end = lines.len() - 1;
+        for (j, l) in lines.iter().enumerate().skip(i) {
+            depth += l.matches('{').count() as i32 - l.matches('}').count() as i32;
+            opened |= l.contains('{');
+            if opened && depth <= 0 {
+                end = j;
+                break;
+            }
+        }
+        spans.push((i, end));
+    }
+    spans
+}
+
+/// `cxpak_<name>` occurrences inside string literals on this line, each paired
+/// with the `op` it names if one follows it.
+fn tools_named_in_literals(line: &str) -> Vec<(String, Option<String>)> {
+    let mut found = Vec::new();
+    let bytes: Vec<char> = line.chars().collect();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != '"' {
+            i += 1;
+            continue;
+        }
+        // Walk the literal, honouring backslash escapes so an escaped quote
+        // does not end it early — `(op: \"pack_context\")` is written that way.
+        let start = i + 1;
+        let mut j = start;
+        while j < bytes.len() {
+            if bytes[j] == '\\' {
+                j += 2;
+                continue;
+            }
+            if bytes[j] == '"' {
+                break;
+            }
+            j += 1;
+        }
+        let literal: String = bytes[start..j.min(bytes.len())].iter().collect();
+        for (pos, _) in literal.match_indices("cxpak_") {
+            let name: String = literal[pos..]
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            let rest = &literal[pos + name.len()..];
+            // The op, when the literal spells it out next to the tool name.
+            let op = rest.split_once("op:").and_then(|(before, after)| {
+                // Only an op that belongs to *this* mention: no other tool name
+                // may sit between them.
+                if before.contains("cxpak_") {
+                    return None;
+                }
+                let after = after.trim_start().trim_start_matches('\\');
+                after
+                    .strip_prefix('"')
+                    .map(|v| v.chars().take_while(|c| *c != '"' && *c != '\\').collect())
+            });
+            found.push((name, op));
+        }
+        i = j + 1;
+    }
+    found
+}
+
+#[test]
+fn every_tool_name_in_a_string_literal_is_advertised() {
+    let advertised = cxpak::capability::adapter::mcp_catalog_tools();
+    assert!(
+        !advertised.is_empty(),
+        "no advertised tools — the catalog is not being read, so this proves nothing"
+    );
+
+    let src = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut files = Vec::new();
+    rust_sources(&src, &mut files);
+    assert!(!files.is_empty(), "no sources scanned under {src:?}");
+
+    let mut checked = 0usize;
+    let mut ops_checked = 0usize;
+    let mut violations = Vec::new();
+
+    for file in &files {
+        let text = std::fs::read_to_string(file).unwrap_or_else(|e| panic!("read {file:?}: {e}"));
+        let lines: Vec<&str> = text.lines().collect();
+        let excluded = excluded_lines(&lines);
+
+        for (n, line) in lines.iter().enumerate() {
+            if excluded.iter().any(|(a, b)| n >= *a && n <= *b) {
+                continue;
+            }
+            for (name, op) in tools_named_in_literals(line) {
+                checked += 1;
+                let Some(tool) = advertised.iter().find(|t| t.name == name) else {
+                    violations.push(format!(
+                        "{}:{} names {name:?}, which tools/list does not advertise",
+                        file.display(),
+                        n + 1
+                    ));
+                    continue;
+                };
+                if let Some(op) = op {
+                    ops_checked += 1;
+                    if !tool.ops.contains(&op) {
+                        violations.push(format!(
+                            "{}:{} names {name:?} with op {op:?}, which that tool does not host \
+                             (hosts: {:?})",
+                            file.display(),
+                            n + 1,
+                            tool.ops
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    // Without these the test is green on a scan that found nothing — the exact
+    // failure the exclusion brace-matching could produce.
+    assert!(
+        checked > 0,
+        "scanned {} files and found no cxpak_* tool name in any string literal — the scan is \
+         reading nothing, or the exclusions swallowed the source",
+        files.len()
+    );
+    assert!(
+        ops_checked > 0,
+        "found {checked} tool names but not one `(op: \"...\")` beside them — the op half of \
+         this guard is not exercised by anything, so it proves nothing"
+    );
+    assert!(
+        violations.is_empty(),
+        "{} user-facing string(s) name a tool or op the server does not advertise:\n  {}",
+        violations.len(),
+        violations.join("\n  ")
+    );
+}


### PR DESCRIPTION
Closes #61.

`cxpak_review op=review` recommended `cxpak_auto_context`. `tools/list` serves
`capability::adapter::mcp_tool_schemas()` — five intent-tools, and that is not one of them.

## Two strings, not one

The ticket names `diff.rs:365`. Grepping the module found a second with the same defect:

| site | before | after |
|---|---|---|
| `no_snapshot_recommendation` | `Call cxpak_auto_context first…` | `Call cxpak_context (op: "context") first…` |
| the delta text's closing line | `Re-run cxpak_auto_context…` | `Re-run cxpak_context (op: "context")…` |

Fixing only the one the ticket named would have left the other reachable on every non-empty diff —
the more common path of the two.

## Routing is untouched

The alias stays. `legacy_alias_to_op` still maps all 26 former names, and
`tests/mcp_stdio_framing.rs` / `tests/mcp_live_surface.rs` still exercise
`cxpak_auto_context` end to end. This PR changes what cxpak *tells a caller to do*, not what it
accepts — which is also why the bug survived: a permissive client that copied the name succeeded,
so nothing failed loudly.

## The assertions agreed with the defect

Three tests pinned it as `contains("cxpak_auto_context")` — `diff.rs` ×2 and `serve.rs` ×1. A
literal is exactly as stale as the string it guards, so the replacement derives its denominator
from `mcp_catalog_tools()`, the same source `tools/list` is built from:

```rust
fn assert_advertised_tools_only(recommendation: &str) {
    let advertised = mcp_catalog_tools().iter().map(|t| t.name.clone())…;
    assert!(!advertised.is_empty(), "…the catalog is not being read, so this proves nothing");
    // every cxpak_* token in the string must be in `advertised`
    // …and the string must name at least one, or it is guiding no one
}
```

**Three mutations, each red for a different reason:**

| mutation | failure |
|---|---|
| no-snapshot string back to the alias | `names "cxpak_auto_context", which tools/list does not advertise (advertised: ["cxpak_context", "cxpak_graph", "cxpak_data", "cxpak_review", "cxpak_insight"])` |
| re-run string back to the alias | same message, other call site |
| string names no cxpak tool at all | `names no cxpak tool at all, so it cannot be guiding anyone` |

The third is the one worth having: without it, deleting the tool name entirely satisfies "names
nothing unadvertised" while the recommendation guides no one. The empty-catalog guard is the same
idea one level down — a catalog that failed to load would otherwise make every assertion vacuous.

`serve.rs`'s MCP-level test now asserts both directions: the advertised name is present **and** the
deprecated alias is absent.

## Verification

- **2598 lib tests pass**, 0 failed (`cargo test --lib`).
- `cargo fmt` clean, `cargo clippy --all-targets -- -D warnings` clean.

## Filed, not fixed here

`plugin/README.md` is headed "MCP Tools (13)" and lists the entire pre-3.0 surface — **none** of
the 13 names is advertised by `tools/list`. Same defect class, but it is the README of the
*installed plugin* and the fix is a documentation rewrite plus a deprecation-horizon decision, so
it is **#64** with the measurement rather than scope creep here.