### PR TITLE
fix(#33): the watcher keys on the case the index stores

### DIFF
--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -4,7 +4,7 @@ use crate::commands::serve::build_index;
 use crate::daemon::watcher::{FileChange, FileWatcher};
 use crate::index::CodebaseIndex;
 use crate::parser::LanguageRegistry;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::time::Duration;
 
@@ -82,8 +82,15 @@ pub(crate) fn classify_changes(
     changes: &[FileChange],
     base_path: &Path,
 ) -> (HashSet<String>, HashSet<String>) {
-    let mut modified_paths = HashSet::new();
-    let mut removed_paths = HashSet::new();
+    // Keyed on the ASCII-folded path, valued with the spelling the event
+    // carried, first one wins. That collapses two events for one file on a
+    // case-insensitive volume — the reason the old code lowercased — without
+    // storing the folded spelling, which is what broke #33. On a case-sensitive
+    // volume two genuinely distinct files that fold together still collapse to
+    // one; that is unchanged from the lowercasing this replaces, which collapsed
+    // them *and* corrupted the key.
+    let mut modified_by_fold: HashMap<String, String> = HashMap::new();
+    let mut removed_by_fold: HashMap<String, String> = HashMap::new();
 
     // The recursive FileWatcher fires on every path under the root, including
     // build/noise trees (target/, .cxpak/, node_modules/, dist/, …), binary
@@ -139,10 +146,18 @@ pub(crate) fn classify_changes(
                     continue;
                 }
                 if let Ok(rel) = p.strip_prefix(base_path) {
-                    // Use a lowercase key so that case-insensitive filesystems
-                    // (macOS HFS+, Windows NTFS) don't produce duplicate entries
-                    // for the same file with different capitalisation.
-                    modified_paths.insert(rel.to_string_lossy().to_ascii_lowercase());
+                    // The on-disk case, because that is what the index stores
+                    // (`Scanner` keys on `relative_path` verbatim). Lowercasing
+                    // here made `remove_file("readme.md")` miss the stored
+                    // `README.md` entirely and made a modify fork a second,
+                    // orphaned lowercase entry (#33). Duplicate spellings of one
+                    // file — the reason the lowercasing was here — are collapsed
+                    // by `resolve_stored_key` below, against the index rather
+                    // than against a guess.
+                    let real = rel.to_string_lossy().to_string();
+                    modified_by_fold
+                        .entry(real.to_ascii_lowercase())
+                        .or_insert(real);
                 }
             }
             FileChange::Removed(p) => {
@@ -150,13 +165,56 @@ pub(crate) fn classify_changes(
                     continue;
                 }
                 if let Ok(rel) = p.strip_prefix(base_path) {
-                    removed_paths.insert(rel.to_string_lossy().to_ascii_lowercase());
+                    let real = rel.to_string_lossy().to_string();
+                    removed_by_fold
+                        .entry(real.to_ascii_lowercase())
+                        .or_insert(real);
                 }
             }
         }
     }
 
-    (modified_paths, removed_paths)
+    (
+        modified_by_fold.into_values().collect(),
+        removed_by_fold.into_values().collect(),
+    )
+}
+
+/// The key the index actually stores for `rel`, when it stores one.
+///
+/// A case-insensitive filesystem can report an event for `readme.md` against a
+/// file the scanner stored as `README.md`; upserting the event's spelling would
+/// leave two entries for one file. Resolution is deliberately
+/// conservative: exactly one case-insensitive match resolves to it; zero
+/// matches (a new file) or more than one return `rel` unchanged, because a
+/// rewrite there would be a guess.
+///
+/// A path that already names a stored file exactly comes back unchanged, and
+/// needs no branch of its own to do it: it is either the only fold match, so it
+/// resolves to itself, or one of several, so the ambiguity rule passes it
+/// through. An earlier draft special-cased it and no mutation could kill the
+/// test covering that branch — which is what a redundant branch looks like from
+/// the outside.
+///
+/// ASCII folding only, matching the `to_ascii_lowercase` this replaces — a
+/// non-ASCII case difference is left alone rather than resolved wrongly.
+///
+/// Linear in the index for each path. Watch batches are a handful of files, so
+/// this is cheaper than building a fold map per call; if a batch ever carries
+/// hundreds of paths, build the map once instead.
+fn resolve_stored_key(index: &CodebaseIndex, rel: &str) -> String {
+    let mut resolved: Option<&str> = None;
+    for f in &index.files {
+        if f.relative_path.eq_ignore_ascii_case(rel) {
+            if resolved.is_some() {
+                return rel.to_string();
+            }
+            resolved = Some(&f.relative_path);
+        }
+    }
+    resolved
+        .map(str::to_string)
+        .unwrap_or_else(|| rel.to_string())
 }
 
 /// Apply incremental changes to the index. Returns the number of files updated.
@@ -170,13 +228,25 @@ pub(crate) fn apply_incremental_update(
     let registry = LanguageRegistry::new();
     let mut update_count = 0;
 
-    for rel_path in removed_paths {
+    // Resolved up front, and against the index as it stands: `remove_file` below
+    // mutates `index.files`, so resolving a modified path afterwards could read a
+    // different answer than the same path resolved before.
+    let removed: HashSet<String> = removed_paths
+        .iter()
+        .map(|p| resolve_stored_key(index, p))
+        .collect();
+    let modified: Vec<String> = modified_paths
+        .iter()
+        .map(|p| resolve_stored_key(index, p))
+        .collect();
+
+    for rel_path in &removed {
         index.remove_file(rel_path);
         update_count += 1;
     }
 
-    for rel_path in modified_paths {
-        if removed_paths.contains(rel_path) {
+    for rel_path in &modified {
+        if removed.contains(rel_path) {
             continue;
         }
         let abs_path = base_path.join(rel_path);
@@ -519,6 +589,186 @@ mod tests {
         assert!(
             !index.graph.edges.contains_key("b.rs"),
             "stale edges from removed file b.rs must be purged after rebuild_graph"
+        );
+    }
+}
+
+#[cfg(test)]
+mod case_preservation_tests {
+    use super::*;
+    use crate::budget::counter::TokenCounter;
+    use crate::index::CodebaseIndex;
+    use crate::scanner::ScannedFile;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// An index holding files whose stored keys are the real on-disk case.
+    fn index_with(paths: &[&str]) -> CodebaseIndex {
+        let counter = TokenCounter::new();
+        let mut content_map = HashMap::new();
+        let files = paths
+            .iter()
+            .map(|p| {
+                content_map.insert((*p).to_string(), "fn main() {}".to_string());
+                ScannedFile {
+                    relative_path: (*p).to_string(),
+                    absolute_path: PathBuf::from("/repo").join(p),
+                    language: Some("rust".to_string()),
+                    size_bytes: 100,
+                }
+            })
+            .collect();
+        CodebaseIndex::build_with_content(files, HashMap::new(), &counter, content_map)
+    }
+
+    fn stored(index: &CodebaseIndex) -> Vec<String> {
+        let mut v: Vec<String> = index
+            .files
+            .iter()
+            .map(|f| f.relative_path.clone())
+            .collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn classify_changes_keeps_the_on_disk_case() {
+        let base = PathBuf::from("/repo");
+        let (modified, removed) = classify_changes(
+            &[
+                FileChange::Modified(base.join("README.md")),
+                FileChange::Removed(base.join("src/Main.rs")),
+            ],
+            &base,
+        );
+        assert!(
+            modified.contains("README.md"),
+            "modified set lost the on-disk case: {modified:?}"
+        );
+        assert!(
+            removed.contains("src/Main.rs"),
+            "removed set lost the on-disk case: {removed:?}"
+        );
+    }
+
+    #[test]
+    fn batch_dedup_keeps_the_first_spelling_seen() {
+        // Which spelling survives a collapse does not affect correctness — a
+        // known file is resolved against the index anyway — but it must be
+        // decided by something, or the same batch can key the index differently
+        // between runs. Input order decides it.
+        let base = PathBuf::from("/repo");
+        let (modified, _) = classify_changes(
+            &[
+                FileChange::Modified(base.join("Src/Main.rs")),
+                FileChange::Modified(base.join("src/main.rs")),
+            ],
+            &base,
+        );
+        assert_eq!(
+            modified.iter().collect::<Vec<_>>(),
+            vec!["Src/Main.rs"],
+            "the surviving spelling is not the first event's"
+        );
+    }
+
+    #[test]
+    fn a_removed_mixed_case_file_leaves_the_index() {
+        let mut index = index_with(&["README.md", "src/main.rs"]);
+        let base = PathBuf::from("/repo");
+        let (modified, removed) =
+            classify_changes(&[FileChange::Removed(base.join("README.md"))], &base);
+        apply_incremental_update(&mut index, &base, &modified, &removed);
+        assert_eq!(
+            stored(&index),
+            vec!["src/main.rs".to_string()],
+            "README.md survived its own deletion — it is served as live content forever"
+        );
+    }
+
+    // Resolution is tested directly rather than through a modify round-trip.
+    // `apply_incremental_update` reads the file before upserting, so on a
+    // case-sensitive volume — which every CI runner here is — a differently
+    // cased path simply fails to open and the round-trip passes without ever
+    // exercising the rule. That test would be green on the broken code.
+
+    #[test]
+    fn resolution_maps_a_differently_cased_event_onto_the_stored_key() {
+        // The case a case-insensitive filesystem produces: an event spelled
+        // `readme.md` for a file the scanner stored as `README.md`. Taking the
+        // event's spelling forks the entry, which is what the lowercasing this
+        // fix removes was defending against.
+        let index = index_with(&["README.md", "src/main.rs"]);
+        assert_eq!(resolve_stored_key(&index, "readme.md"), "README.md");
+        assert_eq!(resolve_stored_key(&index, "SRC/MAIN.RS"), "src/main.rs");
+    }
+
+    #[test]
+    fn resolution_returns_an_exactly_matching_path_unchanged() {
+        // Stored in this order deliberately: the exact hit is seen first, so an
+        // implementation that let a later fold match win would return the other
+        // spelling and take the wrong entry.
+        let index = index_with(&["readme.md", "README.md"]);
+        assert_eq!(resolve_stored_key(&index, "readme.md"), "readme.md");
+        assert_eq!(resolve_stored_key(&index, "README.md"), "README.md");
+    }
+
+    #[test]
+    fn a_created_mixed_case_file_enters_the_index_with_its_real_case() {
+        // The case `resolve_stored_key` cannot rescue: a file the index has
+        // never seen has nothing to resolve against, so whatever
+        // `classify_changes` emits is what gets stored — permanently. This is
+        // why the lowercasing had to go rather than merely be compensated for.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("Widget.rs"), "pub fn widget() {}\n").unwrap();
+
+        let mut index = index_with(&["src/main.rs"]);
+        let (modified, removed) = classify_changes(
+            &[FileChange::Created(dir.path().join("Widget.rs"))],
+            dir.path(),
+        );
+        apply_incremental_update(&mut index, dir.path(), &modified, &removed);
+
+        assert!(
+            stored(&index).contains(&"Widget.rs".to_string()),
+            "created file was indexed under a case that is not on disk: {:?}",
+            stored(&index)
+        );
+    }
+
+    #[test]
+    fn resolution_leaves_an_ambiguous_or_unknown_path_alone() {
+        // Two stored files fold together and neither matches exactly: any
+        // rewrite would be a guess, so the path is passed through.
+        let index = index_with(&["README.md", "ReadMe.md"]);
+        assert_eq!(resolve_stored_key(&index, "readme.md"), "readme.md");
+        // A file the index has never seen — a create — must reach upsert with
+        // the case the event carried.
+        assert_eq!(resolve_stored_key(&index, "src/New.rs"), "src/New.rs");
+
+        // Matching is whole-path, not substring: `main.rs` is not `src/main.rs`,
+        // and resolving it onto one would silently retarget the update at a
+        // different file. Nothing else in this module fails if that breaks.
+        let nested = index_with(&["src/main.rs"]);
+        assert_eq!(resolve_stored_key(&nested, "main.rs"), "main.rs");
+    }
+
+    #[test]
+    fn an_exact_match_wins_when_both_cases_are_indexed() {
+        // The round-trip through `remove_file` for the case a case-sensitive
+        // volume can produce. Subsumed as a discriminator by
+        // `resolution_returns_an_exactly_matching_path_unchanged` — no mutation
+        // kills this one alone — and kept as the end-to-end check that the
+        // resolved key is what actually reaches the index.
+        let mut index = index_with(&["README.md", "readme.md"]);
+        let base = PathBuf::from("/repo");
+        let mut removed = HashSet::new();
+        removed.insert("readme.md".to_string());
+        apply_incremental_update(&mut index, &base, &HashSet::new(), &removed);
+        assert_eq!(
+            stored(&index),
+            vec!["README.md".to_string()],
+            "removing readme.md took the wrong entry"
         );
     }
 }


### PR DESCRIPTION
Closes #33.

## The ticket is right, and I checked before implementing

`commands/watch.rs` lowercased the relative path into the modified/removed sets; `index/mod.rs:519` matches `f.relative_path == relative_path` exactly, and `Scanner` stores the path verbatim. So `remove_file("readme.md")` never finds `README.md`, and a modify upserts a second, orphaned lowercase entry.

Reproduced as a RED test before touching the fix — `a_removed_mixed_case_file_leaves_the_index` failed with `left: ["README.md", "src/main.rs"], right: ["src/main.rs"]`: *README.md survived its own deletion*.

## Two halves, because neither alone is enough

**`classify_changes` emits the on-disk case.** The lowercasing was there for a reason — an existing test, `test_classify_changes_deduplicates_case_variants`, asserts two events for one file collapse to one entry — so deleting it outright regressed that. Dedup is kept by keying a map on the folded path and valuing it with the spelling the event carried, first one wins. On a case-sensitive volume two genuinely distinct files that fold together still collapse; that is unchanged from the lowercasing this replaces, which collapsed them **and** corrupted the key.

**`resolve_stored_key` maps an incoming path onto the key the index already holds.** Exactly one fold match resolves to it; zero (a create) or several (ambiguous) return the path unchanged, because a rewrite there would be a guess. It runs before any removal, since `remove_file` mutates the set it would otherwise resolve against.

Both are needed. Resolution alone cannot rescue a **created** file — there is nothing in the index to resolve against, so whatever `classify_changes` emits is stored permanently. That is `a_created_mixed_case_file_enters_the_index_with_its_real_case`, and it fails under the lowercasing mutation.

## A branch I wrote and then deleted

The first draft special-cased an exact match. **No mutation could kill the test covering it** — an exactly matching path is either the only fold match, so it resolves to itself, or one of several, so the ambiguity rule passes it through. The branch could not change an answer. Removed, with the reason in the doc comment so the next reader does not re-derive it.

## Mutations — each red for its own reason and no other

| mutation | fails |
|---|---|
| fold the stored key again (**the reported defect**) | `classify_changes_keeps_the_on_disk_case`, `a_created_mixed_case_file_...` |
| dedup on the real key | `test_classify_changes_deduplicates_case_variants` (pre-existing) |
| last event wins instead of first | `batch_dedup_keeps_the_first_spelling_seen` |
| ambiguity resolves to the last hit | `resolution_returns_an_exactly_matching_path_unchanged`, `resolution_leaves_an_ambiguous_or_unknown_path_alone` |
| resolution becomes identity | `resolution_maps_a_differently_cased_event_onto_the_stored_key` |
| fold-match a substring, not the whole path | `resolution_leaves_an_ambiguous_or_unknown_path_alone` — `main.rs` is not `src/main.rs` |

## What the tests do not prove — stated rather than left to be found

- **`a_removed_mixed_case_file_leaves_the_index` survives the lowercasing mutation.** Resolution masks it on the removal path. The discriminator for that half is `classify_changes_keeps_the_on_disk_case`. The round-trip is kept as an end-to-end check, not as evidence for the classify half.
- **`an_exact_match_wins_when_both_cases_are_indexed` has no mutation of its own.** It is subsumed by the pure resolution test.
- **Resolution is tested directly, not through a modify round-trip.** That round-trip reads the file before upserting, so on a case-sensitive volume — which every runner in `ci.yml` is — a differently cased path simply fails to open and the test passes without exercising the rule. It would have been green against the broken code.

## Scope

Behaviour only where the ticket points. `classify_changes` is `pub(crate)`; no `LLM_*` variable, CLI subcommand, or documented surface changes, so no doc update rides along.

`cargo test --workspace --all-targets` exit 0 — **82 suites, 3157 passed, 3 ignored, 0 failed**. `cargo fmt` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
