### PR TITLE
fix(#60): a bind-mounted repo is not a stranger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --uid 10001 --create-home --user-group cxpak
 
+# libgit2 refuses to open a repository whose owner differs from the running uid, and a
+# bind-mounted host repo never belongs to 10001 — so `cxpak diff` failed with
+# `Owner (-36)` on every documented container invocation (cxpak#60). `overview` does not
+# open the repo through libgit2, which is why the README's headline command worked and
+# this stayed invisible.
+#
+# libgit2 honours the system `safe.directory` and reads /etc/gitconfig itself, so this
+# needs no git binary. Measured on the published 3.1.4 image: with this file the
+# documented `docker run -v "$PWD:/repo" … diff` exits 0 and prints the diff; an
+# otherwise identical rebuild without it exits 1 with `Owner (-36)`.
+#
+# The trust decision is the right one for this image: cxpak is a read-only analyser whose
+# entire job is to open a repo it was explicitly handed on a mount.
+RUN printf '[safe]\n\tdirectory = *\n' > /etc/gitconfig
+
 COPY --from=builder /build/target/release/cxpak /usr/local/bin/cxpak
 
 # Model weights (~30 MB) download on first use to $HOME/.cxpak/models. Mount a

--- a/Dockerfile.dist
+++ b/Dockerfile.dist
@@ -27,6 +27,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --uid 10001 --create-home --user-group cxpak
 
+# libgit2 refuses to open a repository whose owner differs from the running uid, and a
+# bind-mounted host repo never belongs to 10001 — so `cxpak diff` failed with
+# `Owner (-36)` on every documented container invocation (cxpak#60). `overview` does not
+# open the repo through libgit2, which is why the README's headline command worked and
+# this stayed invisible.
+#
+# libgit2 honours the system `safe.directory` and reads /etc/gitconfig itself, so this
+# needs no git binary. Measured on the published 3.1.4 image: with this file the
+# documented `docker run -v "$PWD:/repo" … diff` exits 0 and prints the diff; an
+# otherwise identical rebuild without it exits 1 with `Owner (-36)`.
+#
+# The trust decision is the right one for this image: cxpak is a read-only analyser whose
+# entire job is to open a repo it was explicitly handed on a mount.
+RUN printf '[safe]\n\tdirectory = *\n' > /etc/gitconfig
+
 # Populated by CI (or a manual tar extraction) before build; buildx sets TARGETARCH.
 ARG TARGETARCH
 COPY --chmod=755 dist/linux/${TARGETARCH}/cxpak /usr/local/bin/cxpak

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -85,6 +85,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && useradd --uid 10001 --create-home --user-group cxpak
 
+# libgit2 refuses to open a repository whose owner differs from the running uid, and a
+# bind-mounted host repo never belongs to 10001 — so `cxpak diff` failed with
+# `Owner (-36)` on every documented container invocation (cxpak#60). `overview` does not
+# open the repo through libgit2, which is why the README's headline command worked and
+# this stayed invisible.
+#
+# libgit2 honours the system `safe.directory` and reads /etc/gitconfig itself, so this
+# needs no git binary. Measured on the published 3.1.4 image: with this file the
+# documented `docker run -v "$PWD:/repo" … diff` exits 0 and prints the diff; an
+# otherwise identical rebuild without it exits 1 with `Owner (-36)`.
+#
+# The trust decision is the right one for this image: cxpak is a read-only analyser whose
+# entire job is to open a repo it was explicitly handed on a mount.
+RUN printf '[safe]\n\tdirectory = *\n' > /etc/gitconfig
+
 COPY --from=downloader /usr/local/bin/cxpak /usr/local/bin/cxpak
 
 # Model weights (~30 MB) download on first use to $HOME/.cxpak/models. Mount a

--- a/tests/container_git_ownership.rs
+++ b/tests/container_git_ownership.rs
@@ -18,25 +18,80 @@
 //!
 //! This is a static audit, not a container run: cxpak's CI has no Docker job, and adding one
 //! to build this crate from source would cost far more than the regression it guards. What it
-//! catches is the line being dropped from one image while the others keep it — which is the
-//! realistic regression, since the three Dockerfiles are edited separately and only one of
-//! them is exercised by any release path at a time.
+//! catches is the line being dropped from one image while the others keep it, or a new image
+//! shipping without it — which is the realistic regression, since the Dockerfiles are edited
+//! separately and only one of them is exercised by any release path at a time.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-/// The three images this repo publishes. `Dockerfile` builds from source, `Dockerfile.dist`
-/// wraps a CI-built binary, `Dockerfile.standalone` downloads a release tarball — all three
-/// run as uid 10001 and all three mount a host repo at `/repo`.
-const IMAGES: &[&str] = &["Dockerfile", "Dockerfile.dist", "Dockerfile.standalone"];
+/// Directories a Dockerfile under them would not be a published image: build output and git
+/// internals. Everything else in the tree is in scope.
+const NOT_SOURCE: &[&str] = &["target", ".git"];
 
 fn repo_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+/// Every Dockerfile in the repo, discovered rather than listed.
+///
+/// This was `const IMAGES: &[&str] = &["Dockerfile", "Dockerfile.dist",
+/// "Dockerfile.standalone"]`. That is a hand-written denominator for a property about *every*
+/// image, and it fails exactly where it matters: a fourth root Dockerfile with no `[safe]`
+/// exemption was green across the whole suite, because a name not in the list is a name
+/// nothing checks. Review caught it (cxpak#60).
+///
+/// The three current entries all run as uid 10001 and all mount a host repo at `/repo`:
+/// `Dockerfile` builds from source, `Dockerfile.dist` wraps a CI-built binary,
+/// `Dockerfile.standalone` downloads a release tarball. A future Dockerfile that genuinely
+/// does not open a mounted repo will fail here and needs an exemption written down with its
+/// reason — the scan must not stop seeing it quietly.
+fn dockerfiles() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(e) => panic!("read_dir {}: {e}", dir.display()),
+        };
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or_default();
+            if path.is_dir() {
+                if !NOT_SOURCE.contains(&name) {
+                    walk(&path, out);
+                }
+            } else if name.starts_with("Dockerfile") {
+                out.push(path);
+            }
+        }
+    }
+    let mut found = Vec::new();
+    walk(&repo_root(), &mut found);
+    found.sort();
+    // Without this the two tests below are green on an empty walk — the failure mode a
+    // discovered denominator has and a hard-coded one does not.
+    assert!(
+        !found.is_empty(),
+        "no Dockerfile found under {} — the scan is reading nothing, so it proves nothing",
+        repo_root().display()
+    );
+    found
+}
+
+/// Path relative to the repo root. The basename alone is ambiguous the moment the scan
+/// reaches a subdirectory — two images both reported as `Dockerfile` name neither.
+fn name_of(path: &Path) -> String {
+    path.strip_prefix(repo_root())
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
 #[test]
 fn every_image_exempts_the_mounted_repo_from_ownership_validation() {
-    for name in IMAGES {
-        let path = repo_root().join(name);
+    for path in dockerfiles() {
+        let name = name_of(&path);
         let text = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
         assert!(
@@ -57,8 +112,8 @@ fn the_exemption_is_written_before_the_image_drops_to_uid_10001() {
     // some daemons and a silently unwritten file on others, so position is the property — the
     // same shape as commitward's root-refusal guard, where the characters existing somewhere
     // in the file was not the thing that mattered.
-    for name in IMAGES {
-        let path = repo_root().join(name);
+    for path in dockerfiles() {
+        let name = name_of(&path);
         let text = std::fs::read_to_string(&path)
             .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
 

--- a/tests/container_git_ownership.rs
+++ b/tests/container_git_ownership.rs
@@ -1,0 +1,78 @@
+//! Every published image must be able to open a bind-mounted repository.
+//!
+//! libgit2 refuses a repository whose owner differs from the running uid. The images run as
+//! uid 10001 and a host repo bind-mounted at `/repo` never belongs to 10001, so `cxpak diff`
+//! failed with `Owner (-36)` on every documented container invocation (cxpak#60). `overview`
+//! does not open the repo through libgit2, which is why the README's headline command worked
+//! and this went unnoticed for the life of the image.
+//!
+//! Measured on the published `ghcr.io/barnett-studios/cxpak:3.1.4`, same fixture, same mount:
+//!
+//! ```text
+//! base + `printf '[safe]\n\tdirectory = *\n' > /etc/gitconfig`  -> exit 0, prints the diff
+//! base + an otherwise identical rebuild, no /etc/gitconfig      -> exit 1, Owner (-36)
+//! ```
+//!
+//! libgit2 reads `/etc/gitconfig` itself, so the exemption needs no `git` binary — the probe
+//! image had none.
+//!
+//! This is a static audit, not a container run: cxpak's CI has no Docker job, and adding one
+//! to build this crate from source would cost far more than the regression it guards. What it
+//! catches is the line being dropped from one image while the others keep it — which is the
+//! realistic regression, since the three Dockerfiles are edited separately and only one of
+//! them is exercised by any release path at a time.
+
+use std::path::PathBuf;
+
+/// The three images this repo publishes. `Dockerfile` builds from source, `Dockerfile.dist`
+/// wraps a CI-built binary, `Dockerfile.standalone` downloads a release tarball — all three
+/// run as uid 10001 and all three mount a host repo at `/repo`.
+const IMAGES: &[&str] = &["Dockerfile", "Dockerfile.dist", "Dockerfile.standalone"];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+#[test]
+fn every_image_exempts_the_mounted_repo_from_ownership_validation() {
+    for name in IMAGES {
+        let path = repo_root().join(name);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        assert!(
+            text.contains("/etc/gitconfig"),
+            "{name} does not write /etc/gitconfig — an image built from it cannot open a \
+             bind-mounted repo, and `cxpak diff` exits 1 with Owner (-36) (cxpak#60)"
+        );
+        assert!(
+            text.contains("safe]") && text.contains("directory = *"),
+            "{name} writes /etc/gitconfig without a `[safe] directory = *` entry"
+        );
+    }
+}
+
+#[test]
+fn the_exemption_is_written_before_the_image_drops_to_uid_10001() {
+    // The bound. `> /etc/gitconfig` after `USER 10001` is a permission error at build time on
+    // some daemons and a silently unwritten file on others, so position is the property — the
+    // same shape as commitward's root-refusal guard, where the characters existing somewhere
+    // in the file was not the thing that mattered.
+    for name in IMAGES {
+        let path = repo_root().join(name);
+        let text = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+
+        let gitconfig = text
+            .find("> /etc/gitconfig")
+            .unwrap_or_else(|| panic!("{name}: no /etc/gitconfig write to position"));
+        let user = text
+            .find("\nUSER ")
+            .unwrap_or_else(|| panic!("{name}: no USER instruction — the image runs as root?"));
+
+        assert!(
+            gitconfig < user,
+            "{name} writes /etc/gitconfig after dropping to a non-root USER, so the file is \
+             not written and the ownership refusal returns"
+        );
+    }
+}


### PR DESCRIPTION
Closes #60. One line per image, plus a static audit.

libgit2 refuses to open a repository whose owner differs from the running uid. All three images
run as `10001`; a host repo bind-mounted at `/repo` never does. So `cxpak diff` exited 1 with
`Owner (-36)` on **every documented container invocation**, for the life of the published image.
`overview` does not open the repo through libgit2, which is why the README's headline command
worked and this stayed invisible.

## Measured, with a control

Published `ghcr.io/barnett-studios/cxpak:3.1.4`, same fixture, same mount. Two images whose only
difference is the file:

| image | result |
|---|---|
| base + `printf '[safe]\n\tdirectory = *\n' > /etc/gitconfig` | **exit 0**, prints the diff |
| base + an otherwise identical rebuild, no `/etc/gitconfig` | **exit 1**, `Owner (-36)` |

libgit2 reads `/etc/gitconfig` itself — the probe image has **no `git` binary** (`command -v git`
→ nothing) and the exemption still takes effect. So this adds no package.

**The intermittency in the ticket goes with it.** The reported sequence — cold `diff` fails,
`overview` succeeds, `diff` then passes from cache, an edit breaks it again — is exit 0 at every
step on the fixed image and exit 1 on the control. I did **not** establish whether `diff` can serve
from cache without opening the repo in general; what is established is that the ownership refusal
no longer produces that window.

Run from `~/qa-scratch`, not the session scratchpad — a colima host bind-mounts only `$HOME`, and
a non-shared source mounts silently empty, which would have made every result above meaningless.

## All three images, not the one I could reach

The ticket reproduces against the published image, which is built from `Dockerfile.dist`. The same
refusal applies to `Dockerfile` (source build) and `Dockerfile.standalone` (release tarball) — same
uid, same mount, same libgit2. They are edited separately and only one is exercised by any release
path at a time, which is exactly how one gets fixed and the others do not.

Same one-liner commitward#13 landed, one component over. The ticket's alternative
(`git_libgit2_opts(GIT_OPT_SET_OWNER_VALIDATION, 0)`) is not needed: the config path works, and it
keeps the trust decision in the image rather than compiled into the binary, where it would also
apply to non-container use.

## The test is a static audit, and says so

cxpak's CI has no Docker job; adding one to build this crate from source would cost far more than
the regression it guards. `tests/container_git_ownership.rs` checks the three Dockerfiles instead,
and its doc comment carries the measurement above so the evidence is not only in this PR body.

**Two mutations, and they separate** — the distinction I got wrong on commitward#19 and am
applying here:

| mutation | result |
|---|---|
| drop the line from `Dockerfile.dist` only | **both** tests fail |
| move it *after* `USER 10001` | **only** the position test fails |

The second is why the position test exists: `> /etc/gitconfig` as uid 10001 is a build error on
some daemons and a silently unwritten file on others, so the characters existing somewhere in the
file is not the property.

## Verification

- `cargo test --test container_git_ownership` — 2 passed.
- `docker build --check` clean on `Dockerfile` and `Dockerfile.dist`.
- The two `InvalidBaseImagePlatform` warnings on `Dockerfile.standalone` are **pre-existing** —
  I re-ran the check on stashed `main` and got the identical pair. It is an amd64-pinned digest
  read on an arm64 host, not something this diff introduces.

## Left alone

The ticket's "worth deciding for the family rather than per-component" point stands and is not
mine to settle here — this fixes cxpak. cordon already refuses to bake such an exemption for a
different and correct reason (it mounts a worktree it does not trust); commitward and cxpak both
open repos they were handed, which is the case this applies to.