### PR TITLE
fix(#39): a committed private key is not context

### DIFF
--- a/src/scanner/defaults.rs
+++ b/src/scanner/defaults.rs
@@ -53,4 +53,40 @@ pub const BUILTIN_IGNORES: &[&str] = &[
     "*.min.js",
     "*.min.css",
     "*.map",
+    // ── Credential material (cxpak#39) ────────────────────────────────────────
+    //
+    // Measured on the published 3.1.4 image: a repo containing `id_rsa`,
+    // `server.key` and `credentials.json` indexed all three, and `credentials.json`
+    // was packed VERBATIM into the `overview` bundle. The only thing standing
+    // between a committed private key and the model was whether the user's
+    // `.gitignore` happened to cover it — `git_global(true)`'s comment already
+    // banked on that ("often excludes .env, *.pem"), which is a hope, not a control.
+    //
+    // These are exact names and key-material extensions, deliberately NOT the
+    // `*secret*` / `*credentials*` globs the ticket proposed. A glob that wide
+    // silently drops `secrets_manager.rs`, `credentials_test.go` and
+    // `SecretScanner.java` out of the index — real source vanishing from context
+    // with no diagnostic, which is the same defect class this list is closing, in
+    // the other direction.
+    ".env",
+    ".env.*",
+    "*.pem",
+    "*.key",
+    "*.p12",
+    "*.pfx",
+    "*.jks",
+    "*.keystore",
+    "id_rsa",
+    "id_dsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "credentials.json",
+    "credentials.yml",
+    "credentials.yaml",
+    "secrets.json",
+    "secrets.yml",
+    "secrets.yaml",
+    ".netrc",
+    ".npmrc",
+    ".pypirc",
 ];

--- a/tests/scanner_test.rs
+++ b/tests/scanner_test.rs
@@ -206,3 +206,103 @@ fn language_detection_markdown() {
         "README.md should be detected as 'markdown'"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Credential material never reaches the index (cxpak#39)
+// ---------------------------------------------------------------------------
+
+/// Build a throwaway repo containing the named files, each with trivial content.
+fn repo_with(files: &[&str]) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    std::fs::create_dir_all(tmp.path().join(".git")).expect("create .git");
+    for f in files {
+        let p = tmp.path().join(f);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(&p, "placeholder\n").expect("write fixture file");
+    }
+    tmp
+}
+
+fn scanned_paths(root: &Path) -> Vec<String> {
+    Scanner::new(root)
+        .expect("scanner")
+        .scan()
+        .expect("scan")
+        .into_iter()
+        .map(|f| f.relative_path)
+        .collect()
+}
+
+#[test]
+fn credential_files_are_never_scanned() {
+    // Measured on the published 3.1.4 image before this list existed: a repo holding
+    // `id_rsa`, `server.key` and `credentials.json` indexed all three, and
+    // `credentials.json` was packed verbatim into the `overview` bundle. The only
+    // protection was whether the user's gitignore happened to cover them.
+    let secrets = [
+        "id_rsa",
+        "id_dsa",
+        "id_ecdsa",
+        "id_ed25519",
+        "server.key",
+        "server.pem",
+        "bundle.p12",
+        "cert.pfx",
+        "app.jks",
+        "release.keystore",
+        "credentials.json",
+        "credentials.yml",
+        "credentials.yaml",
+        "secrets.json",
+        "secrets.yml",
+        "secrets.yaml",
+        ".env",
+        ".env.production",
+        ".netrc",
+        ".npmrc",
+        ".pypirc",
+        // Nested, because a denylist that only matches at the root is a denylist
+        // anyone defeats by putting the key in `config/`.
+        "config/deploy.key",
+        "deploy/credentials.json",
+    ];
+    let tmp = repo_with(&secrets);
+    let scanned = scanned_paths(tmp.path());
+    let leaked: Vec<&String> = scanned.iter().collect();
+    assert!(
+        leaked.is_empty(),
+        "credential material reached the index: {leaked:?}"
+    );
+}
+
+#[test]
+fn ordinary_source_that_merely_mentions_secrets_is_still_scanned() {
+    // The bound, and the reason this list is exact names rather than the `*secret*` /
+    // `*credentials*` globs the ticket proposed. Those globs drop real source out of the
+    // index with no diagnostic — the same silent-exclusion defect, pointed the other way.
+    //
+    // Without it, `credential_files_are_never_scanned` is satisfied by a scanner that
+    // returns nothing at all.
+    let sources = [
+        "src/secrets_manager.rs",
+        "src/credentials_test.go",
+        "src/SecretScanner.java",
+        "src/keyring.py",
+        "src/env_loader.ts",
+        "docs/secrets.md",
+    ];
+    let tmp = repo_with(&sources);
+    let scanned = scanned_paths(tmp.path());
+    let mut missing: Vec<&str> = sources
+        .iter()
+        .copied()
+        .filter(|s| !scanned.iter().any(|p| p == s))
+        .collect();
+    missing.sort_unstable();
+    assert!(
+        missing.is_empty(),
+        "real source was excluded by the credential denylist: {missing:?}"
+    );
+}


### PR DESCRIPTION
Closes the **security half** of #39. The dotfile half is deliberately not here — see the bottom.

## Measured first, on the published image

Fixture repo with six files, `docker run -v "$PWD:/repo" ghcr.io/barnett-studios/cxpak:3.1.4 overview .`:

```
Files: 4
  credentials.json
  id_rsa
  server.key
  src/a.py

### credentials.json          <- packed verbatim into the bundle
```

`.github/workflows/ci.yml` and `.env` were **not** seen — both are dotfiles, and `hidden(true)`
drops them. So the report is right on both counts, and the two interact exactly as it says: `.env`
is protected *incidentally*, and fixing `hidden` first would expose it on every repo. That is why
the denylist lands **before** the dotfile change rather than with it.

## Exact names, not the proposed globs — and that is measured too

The report proposes `*credentials*`, `*secret*`. I ran that version:

```
real source was excluded by the credential denylist:
  ["docs/secrets.md", "src/credentials_test.go", "src/secrets_manager.rs"]
```

Real source vanishing from the index with no diagnostic is the **same defect class** this list
exists to close, pointed the other way — and it is the one nobody would notice, because the symptom
is context that is quietly a little worse. So the list is exact filenames plus key-material
extensions: `*.pem *.key *.p12 *.pfx *.jks *.keystore`, `id_rsa|id_dsa|id_ecdsa|id_ed25519`,
`credentials.{json,yml,yaml}`, `secrets.{json,yml,yaml}`, `.env`, `.env.*`, `.netrc`, `.npmrc`,
`.pypirc`.

## Two tests, and they separate

| mutation | result |
|---|---|
| revert the denylist | `credential_files_are_never_scanned` **FAILED** — names all 18 non-dotfile secrets that reached the index |
| use the report's `*secret*` / `*credentials*` globs | `ordinary_source_that_merely_mentions_secrets_is_still_scanned` **FAILED** — names the 3 real files lost |

The second is not decoration: without it the first is satisfied by a scanner that returns nothing at
all. Row 1's output is also worth reading as the finding itself — `id_rsa`, `server.key`,
`credentials.json`, `config/deploy.key` and 14 more, all reaching the index on `main` today.

Nested paths are in the fixture (`config/deploy.key`, `deploy/credentials.json`) because a denylist
that only matches at the root is one anybody defeats by putting the key in a subdirectory.

## Verification

2598 lib + 50 cli + 13 scanner tests pass. `cargo fmt` and `cargo clippy --all-targets -- -D
warnings` clean.

## Not in this PR: the `hidden(true)` half

`scanner/mod.rs:97` reads `.hidden(true) // visit hidden files`, and in the `ignore` crate
`hidden(true)` **skips** hidden entries. Confirmed above — `.github/workflows/ci.yml` is not
indexed.

Fixing it changes what every repo indexes and what every bundle costs. On cxpak's own tree that is
**19 of 575 tracked files** (7 under `.github`, plus `.mise.toml`, `.gitignore`, `.dockerignore`,
`.cxpakignore.example` and nested dotfiles) — small here, unbounded in general. That is a decision
about the product's default, not a bug fix, and it should land with its own token-budget number.
Reported on #39 with these figures rather than smuggled in behind a security patch.

One knob worth naming for whoever takes it: `BUILTIN_IGNORES` becomes negative overrides, and there
is no way for a repo to *un*-exclude an entry. That is pre-existing for all 55 patterns, not new
here, but it is the reason to keep this list narrow.