### PR TITLE
fix(#91): one version, four declarations, and a test that says so

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "cxpak",
       "source": "./plugin",
       "description": "Structured codebase context for Claude. Auto-context on every prompt plus an on-demand single-page dashboard with Cmd+K command palette: three modes — Overview (health, top risks, signals, repo-DNA), Explore (dependency + risk lenses), and History (architecture timeline). 5 intent-parameterized MCP tools, 12 HTTP endpoints, 14 LSP custom methods — all wired to real intelligence: health scoring, blast radius, change prediction, drift detection, security surface, data flow tracing, cross-language resolution. tree-sitter across 43 languages. Cross-process deterministic output.",
-      "version": "3.1.3"
+      "version": "3.1.4"
     }
   ]
 }

--- a/docs/adrs/0037-plugin-versioned-in-repo-distribution.md
+++ b/docs/adrs/0037-plugin-versioned-in-repo-distribution.md
@@ -38,5 +38,23 @@ The plugin version is held in lockstep with the crate across `plugin/.claude-plu
 ### Neutral
 - The shipped repo carries a `.claude-plugin/marketplace.json` listing and a `plugin/.claude-plugin/plugin.json`, both kept in lockstep with the crate version (2.2.1 at time of inspection).
 
+### Enforcement (added after #91)
+
+Lockstep was prose until `v3.1.4` shipped with `Cargo.toml` at `3.1.4` and every other
+declaration at `3.1.3`, so `ensure-cxpak` rejected the binary its own release published — the MCP
+server, four commands, two skills and both git hook wrappers with it. The cost of Option A was
+paid and its benefit was not received.
+
+`tests/version_lockstep.rs` now asserts it. Two things worth recording here rather than only in
+the test:
+
+- **There are three declarations, not the two this ADR names.** `plugin/lib/ensure-cxpak`'s
+  `REQUIRED_VERSION` postdates this decision (ADR-0033 made it the single binary resolver) and is
+  the one that actually refuses to run. It is the site the ADR's own file list would have let you
+  miss.
+- **The list is enumerated from this document, not discovered by scanning.** A check that finds
+  its own denominator can only confirm that the files it happened to find agree with each other.
+  So a fourth declaration means editing that list — here and in the test.
+
 ## Revisit if
 - An independent plugin release cadence becomes necessary (e.g., plugin-only fixes that should not wait on a CLI release).

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cxpak",
   "description": "Structured codebase context for Claude. Auto-context on every prompt plus an on-demand single-page dashboard with Cmd+K command palette: three modes — Overview (health, top risks, signals, repo-DNA), Explore (dependency + risk lenses), and History (architecture timeline). 5 intent-parameterized MCP tools, 12 HTTP endpoints, 14 LSP custom methods — all wired to real intelligence: health scoring, blast radius, change prediction, drift detection, security surface, data flow tracing, cross-language resolution. tree-sitter across 43 languages. Cross-process deterministic output.",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "author": {
     "name": "Barnett Studios"
   },

--- a/plugin/lib/ensure-cxpak
+++ b/plugin/lib/ensure-cxpak
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REQUIRED_VERSION="3.1.3"
+REQUIRED_VERSION="3.1.4"
 
 version_matches() {
     local installed

--- a/tests/version_lockstep.rs
+++ b/tests/version_lockstep.rs
@@ -1,0 +1,125 @@
+//! The plugin's version pin must agree with the crate it ships beside.
+//!
+//! ADR-0037 chose in-repo plugin distribution over a separate plugin repo *because* it
+//! "eliminates an entire class of version-skew bugs", accepting in exchange that "the plugin
+//! cannot version independently of the CLI". At `v3.1.4` the plugin versioned independently
+//! anyway — `Cargo.toml` moved and three other declarations did not — so the cost of Option A
+//! was paid and its benefit was not received (#91).
+//!
+//! Nothing enforced it. The release checklist named the step in prose
+//! (`plans/2026-07-11-cxpak-ui-overhaul-PLAN.md:317`), no test asserted it, and the result was a
+//! published release whose `ensure-cxpak` rejects its own binary — taking the MCP server, four
+//! commands, two skills and both git hook wrappers with it.
+//!
+//! The three paths below are enumerated from ADR-0037 and that checklist, NOT from a scan of the
+//! tree. A completeness check that discovers its own denominator only ever confirms that the
+//! files it found agree with each other; it cannot notice a fourth declaration nobody listed.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The authority. Resolved by cargo from `Cargo.toml`, so this cannot drift from the crate.
+const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// (path, the text immediately preceding the version literal, which is then read to the next `"`)
+const SITES: [(&str, &str); 3] = [
+    // ADR-0037, Decision: "held in lockstep with the crate across plugin/.claude-plugin/plugin.json
+    // and .claude-plugin/marketplace.json".
+    ("plugin/.claude-plugin/plugin.json", "\"version\": \""),
+    (".claude-plugin/marketplace.json", "\"version\": \""),
+    // The rollout checklist's fourth file: the resolver's own pin.
+    ("plugin/lib/ensure-cxpak", "REQUIRED_VERSION=\""),
+];
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn declared(path: &Path, prefix: &str) -> String {
+    let body = std::fs::read_to_string(path).unwrap_or_else(|e| {
+        panic!(
+            "{} is unreadable ({e}) — this check cannot answer, and a \
+                                    version site that moved is exactly what it exists to catch",
+            path.display()
+        )
+    });
+    let hits = body.matches(prefix).count();
+    assert_eq!(
+        hits,
+        1,
+        "{} contains {hits} occurrences of {prefix:?}, expected exactly 1. With none, the \
+         declaration moved or was renamed and this check would silently pass over it; with \
+         several, it is ambiguous which one ships.",
+        path.display()
+    );
+    let rest = &body[body.find(prefix).unwrap() + prefix.len()..];
+    rest[..rest
+        .find('"')
+        .unwrap_or_else(|| panic!("{}: unterminated version literal", path.display()))]
+        .to_string()
+}
+
+#[test]
+fn every_declaration_agrees_with_the_crate_version() {
+    let root = repo_root();
+    let mut wrong = Vec::new();
+    for (rel, prefix) in SITES {
+        let got = declared(&root.join(rel), prefix);
+        if got != CRATE_VERSION {
+            wrong.push(format!("  {rel}: {got} (Cargo.toml says {CRATE_VERSION})"));
+        }
+    }
+    assert!(
+        wrong.is_empty(),
+        "the plugin is versioned independently of the CLI, which is the one thing ADR-0037 \
+         chose in-repo distribution to prevent:\n{}\n\nA release cut here ships a resolver that \
+         rejects its own binary.",
+        wrong.join("\n")
+    );
+}
+
+/// The consumer-side proof. `ensure-cxpak` is the single binary resolver (ADR-0033); every plugin
+/// surface goes through it. Handed a cxpak that reports THIS crate's version — which is what a
+/// user gets from `brew install cxpak` or `cargo install cxpak` the moment a release is cut — it
+/// must resolve. At `v3.1.4` it did not, and the string check above says which file to fix while
+/// this one says what the user experiences.
+#[test]
+fn ensure_cxpak_resolves_a_binary_reporting_the_crate_version() {
+    let root = repo_root();
+    let shim_dir = std::env::temp_dir().join(format!("cxpak-lockstep-{}", std::process::id()));
+    std::fs::create_dir_all(&shim_dir).expect("create shim dir");
+    let shim = shim_dir.join("cxpak");
+    std::fs::write(
+        &shim,
+        format!("#!/bin/sh\necho \"cxpak {CRATE_VERSION}\"\n"),
+    )
+    .expect("write shim");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&shim, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    // `/usr/bin:/bin` only, so `brew` is absent and the auto-install step cannot fire and change
+    // the answer — the resolution being tested is the version comparison, nothing else.
+    let out = Command::new("bash")
+        .arg(root.join("plugin/lib/ensure-cxpak"))
+        .env("PATH", format!("{}:/usr/bin:/bin", shim_dir.display()))
+        .output()
+        .expect("run ensure-cxpak");
+    let _ = std::fs::remove_dir_all(&shim_dir);
+
+    assert!(
+        out.status.success(),
+        "ensure-cxpak rejected a cxpak reporting {CRATE_VERSION}, the version this crate \
+         publishes. Both remedies it prints install exactly that version, so a user following \
+         them cannot recover.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&out.stdout).trim(),
+        shim.display().to_string(),
+        "resolved a different binary than the one on PATH"
+    );
+}


### PR DESCRIPTION
At `v3.1.4` the crate said `3.1.4` and three other declarations said `3.1.3`:

    plugin/.claude-plugin/plugin.json    "version": "3.1.3"
    .claude-plugin/marketplace.json      "version": "3.1.3"
    plugin/lib/ensure-cxpak              REQUIRED_VERSION="3.1.3"

`version_matches` is exact equality, so the published resolver rejected the binary its own
release published — and both remedies it prints (`brew install cxpak`, `cargo install cxpak`)
produce 3.1.4, the version being refused. Following the instructions could not fix it. Downstream:
the MCP server does not start, `cxpak-merge-driver` fails loudly, and `cxpak-post-commit`
regenerates nothing while reporting nothing.

WHY A TEST AND NOT THREE EDITS. The three edits are the smaller half. ADR-0037 chose in-repo
plugin distribution *because* it "eliminates an entire class of version-skew bugs", accepting that
"the plugin cannot version independently of the CLI" — and at v3.1.4 the plugin versioned
independently anyway. The cost of Option A was paid and the benefit was not received, because
nothing enforced the property the option was chosen for. It was prose in a rollout checklist.

`tests/version_lockstep.rs` asserts it two ways:

  - every declaration equals `env!("CARGO_PKG_VERSION")`, which cargo resolves from Cargo.toml and
    so cannot itself drift; the failure names the file and both versions;
  - `ensure-cxpak`, handed a cxpak reporting this crate's version, resolves it. That is the user's
    experience rather than a string comparison, and it reproduces the ticket's exact stderr when
    the pin is stale.

The three paths are enumerated from ADR-0037 and the rollout checklist, NOT from a scan of the
tree (ADR-0060): a completeness check that discovers its own denominator only ever confirms that
the files it found agree with each other. Each site asserts exactly one occurrence of its
declaration, so a renamed or duplicated key fails rather than passing over.

ADR-0037's Consequences now record the enforcement, and correct the ADR's own file list — it names
two declarations; `ensure-cxpak`'s `REQUIRED_VERSION` postdates it (ADR-0033) and is the one that
actually refuses to run, so the ADR's list is exactly how the third site gets missed.

Census: `git grep 3.1.3` over the tree leaves one hit, `bench/corpus.toml:147`, a search-query
title in a bench fixture — not a declaration. The three sites were the complete set.

Provenance: regression — v3.1.0 through v3.1.3 have all four sites in sync at their tags; v3.1.4
moved only Cargo.toml. Last known good: v3.1.3.

Mutation matrix: 6/6 killed. Each of the three files reverted to 3.1.3; plugin.json's key renamed
so the declaration moves out of sight (the vacuity case — count 0 must fail, not pass);
marketplace.json declaring the version twice; REQUIRED_VERSION emptied.

Not fixed here, filed as #119: `version_matches` rejects a NEWER cxpak identically to a missing
one — measured 3.1.5 and 4.0.0 both refused against a 3.1.4 pin, so a patch release and a major
release are the same answer. That is skew on a user's machine between a binary moved by `brew
upgrade` and a plugin moved by a marketplace refresh, which this change moves forward one release
rather than closing. Changing the comparison contradicts a reading of ADR-0037's "lockstep" and
wants a Planner or an ADR amendment, not a Coder's judgement.

Not verified: no release is cut here. #51 stays blocked until one exists.

Claude-Session: https://claude.ai/code/session_01Nu1wdFgYpeMwM29Qgztxi8


Closes #91

https://claude.ai/code/session_01Nu1wdFgYpeMwM29Qgztxi8
