### PR TITLE
fix(#31): pin every action to a commit, and publish from a clean tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9  # branch 1.94.1
         with:
           components: rustfmt
       - run: cargo fmt -- --check
@@ -34,11 +34,11 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.94.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9  # branch 1.94.1
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       # `--features client` because features are ADDITIVE: this still lints everything the
       # default set covers, and additionally compiles src/client.rs, which no job did before
       # (#57). Without it the client is shipped unlinted.
@@ -48,9 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fmt, clippy]
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9  # branch 1.94.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       # The `client` gate has two directions and CI has to see both.
       #
       # Direction 1 — the client must COMPILE AND RUN. Under default features
@@ -93,9 +93,9 @@ jobs:
     needs: [fmt, clippy]
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9  # branch 1.94.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - name: No-network bench tests (corpus + metrics + baseline integrity)
         run: cargo test --features bench --test bench_recall --test bench_gate
       - name: Recall-regression gate (network)
@@ -119,9 +119,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [fmt, clippy]
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.91.0
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@839ed2261f110eedd370cb037b6038e074512c4e  # branch 1.91.0
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - name: Verify build on declared MSRV (1.91.0)
         run: cargo build --verbose
 
@@ -129,9 +129,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@1.94.1
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@75be91dd2711b583df57c31d0873b4145c89f1d9  # branch 1.94.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin --version 0.35.2 --locked
       - name: Check coverage (90% minimum)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # branch stable
         with:
           targets: ${{ matrix.target }}
 
@@ -49,7 +49,7 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      - uses: Swatinem/rust-cache@v2.9.1
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # v2.9.1
         with:
           key: ${{ matrix.target }}
 
@@ -70,7 +70,7 @@ jobs:
           Compress-Archive -Path target/${{ matrix.target }}/release/cxpak.exe -DestinationPath cxpak-${{ matrix.target }}.zip
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: cxpak-${{ matrix.target }}
           path: cxpak-${{ matrix.target }}.*
@@ -79,16 +79,16 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2.6.1
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe  # v2.6.1
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
@@ -103,13 +103,13 @@ jobs:
       packages: write
       id-token: write   # cosign keyless signing via GitHub OIDC
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Compute lowercase image name
         run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
 
       - name: Download Linux artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: artifacts
           merge-multiple: true
@@ -121,10 +121,10 @@ jobs:
           tar -xzf artifacts/cxpak-aarch64-unknown-linux-gnu.tar.gz -C dist/linux/arm64/
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -132,7 +132,7 @@ jobs:
 
       - name: Image metadata (tags + OCI labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5
         with:
           images: ${{ env.IMAGE }}
           tags: |
@@ -143,7 +143,7 @@ jobs:
       # from the prebuilt per-arch binaries.
       - name: Build and push multi-arch image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           file: Dockerfile.dist
@@ -155,7 +155,7 @@ jobs:
           sbom: true
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac  # v3
 
       - name: Sign image (keyless)
         env:
@@ -167,9 +167,9 @@ jobs:
     if: ${{ !contains(github.ref_name, '-') }}   # skip crates.io on prerelease tags
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish --allow-dirty
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c  # branch stable
+      - run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8.0.1
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: artifacts
           merge-multiple: true

--- a/tests/workflow_action_pins.rs
+++ b/tests/workflow_action_pins.rs
@@ -1,0 +1,140 @@
+//! Every GitHub Action this repo runs must be pinned to a commit, and say what it was pinned from.
+//!
+//! cxpak advertises cosign signatures, an SBOM and provenance as a trust story. Those attest the
+//! output of the build; they say nothing about the toolchain that produced it. With
+//! `uses: owner/repo@v3` the ref is MUTABLE — the owner can retag it, and a retagged or
+//! compromised action injects code *before* signing, so the signature attests a poisoned build
+//! faithfully. The posture was inverted relative to what it advertised (cxpak#31).
+//!
+//! THE COMMENT IS PART OF THE PIN. A bare 40-hex string is unauditable: nobody can tell whether
+//! `de0fac2e…` is `v6.0.2` or something a pull request quietly substituted, and a reviewer who
+//! cannot check a pin does not review it. Each line carries `# <ref>` naming what it was resolved
+//! from, so the pin can be re-derived with one API call.
+//!
+//! ENUMERATED FROM THE DIRECTORY, deliberately. A hand-written list of workflow files is a list
+//! that a new workflow is not on — and a new workflow is exactly where an unpinned action would
+//! next appear. The refusals below exist because "no workflow files found" and "no actions found"
+//! would otherwise both read as a pass.
+
+use std::path::{Path, PathBuf};
+
+fn workflows() -> Vec<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join(".github/workflows");
+    let mut out: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap_or_else(|e| {
+            panic!(
+                "{} is unreadable ({e}) — this check cannot answer",
+                dir.display()
+            )
+        })
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            matches!(
+                p.extension().and_then(|s| s.to_str()),
+                Some("yml") | Some("yaml")
+            )
+        })
+        .collect();
+    out.sort();
+    assert!(
+        !out.is_empty(),
+        "no workflow files under {} — a check that finds nothing to check must not report success",
+        dir.display()
+    );
+    out
+}
+
+/// `(file, line number, the `uses:` value, the rest of the line after it)`
+fn uses_lines() -> Vec<(String, usize, String, String)> {
+    let mut out = Vec::new();
+    for wf in workflows() {
+        let name = wf.file_name().unwrap().to_string_lossy().to_string();
+        let body = std::fs::read_to_string(&wf).expect("read workflow");
+        for (i, line) in body.lines().enumerate() {
+            let Some(rest) = line.split_once("uses:") else {
+                continue;
+            };
+            let mut parts = rest.1.trim().splitn(2, char::is_whitespace);
+            let value = parts.next().unwrap_or("").to_string();
+            let trailing = parts.next().unwrap_or("").trim().to_string();
+            out.push((name.clone(), i + 1, value, trailing));
+        }
+    }
+    assert!(
+        !out.is_empty(),
+        "no `uses:` found in any workflow — either the workflows stopped using actions, or this \
+         parser stopped matching them. Both need a human; neither is a pass."
+    );
+    out
+}
+
+fn is_sha_pinned(value: &str) -> bool {
+    match value.split_once('@') {
+        Some((_, r)) => {
+            r.len() == 40
+                && r.chars()
+                    .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase())
+        }
+        None => false,
+    }
+}
+
+#[test]
+fn every_action_is_pinned_to_a_commit() {
+    let mut bad = Vec::new();
+    for (file, line, value, _) in uses_lines() {
+        // A local action (`./.github/actions/x`) is this repository's own code at this commit,
+        // and a docker:// reference is pinned by its own digest rules — neither is a mutable
+        // third-party ref.
+        if value.starts_with("./") || value.starts_with("docker://") {
+            continue;
+        }
+        if !is_sha_pinned(&value) {
+            bad.push(format!("  {file}:{line}: {value}"));
+        }
+    }
+    assert!(
+        bad.is_empty(),
+        "these actions are on a MUTABLE ref. The owner can retag it, and the retagged code runs \
+         before cosign signs anything — so the signature attests whatever it did.\n{}\n\nPin with \
+         `uses: owner/repo@<40-char-sha>  # <ref>`; resolve with \
+         `gh api repos/<owner>/<repo>/commits/<ref> --jq .sha`.",
+        bad.join("\n")
+    );
+}
+
+#[test]
+fn every_pin_says_what_it_was_pinned_from() {
+    let mut bare = Vec::new();
+    for (file, line, value, trailing) in uses_lines() {
+        if !is_sha_pinned(&value) {
+            continue; // the test above owns that failure
+        }
+        if !trailing.starts_with('#') || trailing.trim_start_matches('#').trim().is_empty() {
+            bare.push(format!("  {file}:{line}: {value}"));
+        }
+    }
+    assert!(
+        bare.is_empty(),
+        "these pins are bare SHAs with no comment saying what they were pinned from. A reviewer \
+         cannot tell a legitimate `v6.0.2` from a substituted commit, so an unauditable pin buys \
+         immutability and gives up review:\n{}",
+        bare.join("\n")
+    );
+}
+
+#[test]
+fn cargo_publish_runs_from_a_clean_tree() {
+    // `--allow-dirty` tells cargo to package whatever is on disk, uncommitted changes included,
+    // so what reaches crates.io need not correspond to any commit — under a workflow whose whole
+    // claim is provenance. Measured on a clean checkout: `cargo package` succeeds without it.
+    for wf in workflows() {
+        let body = std::fs::read_to_string(&wf).expect("read workflow");
+        assert!(
+            !body.contains("--allow-dirty"),
+            "{}: `--allow-dirty` publishes files that are in no commit, which is the opposite of \
+             the provenance this workflow signs for",
+            wf.display()
+        );
+    }
+}


### PR DESCRIPTION
cxpak advertises cosign signatures, an SBOM and provenance as a trust story. Those attest the
OUTPUT of the build and say nothing about the toolchain that produced it. Every `uses:` was on a
mutable ref — `@v3`, `@v6.0.2`, and `dtolnay/rust-toolchain@stable`, which is a BRANCH — so a
retagged or compromised action injects code before cosign runs and the signature attests the
poisoned build faithfully. The posture was inverted relative to what it advertised.

34 references pinned across both workflows, from 13 distinct actions. Each carries `# <ref>` naming
what it was resolved from, because a bare 40-hex string is unauditable: a reviewer cannot tell
`de0fac2e…` from a substituted commit, and a pin nobody can check buys immutability by giving up
review. Resolved 2026-09-03 with `gh api repos/<owner>/<repo>/commits/<ref> --jq .sha`, and every
pinned SHA was then verified to exist in its own repository — 13/13 — because a transcription slip
here breaks CI in a way that reads like an infrastructure outage.

BEHAVIOUR PRESERVED FOR THE TOOLCHAIN, WHICH IS THE PART THAT LOOKED LIKE A TRAP. All three
`dtolnay/rust-toolchain` refs are branches, not tags, and the action selects the toolchain from
the branch it is on — so pinning by SHA could have silently changed which Rust builds the release.
Read the action's `action.yml` at each pinned commit rather than assuming:

  branch `stable`  declares a `toolchain` input defaulting to the literal `stable`, so rustup
                   still resolves stable at run time — the ref's meaning is intact;
  branch `1.94.1`  declares NO `toolchain` input at all and hardcodes `toolchain: 1.94.1` in its
                   run step (same for `1.91.0`).

So no `with:` was added. Adding `toolchain:` to the version branches would have passed an input
they do not declare.

SCOPE, WIDENED DELIBERATELY AND SAID OUT LOUD. The issue names `release.yml`; `ci.yml` had the
identical defect on 17 of the 34 references. Fixing one file leaves the same root cause live in the
same repo, and the guard below would have needed a hole cut in it to allow that — a guard with a
carve-out for the file nobody looked at. Both are pinned.

`--allow-dirty` is gone. It tells cargo to package whatever is on disk, uncommitted changes
included, so what reaches crates.io need not correspond to any commit — under a workflow whose
whole claim is provenance. Measured on a clean checkout of this branch: `cargo package` succeeds
without it (544 files, 7.2 MiB, rc=0).

`tests/workflow_action_pins.rs` keeps it that way, and enumerates the workflow files FROM THE
DIRECTORY: a hand-written list is a list the next workflow is not on, and the next workflow is
exactly where an unpinned action appears. It refuses rather than passes when it finds no workflow
files or no `uses:` lines at all, because both would otherwise read as a clean result.

Mutation matrix: 7/7 killed.
  one ci.yml action reverted to a mutable tag          -> every_action_is_pinned_to_a_commit
  one release.yml action reverted                      -> every_action_is_pinned_to_a_commit
  a pin truncated to 39 hex (looks pinned, is not)     -> every_action_is_pinned_to_a_commit
  a pin stripped of its `# <ref>` comment              -> every_pin_says_what_it_was_pinned_from
  `--allow-dirty` restored                             -> cargo_publish_runs_from_a_clean_tree
  every workflow file deleted                          -> all three refuse rather than pass
  a workflow with no actions at all                    -> both pin guards refuse

The last two are the ones worth having. A checker that answers "clean" when it found nothing to
check is the failure this repo has hit before; both cases now refuse and say which question they
could not answer.

Why `cargo package --no-verify` is sufficient evidence for dropping the flag: `--allow-dirty` has
exactly one effect — it suppresses the uncommitted-VCS-changes refusal. It does not change what is
packaged or how it is verified, so the check that matters is whether a clean checkout passes that
refusal, and it does. A full verify build would exercise packaging correctness, which this change
does not touch.

NOT DONE, and it is half of what the issue proposed: no Dependabot. The issue pairs pinning with
"Dependabot keeps them current", and without it these pins FREEZE — a security fix in an action
will not arrive until a human refreshes the SHA. That is a real cost of this change and someone
has to own it. I have not added it because it is repo automation policy rather than this defect,
and because a sibling repo carries the opposite position in writing (`corpus`'s ci.yml: "Actions
pinned to commit SHAs (never @vN — tags are mutable). No Dependabot."). Two repos in one family
should not disagree about that by accident; it wants a Planner, not a Coder's guess.

Checked and NOT a finding, recorded so a reviewer need not re-derive it: `ci.yml` declares no
`permissions:` block, but `repos/Barnett-Studios/cxpak/actions/permissions/workflow` reports
`default_workflow_permissions=read` and `can_approve_pull_request_reviews=false`, so it already
runs read-only. Same for dotclaude, corpus and baseplate.

Provenance: never-worked — no `uses:` in this repo has ever been pinned to a commit.

Claude-Session: https://claude.ai/code/session_01Nu1wdFgYpeMwM29Qgztxi8


Closes #31

https://claude.ai/code/session_01Nu1wdFgYpeMwM29Qgztxi8
