### PR TITLE
fix(#70): the canonical form orders arrays, and the producers sort totally

### DIFF
--- a/docs/adrs/0128-convention-export-versioned-checksummed-artifact.md
+++ b/docs/adrs/0128-convention-export-versioned-checksummed-artifact.md
@@ -31,6 +31,29 @@ Add `src/conventions/export.rs` defining `ConventionExport { version: "1.0", gen
 ### Neutral
 - `ConventionExport`/`ConventionDiff` and the `.cxpak/conventions.json` artifact are documented in the shipped CLAUDE.md.
 
+## Amendment (cxpak#70) — sorted keys are not sorted arrays
+
+The decision above says the hash must be unaffected by "any non-deterministic field ordering", and
+`compute_checksum` sorted object **keys** only. The lists under those keys kept whatever order their
+producer emitted, and several producers drain a `HashMap` — `churn_30d` / `churn_180d` sorted by
+modification count with no tiebreaker, `strict_layers` and the co-change edges not sorted at all — so
+`HashMap`'s per-process random iteration order reached the artifact. Ten cold exports of an unchanged
+four-file repo produced **ten different checksums**, and `conventions diff` reported drift on every
+run whose cache was cold: a CI drift gate that fires always, which is as useless as one that never
+fires and fails in the direction that gets it switched off.
+
+Two changes, and the pairing is deliberate:
+
+- the producers sort **totally** (count then path; from/to; file_a/file_b), so the emitted artifact
+  is stable for a human diffing two committed files, and ranked lists keep their rank;
+- the canonical image the checksum hashes orders **arrays as well as keys**, so a field that ever
+  becomes non-deterministic again cannot move the checksum. Reordering a list without changing its
+  contents is not drift.
+
+`diff_exports` compares that same canonical image, so the checksum and the field-by-field walk cannot
+disagree. The "checksum differs, fields identical" summary no longer blames `generated_at`, which
+this ADR excludes from the hash by construction and which therefore could never have caused it.
+
 ## Revisit if
 - Per-field (not per-category) diffing is required.
 - The export schema needs a `2.0` version with breaking changes.

--- a/src/conventions/deps.rs
+++ b/src/conventions/deps.rs
@@ -52,6 +52,11 @@ pub fn extract_deps(index: &CodebaseIndex) -> DependencyConventions {
         }
     }
 
+    // Total order. `dir_edges` is a `HashMap`, so without this the same three edges are
+    // emitted in a different permutation each run — the same cxpak#70 cause as the churn
+    // lists, reached by a loop that never sorted at all rather than by a partial sort.
+    strict_layers.sort_by(|a, b| a.from.cmp(&b.from).then_with(|| a.to.cmp(&b.to)));
+
     // Detect circular dependencies at directory level
     let circular_deps = detect_circular_deps(&dir_edges);
 
@@ -147,6 +152,37 @@ mod tests {
         }
         index.graph = graph;
         index
+    }
+
+    /// cxpak#70. `dir_edges` is a `HashMap`, and this list was pushed straight out of its
+    /// drain with no sort at all, so the same edges were emitted in a different order each
+    /// run and landed verbatim in the exported profile. Several one-directional edges, so
+    /// the fixture has something to permute.
+    #[test]
+    fn strict_layers_are_ordered_by_the_edge_they_describe() {
+        let index = make_index_with_graph(vec![
+            ("zeta/z.rs", "alpha/a.rs"),
+            ("zeta/z.rs", "beta/b.rs"),
+            ("mid/m.rs", "alpha/a.rs"),
+            ("mid/m.rs", "beta/b.rs"),
+            ("omega/o.rs", "gamma/g.rs"),
+        ]);
+        let deps = extract_deps(&index);
+        let pairs: Vec<(String, String)> = deps
+            .strict_layers
+            .iter()
+            .map(|p| (p.from.clone(), p.to.clone()))
+            .collect();
+        assert!(
+            pairs.len() >= 3,
+            "fixture should produce several edges: {pairs:?}"
+        );
+        let mut sorted = pairs.clone();
+        sorted.sort();
+        assert_eq!(
+            pairs, sorted,
+            "strict_layers must be emitted in a stable order"
+        );
     }
 
     #[test]

--- a/src/conventions/diff.rs
+++ b/src/conventions/diff.rs
@@ -1,4 +1,4 @@
-use crate::conventions::export::{compute_checksum, ConventionExport};
+use crate::conventions::export::{compute_checksum, to_stable_value, ConventionExport};
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
@@ -21,8 +21,11 @@ pub fn diff_exports(current: &ConventionExport, baseline: &ConventionExport) -> 
         };
     }
 
-    let current_val = serde_json::to_value(&current.profile).unwrap_or_default();
-    let baseline_val = serde_json::to_value(&baseline.profile).unwrap_or_default();
+    // The SAME canonical image the checksum hashes. Comparing raw values here would let the
+    // two disagree — checksum equal, field diff not — which is the failure the fast-path
+    // above exists to avoid rather than to hide.
+    let current_val = to_stable_value(serde_json::to_value(&current.profile).unwrap_or_default());
+    let baseline_val = to_stable_value(serde_json::to_value(&baseline.profile).unwrap_or_default());
 
     let mut changed = Vec::new();
     if let (serde_json::Value::Object(cur), serde_json::Value::Object(base)) =
@@ -45,7 +48,15 @@ pub fn diff_exports(current: &ConventionExport, baseline: &ConventionExport) -> 
     changed.dedup();
 
     let summary = if changed.is_empty() {
-        "Checksum differs (generated_at or metadata changed) but profile fields are identical."
+        // NOT "generated_at changed": the timestamp is excluded from the hash by construction
+        // — `compute_checksum` hashes the profile only — so naming it sent every reader of
+        // this line to the one cause that cannot produce it (cxpak#70). What remains, now
+        // that both sides are canonicalized, is a checksum that does not describe the
+        // profile beside it: a hand-edited or stale export, or one written by a different
+        // cxpak whose canonical form differs.
+        "Checksum differs but every profile field is identical — the stored checksum does \
+         not describe this profile. The export is stale, hand-edited, or written by a \
+         different cxpak version; re-run `cxpak conventions export`."
             .to_string()
     } else {
         format!(
@@ -75,6 +86,94 @@ mod tests {
         let diff = diff_exports(&a, &a);
         assert!(!diff.has_changes);
         assert!(diff.changed_fields.is_empty());
+    }
+
+    /// cxpak#70, end to end at this layer: the reported defect is that an unchanged tree
+    /// reads as drift, and the two exports of an unchanged tree differ exactly here — the
+    /// same entries, a different permutation.
+    #[test]
+    fn two_exports_differing_only_in_list_order_report_no_changes() {
+        use crate::core_graph::conventions::ChurnEntry;
+        let entry = |path: &str| ChurnEntry {
+            path: path.to_string(),
+            modifications: 1,
+            last_commit_epoch: Some(1_700_000_000),
+        };
+        let mut pa = ConventionProfile::default();
+        let mut pb = ConventionProfile::default();
+        pa.git_health.churn_180d = vec![
+            entry("pkg/gamma.py"),
+            entry("pkg/alpha.py"),
+            entry(".gitignore"),
+        ];
+        pb.git_health.churn_180d = vec![
+            entry("pkg/alpha.py"),
+            entry(".gitignore"),
+            entry("pkg/gamma.py"),
+        ];
+        let a = build_export("repo", pa);
+        let b = build_export("repo", pb);
+        let diff = diff_exports(&a, &b);
+        assert!(
+            !diff.has_changes,
+            "an unchanged tree exported twice must not read as drift: {} / {:?}",
+            diff.summary, diff.changed_fields
+        );
+    }
+
+    /// The summary for "checksum differs, fields identical" used to name `generated_at`,
+    /// which `compute_checksum` excludes by construction — it hashes the profile only. The
+    /// one diagnostic offered for this state sent every reader to the one cause that cannot
+    /// produce it.
+    #[test]
+    fn the_identical_fields_summary_does_not_blame_the_timestamp() {
+        let mut export = build_export("repo", ConventionProfile::default());
+        let baseline = build_export("repo", ConventionProfile::default());
+        // A stale/hand-edited checksum: the profile is untouched, the stored digest is not.
+        export.checksum = "deadbeefdeadbeef".to_string();
+        let diff = diff_exports(&export, &baseline);
+        assert!(
+            diff.has_changes && diff.changed_fields.is_empty(),
+            "{diff:?}"
+        );
+        assert!(
+            !diff.summary.contains("generated_at"),
+            "the timestamp cannot affect the checksum, so it must not be offered as the \
+             explanation: {}",
+            diff.summary
+        );
+        assert!(
+            diff.summary.contains("stale") || diff.summary.contains("hand-edited"),
+            "the summary must name a cause that can actually produce this state: {}",
+            diff.summary
+        );
+    }
+
+    /// The field-by-field path, which only runs when the checksum fast-path does NOT fire.
+    /// Without canonicalizing both sides here, the two disagree: the checksum says the
+    /// profiles are the same and the field walk says `git_health` changed, purely from list
+    /// order. A stale checksum is the ordinary way to reach this path.
+    #[test]
+    fn a_stale_checksum_does_not_turn_list_order_into_a_changed_field() {
+        use crate::core_graph::conventions::ChurnEntry;
+        let entry = |path: &str| ChurnEntry {
+            path: path.to_string(),
+            modifications: 1,
+            last_commit_epoch: Some(1_700_000_000),
+        };
+        let mut pa = ConventionProfile::default();
+        let mut pb = ConventionProfile::default();
+        pa.git_health.churn_180d = vec![entry("pkg/gamma.py"), entry("pkg/alpha.py")];
+        pb.git_health.churn_180d = vec![entry("pkg/alpha.py"), entry("pkg/gamma.py")];
+        let mut a = build_export("repo", pa);
+        let b = build_export("repo", pb);
+        a.checksum = "deadbeefdeadbeef".to_string();
+        let diff = diff_exports(&a, &b);
+        assert!(
+            diff.changed_fields.is_empty(),
+            "a permuted list is not a changed field: {:?}",
+            diff.changed_fields
+        );
     }
 
     #[test]

--- a/src/conventions/export.rs
+++ b/src/conventions/export.rs
@@ -14,7 +14,21 @@ pub struct ConventionExport {
 }
 
 /// Compute a stable SHA256 checksum of the profile by serializing via BTreeMap
-/// for deterministic key ordering.
+/// for deterministic key ordering **and ordering the arrays under those keys**.
+///
+/// cxpak#70: sorting keys does not order the lists inside them. Several profile fields are
+/// built by draining a `HashMap`, whose iteration order is randomised per process, and their
+/// sorts were not total — `churn_180d` sorts by `modifications` descending, so a tree where
+/// every file was touched once has no tiebreaker and emits a different permutation each run.
+/// The checksum therefore differed between two exports of an unchanged tree, and
+/// `conventions diff` reported drift on 9 runs in 10, which is a CI gate that enforces
+/// nothing in the direction that gets it switched off.
+///
+/// The producers are fixed to sort totally, so the emitted profile is stable for a human
+/// reading two committed files. This is the backstop under that: a field that ever becomes
+/// non-deterministic again cannot make the checksum move, because reordering a list without
+/// changing its contents is not drift. Ranked lists keep their rank in the emitted JSON —
+/// only the hashed image is reordered.
 pub fn compute_checksum(profile: &ConventionProfile) -> String {
     let value = serde_json::to_value(profile).unwrap_or_default();
     let stable = to_stable_value(value);
@@ -24,7 +38,8 @@ pub fn compute_checksum(profile: &ConventionProfile) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-fn to_stable_value(v: serde_json::Value) -> serde_json::Value {
+/// Canonical image of a value: object keys sorted, array elements sorted, recursively.
+pub(crate) fn to_stable_value(v: serde_json::Value) -> serde_json::Value {
     match v {
         serde_json::Value::Object(map) => {
             let btree: BTreeMap<_, _> = map
@@ -34,7 +49,12 @@ fn to_stable_value(v: serde_json::Value) -> serde_json::Value {
             serde_json::Value::Object(btree.into_iter().collect())
         }
         serde_json::Value::Array(arr) => {
-            serde_json::Value::Array(arr.into_iter().map(to_stable_value).collect())
+            // Sorted by the canonical serialization of each element: a total order that needs
+            // no per-field knowledge, so a new list field is covered the day it is added
+            // rather than the day someone remembers to add it here.
+            let mut items: Vec<serde_json::Value> = arr.into_iter().map(to_stable_value).collect();
+            items.sort_by_cached_key(|v| serde_json::to_string(v).unwrap_or_default());
+            serde_json::Value::Array(items)
         }
         other => other,
     }
@@ -75,6 +95,54 @@ mod tests {
         let a = compute_checksum(&profile);
         let b = compute_checksum(&profile);
         assert_eq!(a, b);
+    }
+
+    /// cxpak#70. Two profiles whose only difference is the ORDER of a list must hash the
+    /// same: reordering entries without changing them is not drift, and the producers feed
+    /// these lists from `HashMap`s whose drain order is randomised per process.
+    #[test]
+    fn checksum_ignores_the_order_of_list_entries() {
+        use crate::core_graph::conventions::ChurnEntry;
+        let entry = |path: &str| ChurnEntry {
+            path: path.to_string(),
+            modifications: 1,
+            last_commit_epoch: Some(1_700_000_000),
+        };
+        let mut a = ConventionProfile::default();
+        let mut b = ConventionProfile::default();
+        a.git_health.churn_180d = vec![
+            entry("pkg/alpha.py"),
+            entry("pkg/beta.py"),
+            entry(".gitignore"),
+        ];
+        b.git_health.churn_180d = vec![
+            entry(".gitignore"),
+            entry("pkg/alpha.py"),
+            entry("pkg/beta.py"),
+        ];
+        assert_eq!(
+            compute_checksum(&a),
+            compute_checksum(&b),
+            "a permuted list is the same profile; a checksum that moves with it reports \
+             drift on an unchanged tree"
+        );
+    }
+
+    /// The control for the test above: order-insensitivity must not become
+    /// content-insensitivity. Same three paths, one modification count changed.
+    #[test]
+    fn checksum_still_moves_when_a_list_entry_changes() {
+        use crate::core_graph::conventions::ChurnEntry;
+        let entry = |path: &str, n: usize| ChurnEntry {
+            path: path.to_string(),
+            modifications: n,
+            last_commit_epoch: Some(1_700_000_000),
+        };
+        let mut a = ConventionProfile::default();
+        let mut b = ConventionProfile::default();
+        a.git_health.churn_180d = vec![entry("pkg/alpha.py", 1), entry("pkg/beta.py", 1)];
+        b.git_health.churn_180d = vec![entry("pkg/beta.py", 1), entry("pkg/alpha.py", 2)];
+        assert_ne!(compute_checksum(&a), compute_checksum(&b));
     }
 
     #[test]

--- a/src/conventions/git_health.rs
+++ b/src/conventions/git_health.rs
@@ -158,7 +158,15 @@ pub fn extract_git_health(repo_path: &Path) -> GitHealthProfile {
             }
         })
         .collect();
-    churn_30d_vec.sort_by(|a, b| b.modifications.cmp(&a.modifications));
+    // Total order. `modifications` alone leaves every tie to be broken by the
+    // `HashMap` drain order above, which is randomised per process — the source of
+    // cxpak#70's phantom drift, and most visible on exactly the repos where every
+    // file was touched once.
+    churn_30d_vec.sort_by(|a, b| {
+        b.modifications
+            .cmp(&a.modifications)
+            .then_with(|| a.path.cmp(&b.path))
+    });
 
     let mut churn_180d_vec: Vec<ChurnEntry> = churn_180d
         .into_iter()
@@ -171,7 +179,15 @@ pub fn extract_git_health(repo_path: &Path) -> GitHealthProfile {
             }
         })
         .collect();
-    churn_180d_vec.sort_by(|a, b| b.modifications.cmp(&a.modifications));
+    // Total order. `modifications` alone leaves every tie to be broken by the
+    // `HashMap` drain order above, which is randomised per process — the source of
+    // cxpak#70's phantom drift, and most visible on exactly the repos where every
+    // file was touched once.
+    churn_180d_vec.sort_by(|a, b| {
+        b.modifications
+            .cmp(&a.modifications)
+            .then_with(|| a.path.cmp(&b.path))
+    });
 
     // Compute the 75th-percentile churn threshold from the 180-day data.
     // This replaces the old absolute threshold of 5.
@@ -460,6 +476,43 @@ mod tests {
         );
         // last_computed should be set
         assert!(profile.last_computed.is_some());
+    }
+
+    /// cxpak#70. Every file touched exactly once is the ordinary shape of a young repo, and
+    /// it is the shape with no tiebreaker: `modifications` alone left the order to the
+    /// `HashMap` drain, which is randomised per process, so two exports of an unchanged tree
+    /// disagreed and `conventions diff` reported drift.
+    #[test]
+    fn churn_entries_with_equal_counts_are_ordered_by_path() {
+        let dir = tempfile::TempDir::new().unwrap();
+        init_repo_with_commits(
+            &dir,
+            &[
+                ("gamma.rs", "fn g() {}", "add gamma"),
+                ("alpha.rs", "fn a() {}", "add alpha"),
+                ("beta.rs", "fn b() {}", "add beta"),
+            ],
+        );
+
+        let profile = extract_git_health(dir.path());
+        for window in [&profile.churn_180d, &profile.churn_30d] {
+            let tied: Vec<&str> = window
+                .iter()
+                .filter(|e| e.modifications == 1)
+                .map(|e| e.path.as_str())
+                .collect();
+            assert!(
+                tied.len() >= 3,
+                "fixture should tie at least 3 files: {tied:?}"
+            );
+            let mut sorted = tied.clone();
+            sorted.sort_unstable();
+            assert_eq!(
+                tied, sorted,
+                "entries with equal modification counts must be in path order, or the \
+                 emitted profile is a different permutation on every run"
+            );
+        }
     }
 
     #[test]

--- a/src/intelligence/co_change.rs
+++ b/src/intelligence/co_change.rs
@@ -123,7 +123,11 @@ pub fn build_co_changes(commits: &[(Vec<String>, i64)]) -> Vec<CoChangeEdge> {
         );
     }
 
-    pair_data
+    // Total order on the pair. `pair_data` is a `HashMap`, so this list arrived in a
+    // different permutation on every run and landed verbatim in the exported convention
+    // profile — cxpak#70. Which pairs are dropped at the ceiling is unaffected: that is
+    // decided by insertion order, which follows the commits.
+    let mut edges: Vec<CoChangeEdge> = pair_data
         .into_iter()
         .map(|((a, b), (count, most_recent_days))| CoChangeEdge {
             file_a: paths[a as usize].to_string(),
@@ -131,7 +135,13 @@ pub fn build_co_changes(commits: &[(Vec<String>, i64)]) -> Vec<CoChangeEdge> {
             count,
             recency_weight: co_change_weight(most_recent_days),
         })
-        .collect()
+        .collect();
+    edges.sort_by(|x, y| {
+        x.file_a
+            .cmp(&y.file_a)
+            .then_with(|| x.file_b.cmp(&y.file_b))
+    });
+    edges
 }
 
 /// Alias for `build_co_changes()` taking per-commit dates.
@@ -266,6 +276,40 @@ mod tests {
 
     /// A mass-touch commit carries no pairwise signal — it links every file to
     /// every other file — so it must be skipped rather than expanded.
+    /// cxpak#70. `pair_data` is a `HashMap` and its drain went straight into the returned
+    /// `Vec`, which is stored verbatim in the exported convention profile.
+    #[test]
+    fn co_change_edges_are_emitted_in_a_stable_order() {
+        // Eight files in one commit is 28 pairs. Three files is 3, and a three-element
+        // `HashMap` drains in sorted order often enough that the first version of this test
+        // passed against the unsorted code — a green test measuring nothing. Found by
+        // mutation, not by reading it.
+        let files: Vec<String> = [
+            "zeta", "eta", "mu", "alpha", "theta", "beta", "iota", "gamma",
+        ]
+        .iter()
+        .map(|n| format!("{n}.rs"))
+        .collect();
+        let commits: Vec<(Vec<String>, i64)> = vec![(files.clone(), 0), (files[..4].to_vec(), 1)];
+        let edges = build_co_changes(&commits);
+        assert_eq!(
+            edges.len(),
+            28,
+            "8 files in one commit is 28 pairs: {}",
+            edges.len()
+        );
+        let keys: Vec<(String, String)> = edges
+            .iter()
+            .map(|e| (e.file_a.clone(), e.file_b.clone()))
+            .collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        assert_eq!(
+            keys, sorted,
+            "co-change edges must be emitted in a stable order"
+        );
+    }
+
     #[test]
     fn oversized_commits_are_skipped_entirely() {
         let files: Vec<String> = (0..MAX_FILES_PER_COMMIT + 1)


### PR DESCRIPTION
Closes #70.

## Measured, control first

Four-file repo, one commit, ten **cold** exports each:

| | distinct checksums in 10 runs |
|---|---|
| before | **10** |
| after | **1** |

And end to end through `conventions diff` on an unchanged tree:

| cache state at diff time | before | after |
|---|---|---|
| warm | clean 10/10 | clean 10/10 |
| **cold** | **DRIFT 10/10** | clean 10/10 |

## This corrects the ticket's account of its own defect, in your favour

The report says drift on **9 runs in 10**, as though it were intermittent. It is not: `conventions diff` re-runs the analysis, but `build_index` serves the profile from `.cxpak/cache` when the cache is warm, so the defect is **deterministic on the cold path and absent on the warm one** — 10/10 and 0/10 above. Your own note that *"every no-baseline run skipped cache creation, every drift run created it"* is the tell; the cache state is the whole mechanism, not a correlation with one.

That matters for the fix's evidence: a test that exports twice in one process would have been green.

## Root cause and the two changes

`compute_checksum` sorted object **keys**. The lists under them kept their producer's order, and three producers drain a `HashMap`:

- `churn_30d` / `churn_180d` — sorted by modification count with **no tiebreaker**, so a tree where every file was touched once has nothing to break the tie;
- `strict_layers` — pushed straight out of the drain, never sorted;
- `co_changes` — same, returned verbatim into the profile.

Paired fixes, and the pairing is the point:

1. **The producers sort totally** (count then path; from/to; file_a/file_b), so the emitted artifact is stable for a human diffing two committed files — and ranked lists keep their rank rather than becoming alphabetical, which a blanket sort would have cost.
2. **The canonical image the checksum hashes orders arrays as well as keys**, so a list that ever becomes non-deterministic again cannot move the checksum. Reordering entries without changing them is not drift. This needs no list of which fields are lists, so a new one is covered the day it is added rather than the day someone remembers.

`diff_exports` compares that same canonical image. Without it the two disagree on the non-fast path — checksum equal, field walk reporting `git_health` changed — which is the failure the fast path exists to avoid, not to hide.

## The summary line

> `Checksum differs (generated_at or metadata changed) but profile fields are identical.`

You are right that this names the one cause ADR-0128 excludes by construction. It now names causes that can actually produce the state: a stale export, a hand-edited one, or one written by a different cxpak version.

## Mutations

| mutation | result |
|---|---|
| T1 checksum stops ordering arrays | killed by 3 tests |
| T2 churn sorts back to non-total | killed by the churn-tie test |
| T3 drop the `strict_layers` sort | killed by the deps test |
| T4 drop the co-change sort | killed by the co-change test |
| T5 restore the `generated_at` summary | killed by the summary test |
| T6 diff compares raw values | killed by the stale-checksum test |

**T4 survived the first battery.** My test used three files — three pairs — and a three-element `HashMap` drains in sorted order often enough to be green against the unsorted code. Eight files is 28 pairs. Found by running the mutation, not by reading the test.

`checksum_still_moves_when_a_list_entry_changes` is the control on T1: order-insensitivity must not become content-insensitivity.

## Not reproduced

Your *"1 run in 10 reported the baseline missing"*: **zero occurrences in 40 runs here**. My harness recreates `.cxpak` between runs rather than removing it wholesale, which is a different shape from yours — so this is not evidence against it, and I have not touched the ticket's status on that half. It stays open as you filed it if you want it split.

## Also

- `docs/adrs/0128` carries an amendment stating why sorted keys were not enough — the ADR already required "any non-deterministic field ordering" to be excluded, and the implementation delivered half of it.
- `cargo fmt --check` clean · `clippy --workspace --all-targets -D warnings` clean · **3168 passed / 3 ignored across 84 suites**.
- `detect-hitl --base origin/main` → `fired: []`.