### PR TITLE
fix(#71): a revwalk that fails is an error, not a short list

### DIFF
--- a/src/commands/visual.rs
+++ b/src/commands/visual.rs
@@ -106,8 +106,15 @@ pub fn run(
             // cache under .cxpak/timeline/ is git-ignorable; snapshots are
             // injected into the render so the emitted bytes never depend on a
             // pre-existing cache (determinism).
-            let mut snaps =
-                crate::visual::timeline::compute_timeline_snapshots(path, 12).unwrap_or_default();
+            // The dashboard is more than its History tab, so a timeline failure degrades this
+            // view rather than failing it — but it is SAID, on stderr, in the same shape as the
+            // cache-persist failure below. `unwrap_or_default()` alone rendered an empty
+            // History tab and exited 0, which is the symptom #71 reports.
+            let mut snaps = crate::visual::timeline::compute_timeline_snapshots(path, 12)
+                .unwrap_or_else(|e| {
+                    eprintln!("cxpak: timeline unavailable, History tab will be empty: {e}");
+                    Vec::new()
+                });
             crate::visual::timeline::enrich_snapshots_with_health(path, &mut snaps);
             if let Err(e) = crate::visual::timeline::save_snapshots(path, &snaps) {
                 eprintln!("cxpak: could not persist timeline cache: {e}");
@@ -128,8 +135,10 @@ pub fn run(
             let mut snapshots =
                 crate::visual::timeline::load_cached_snapshots(path).unwrap_or_default();
             if snapshots.is_empty() {
-                snapshots = crate::visual::timeline::compute_timeline_snapshots(path, 12)
-                    .unwrap_or_default();
+                // `--visual-type=timeline` IS the timeline. There is no degraded version of
+                // this view: rendering it empty on a failed walk is the exact "looks like a
+                // normal successful result and is wrong" the class describes, so it fails.
+                snapshots = crate::visual::timeline::compute_timeline_snapshots(path, 12)?;
                 crate::visual::timeline::enrich_snapshots_with_health(path, &mut snapshots);
                 if let Err(e) = crate::visual::timeline::save_snapshots(path, &snapshots) {
                     eprintln!("cxpak: could not persist timeline cache: {e}");

--- a/src/visual/timeline.rs
+++ b/src/visual/timeline.rs
@@ -48,8 +48,20 @@ pub fn compute_timeline_snapshots(
         .set_sorting(git2::Sort::TIME)
         .map_err(|e| e.to_string())?;
 
-    let oids: Vec<git2::Oid> = revwalk.filter_map(|r| r.ok()).collect();
+    // NOT `filter_map(|r| r.ok())`. Every other fallible call in this function propagates with
+    // `?`, and the doc comment above already promises the caller an error when the revwalk
+    // fails — dropping the errors here made a walk that failed mid-traversal indistinguishable
+    // from one that simply ran out of commits, and a walk that failed on its first step
+    // indistinguishable from an empty repository. The caller then rendered an empty timeline
+    // and exited 0, so the failure erased its own cause (#71).
+    let oids: Vec<git2::Oid> = revwalk
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("revwalk failed while walking commits from HEAD: {e}"))?;
 
+    // Defensive, and deliberately kept despite being unreachable today: `push_head` fails on
+    // an unborn HEAD, so a walk that got here yields at least the tip. No test can kill a
+    // mutation of this branch, and that is recorded rather than hidden by deleting it — an
+    // error-handling guard is not the place to trade a cheap check for a tidier mutation score.
     if oids.is_empty() {
         return Ok(vec![]);
     }
@@ -407,6 +419,120 @@ mod tests {
         let deserialized: TimelineSnapshot = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.commit_sha, "abc123");
         assert_eq!(deserialized.files.len(), 1);
+    }
+
+    /// Build a repo whose revwalk genuinely fails partway: two commits, then the parent's
+    /// object file removed. `push_head` still succeeds (HEAD's own object is intact), the walk
+    /// yields the tip, and then errors trying to traverse to a parent that is not there — git
+    /// itself reports `fatal: Failed to traverse parents of commit` on the same fixture.
+    ///
+    /// This is the shape the issue could not isolate: a walk that starts fine and fails mid-way
+    /// is indistinguishable, to `filter_map(|r| r.ok())`, from a walk that simply ended.
+    fn repo_whose_revwalk_fails_partway() -> tempfile::TempDir {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let git = |args: &[&str]| {
+            let out = std::process::Command::new("git")
+                .current_dir(dir.path())
+                .args(args)
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .output()
+                .expect("git must run");
+            assert!(out.status.success(), "git {args:?} failed");
+            String::from_utf8_lossy(&out.stdout).trim().to_string()
+        };
+        git(&["init", "--quiet"]);
+        git(&[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--quiet",
+            "--allow-empty",
+            "-m",
+            "first",
+        ]);
+        git(&[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "--quiet",
+            "--allow-empty",
+            "-m",
+            "second",
+        ]);
+        let parent = git(&["rev-parse", "HEAD~1"]);
+        let object = dir
+            .path()
+            .join(".git/objects")
+            .join(&parent[..2])
+            .join(&parent[2..]);
+        std::fs::remove_file(&object).expect("the parent object must exist to be removed");
+        dir
+    }
+
+    /// The defect: `filter_map(|r| r.ok())` turned a failed walk into a short list, and the
+    /// function returned it as success. The documented contract eleven lines above the code
+    /// already promised the error — this asserts the code keeps that promise.
+    /// The empty that IS reachable, and must stay a success: the caller asked for none. The
+    /// fix propagates walk errors, and this pins that it did not turn every empty result into
+    /// one — "report the failure" and "call success a failure" are different changes.
+    #[test]
+    fn asking_for_zero_snapshots_is_an_empty_success_not_an_error() {
+        let path = std::path::Path::new(".");
+        let snapshots = compute_timeline_snapshots(path, 0)
+            .expect("asking for zero snapshots of a healthy repo is not a failure");
+        assert!(
+            snapshots.is_empty(),
+            "zero requested, {} returned",
+            snapshots.len()
+        );
+    }
+
+    #[test]
+    fn a_failed_revwalk_is_an_error_not_a_silently_shortened_list() {
+        let dir = repo_whose_revwalk_fails_partway();
+        let result = compute_timeline_snapshots(dir.path(), 10);
+        let err = match result {
+            Err(e) => e,
+            Ok(snapshots) => panic!(
+                "a walk that could not traverse its parents returned Ok({}) — the caller \
+                 cannot tell this from a repository that simply has {} commits",
+                snapshots.len(),
+                snapshots.len()
+            ),
+        };
+        assert!(
+            err.to_lowercase().contains("revwalk") || err.to_lowercase().contains("walk"),
+            "the error must name the walk as the thing that failed, so the next occurrence \
+             carries its cause instead of a bare empty list; got: {err}"
+        );
+    }
+
+    /// The other empty, which must stay `Ok`: a repository with no commits at all has nothing
+    /// to walk and that is not a failure. Without this, "propagate the error" could be
+    /// satisfied by making every empty result an error, which is a different defect.
+    #[test]
+    fn a_repository_with_no_commits_is_still_ok_and_empty() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let out = std::process::Command::new("git")
+            .current_dir(dir.path())
+            .args(["init", "--quiet"])
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .output()
+            .expect("git must run");
+        assert!(out.status.success(), "git init failed");
+        // `push_head` on a repo with no HEAD commit is itself an error, so the honest answer
+        // here is an Err naming that — what must NOT happen is a bare `Ok(vec![])` that reads
+        // as "walked fine, found nothing".
+        match compute_timeline_snapshots(dir.path(), 10) {
+            Ok(s) => assert!(s.is_empty(), "an unborn HEAD cannot yield snapshots: {s:?}"),
+            Err(e) => assert!(!e.is_empty(), "an error must carry a reason"),
+        }
     }
 
     #[test]

--- a/tests/visual_cli.rs
+++ b/tests/visual_cli.rs
@@ -48,6 +48,94 @@ mod visual_cli_tests {
         dir
     }
 
+    /// `make_test_repo` plus a second commit, then the FIRST commit's object removed, so the
+    /// revwalk starts fine and fails traversing to a parent that is not there.
+    fn repo_whose_revwalk_fails_partway() -> TempDir {
+        let dir = make_test_repo();
+        let repo = git2::Repository::open(dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "t@t.com").unwrap();
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        let tree = head.tree().unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "second", &tree, &[&head])
+            .unwrap();
+
+        let first = head.id().to_string();
+        let object = dir
+            .path()
+            .join(".git/objects")
+            .join(&first[..2])
+            .join(&first[2..]);
+        std::fs::remove_file(&object).expect("the parent commit object must exist to be removed");
+        dir
+    }
+
+    /// #71's reported symptom, at the surface that reports it: `--visual-type=timeline` on a
+    /// repository whose commit walk fails must NOT render an empty timeline and exit 0.
+    ///
+    /// This is the half a library-only fix leaves behind — `compute_timeline_snapshots` can
+    /// return the error faithfully and the command still swallow it with `unwrap_or_default()`.
+    #[test]
+    fn timeline_view_fails_loudly_when_the_commit_walk_fails() {
+        let repo = repo_whose_revwalk_fails_partway();
+        let out_dir = TempDir::new().unwrap();
+        let out_file = out_dir.path().join("out.html");
+
+        let output = cxpak()
+            .args([
+                "visual",
+                "--visual-type",
+                "timeline",
+                "--out",
+                out_file.to_str().unwrap(),
+            ])
+            .current_dir(repo.path())
+            .output()
+            .expect("cxpak must run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "a timeline that could not be walked must not exit 0; stderr was: {stderr}"
+        );
+        assert!(
+            stderr.to_lowercase().contains("revwalk") || stderr.to_lowercase().contains("walk"),
+            "the failure must name the walk so the cause is not erased; stderr was: {stderr}"
+        );
+    }
+
+    /// The deliberate asymmetry, pinned so it is a decision rather than an oversight: the
+    /// full dashboard is more than its History tab, so a failed walk degrades that one view
+    /// instead of failing the whole render — but it is SAID on stderr. Silently rendering an
+    /// empty History tab is the same defect as the timeline view exiting 0.
+    #[test]
+    fn full_dashboard_still_renders_when_the_walk_fails_but_says_so() {
+        let repo = repo_whose_revwalk_fails_partway();
+        let out_dir = TempDir::new().unwrap();
+        let out_file = out_dir.path().join("out.html");
+
+        let output = cxpak()
+            .args([
+                "visual",
+                "--visual-type",
+                "all",
+                "--out",
+                out_file.to_str().unwrap(),
+            ])
+            .current_dir(repo.path())
+            .output()
+            .expect("cxpak must run");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            output.status.success(),
+            "the dashboard must still render; stderr was: {stderr}"
+        );
+        assert!(
+            stderr.contains("timeline unavailable"),
+            "a degraded History tab must be stated, not silent; stderr was: {stderr}"
+        );
+    }
+
     // -------------------------------------------------------------------------
     // PNG output — binary format validation
     // -------------------------------------------------------------------------


### PR DESCRIPTION
`compute_timeline_snapshots` collected the walk with `filter_map(|r| r.ok())`,
so a walk that failed mid-traversal was indistinguishable from one that simply
ran out of commits, and a walk that failed on its first step was
indistinguishable from an empty repository. Every other fallible call in the
function propagates with `?`, and the doc comment eleven lines above already
promised the caller an error when the revwalk fails — a written invariant with
nothing enforcing it.

The cost is not the lost commits, it is the lost cause. The reporter met this as
`assertion failed: !snapshots.is_empty()` with no reason attached, and could not
isolate the trigger before the state was destroyed. A defect whose failure mode
erases its own diagnostics costs more than the defect.

Fixing only the library would not have fixed the reported symptom. Both callers
in `src/commands/visual.rs` discarded the result with `unwrap_or_default()`, so
`cxpak visual --type timeline` would still have rendered an empty timeline and
exited 0. They are treated differently, deliberately:

  --visual-type=timeline   propagates. This view IS the timeline; there is no
                           degraded version of it, and rendering it empty on a
                           failed walk is exactly the "looks like a normal
                           successful result and is wrong" the class describes.
  --visual-type=all        degrades but SAYS SO on stderr. The dashboard is more
                           than its History tab, so one failed view does not fail
                           the render — but a silent empty tab is the same defect.

Both halves of that asymmetry are pinned by a test, so it reads as a decision
rather than an oversight.

The fixture is a repository whose walk genuinely fails: two commits, then the
parent's object file removed. `push_head` still succeeds, the walk yields the
tip, then errors traversing to a parent that is not there — git itself reports
`fatal: Failed to traverse parents of commit` on it. No repro of the reporter's
original shallow-clone state was manufactured; the issue did not ask for one,
and this reproduces the *class* deterministically.

Mutations — seven run, five killed, and the two that survived are reported
rather than hidden:

  N1 restore filter_map(|r| r.ok())      KILLED  a_failed_revwalk_is_an_error_*
  N3 drop the cause from the message     KILLED  a_failed_revwalk_is_an_error_*
  N4 make the zero-request an error      KILLED  asking_for_zero_snapshots_*
  N6 restore unwrap_or_default on the
     timeline arm                        KILLED  timeline_view_fails_loudly_*
  N7 fail but say nothing about the walk  KILLED  timeline_view_fails_loudly_*

  N2 make every empty walk an error      SURVIVED — the `oids.is_empty()` branch
     is unreachable: `push_head` fails on an unborn HEAD, so a walk that reaches
     it yields at least the tip. No test can kill this mutant. The branch is kept
     anyway and the survivor recorded; an error-handling guard is not the place
     to trade a cheap check for a tidier mutation score.
  N5 let the zero-request fall through   SURVIVED — equivalent mutant. The
     sampler ends in `.take(max_snapshots)`, which is `.take(0)`, so the early
     return and the fall-through produce identical output.

A control guards the over-correction: `asking_for_zero_snapshots_is_an_empty_
success_not_an_error` pins that propagating walk errors did not turn every empty
result into one. "Report the failure" and "call success a failure" are different
changes, and only one of them was asked for.

Claude-Session: https://claude.ai/code/session_01Nu1wdFgYpeMwM29Qgztxi8


Closes #71
Provenance: pre-existing

https://claude.ai/code/session_01Nu1wdFgYpeMwM29Qgztxi8


---

**Not verified, explicitly:**

- **What the degraded dashboard actually shows.** `full_dashboard_still_renders_when_the_walk_fails_but_says_so` asserts exit 0 and the `timeline unavailable` line on **stderr**; nothing in the test reads `out.html`. A viewer opening the dashboard may still see an empty History tab with no in-page explanation. Stating the degradation on stderr is what this PR proves; stating it in the page is not.
- **The reporter's own trigger.** The fixture fails the walk by deleting a parent object, which reproduces the *class* deterministically. No shallow clone was constructed, so I cannot claim their exact state reaches this branch — only that a mid-traversal failure now surfaces instead of vanishing.
- **Anything outside this worktree.** Evidence is `cargo test` on this branch plus the mutation matrix above. Nothing was run against the published 3.1.4 image or a large real repository.

Sibling callers *were* checked: `grep -rn 'filter_map(|r| r.ok())' src/` now returns only comments in `timeline.rs` that name the removed pattern, and both `unwrap_or_default()` call sites in `src/commands/visual.rs` are handled above.
