### PR TITLE
fix(#62): the visual ceiling is a context budget, not a transport limit

### DIFF
--- a/docs/MIGRATION-3.0.md
+++ b/docs/MIGRATION-3.0.md
@@ -83,7 +83,7 @@ be **removed in a future release**. Migrate to the intent-tool + `op` form.
 | `cxpak_security_surface` | `cxpak_insight` | `security_surface` | add `op`; params unchanged (`focus`) |
 | `cxpak_data_flow` | `cxpak_graph` | `data_flow` | add `op`; params unchanged (`symbol`, `sink`, `depth`, `focus`) |
 | `cxpak_cross_lang` | `cxpak_graph` | `cross_lang` | add `op`; params unchanged (`file`, `focus`) |
-| `cxpak_visual` | `cxpak_insight` | `visual` | add `op`; params unchanged (`type`, `format`, `focus`, `symbol`, `files`) |
+| `cxpak_visual` | `cxpak_insight` | `visual` | add `op`; params `type`, `format`, `focus`, `symbol`, `files` unchanged, **plus `tokens`** (cxpak#62) — a payload over the budget is written under `.cxpak/visual/` and the call returns `{path, bytes, tokens, token_budget, format}` instead of the artifact. Default 5 000 tokens, the same ceiling `conventions` uses |
 | `cxpak_onboard` | `cxpak_insight` | `onboard` | add `op`; params unchanged (`focus`, `format`) |
 
 ### New / re-keyed ops with a sub-selector

--- a/docs/adrs/0135-mcp-html-inline-1mb-spill-to-disk.md
+++ b/docs/adrs/0135-mcp-html-inline-1mb-spill-to-disk.md
@@ -1,7 +1,7 @@
 ---
 id: '0135'
 title: Spill MCP visual HTML responses over 1MB to disk, return file path
-status: ACCEPTED
+status: SUPERSEDED by ADR-0208
 date: 2026-04-01
 triggered_by: cxpak_visual MCP tool response sizing (Task 15)
 loop: implementation
@@ -10,6 +10,11 @@ loop: implementation
 # ADR-0135: Spill MCP visual HTML responses over 1MB to disk, return file path
 
 ## Context
+
+> **SUPERSEDED by [ADR-0208](0208-the-mcp-visual-ceiling-is-a-context-budget.md) (cxpak#62).**
+> The spill mechanism below is kept. The 1 MB threshold and the `format == "html"` gate are not:
+> the limit was a transport figure applied to a context problem, and a 340 KB dashboard from a
+> three-file repository passed under it. Read 0208 for what runs today.
 
 Shipped in v2.0.0. Returning large self-contained HTML inline through the MCP tool channel can blow context/transport limits. The `cxpak_visual` tool (Task 15) needed a threshold strategy to keep payloads bounded.
 

--- a/docs/adrs/0208-the-mcp-visual-ceiling-is-a-context-budget.md
+++ b/docs/adrs/0208-the-mcp-visual-ceiling-is-a-context-budget.md
@@ -1,0 +1,100 @@
+---
+id: '0208'
+title: The MCP `visual` ceiling is a context budget, not a transport limit
+status: ACCEPTED
+date: 2026-09-03
+triggered_by: cxpak#62 — 340 KB dashboard returned inline from a three-file repository
+loop: implementation
+supersedes: '0135'
+---
+
+# ADR-0208: The MCP `visual` ceiling is a context budget, not a transport limit
+
+## Context
+
+Supersedes [ADR-0135](0135-mcp-html-inline-1mb-spill-to-disk.md), which shipped the
+spill-to-disk mechanism this keeps and the threshold this replaces.
+
+0135 opens by naming the right hazard:
+
+> Returning large self-contained HTML inline through the MCP tool channel can blow
+> **context/transport** limits.
+
+Then it picks a number for the second word. `MCP_INLINE_LIMIT = 1_048_576` is a transport
+figure; a context window is three orders of magnitude smaller in the units that matter.
+
+cxpak#62 measured the consequence on a **three-file** repository:
+
+| op | bytes |
+|---|---|
+| `drift` | 57 |
+| `health` | 154 |
+| `security_surface` | 447 |
+| `risks` | 744 |
+| `architecture` | 1,009 |
+| `onboard` | 1,102 |
+| `conventions` | 3,916 |
+| **`visual`** | **340,432** |
+
+~90% of that payload is an inlined d3 bundle. It is 32× under 0135's ceiling, so the guard
+was working exactly as designed and the caller lost most of a context window anyway.
+
+0135 also lists this under **Neutral**:
+
+> The spill check is gated strictly on `format == "html"`.
+
+It is not neutral. Seven other formats are reachable through the same op, and `graphml`,
+`json` and `cypher` over a large graph are not small. None of them was bounded at all.
+
+**Its revisit conditions could not fire.** They are *"MCP transport limits change"* and
+*"inline vs path handling confuses tool consumers"*. The failure that happened is neither: a
+payload well **under** the threshold exhausting a context window is invisible to both. A
+guard whose trigger conditions cannot describe its own failure mode is the shape ADR-0060 is
+about, one layer out.
+
+## Decision
+
+**The ceiling is measured in tokens, against a caller-supplied budget, for every format.**
+
+- `MAX_MCP_VISUAL_TOKENS` = `MAX_MCP_CONVENTIONS_TOKENS` (5,000). Not a new number: `visual`
+  is one entry in a menu of eight ops, and an agent picking it off that list should not pay
+  two orders of magnitude more than its neighbours cost.
+- `tokens` is honoured, parsed the same way `conventions` parses it. A caller that wants the
+  whole artifact inline says so. Before this there was no such lever on this op.
+- The spill applies to **all** formats, and the file gets the extension of what was written —
+  a mermaid graph saved as `.html` is a file nothing will open.
+- The spill result is JSON — `{path, bytes, tokens, token_budget, format, note}` — because
+  the caller has to decide what to do next and a prose sentence makes it guess.
+
+**Spill, not truncate.** Every format here is structured, and half a structured document is
+not a smaller document, it is a broken one. `conventions` truncates because its payload
+degrades gracefully; this one writes the whole artifact and returns where it went. That also
+matches what the CLI's `--out` says the command is for.
+
+## Consequences
+
+### Positive
+- The op costs what the caller allowed, in the units the caller is actually spending.
+- Seven previously unbounded formats are bounded.
+- The default is shared with a sibling op, so drift between them is one assertion away
+  (`the_visual_budget_matches_the_other_capped_op`).
+
+### Negative
+- A caller who previously got 340 KB inline now gets a path. That is the point, but it is a
+  behaviour change on a published MCP surface for anyone who was relying on it.
+- The token count is computed over the whole rendered payload, so a large dashboard is still
+  fully rendered before being written. This bounds what the caller *receives*, not what the
+  server *builds*.
+
+### Neutral
+- 0135's spill mechanism, its `.cxpak/visual/` location and its path-escape check are all
+  kept unchanged. What changed is the number, the units, and the set of formats it covers.
+
+## Revisit if
+- A caller needs an artifact **not** written to the repo — the destination is still
+  hardcoded to `.cxpak/visual/` and there is no `out` parameter (0135's unshipped
+  `mcp_inline_limit_bytes` configurability has an echo here).
+- Per-op input schemas land (cxpak#45). `tokens` is honoured but not advertised, because
+  `additionalProperties: true` and per-op parameter documentation is that issue's subject,
+  not this one's.
+- The rendering cost itself, rather than the return payload, becomes the constraint.

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -138,7 +138,7 @@
 | [0132](0132-edgetype-relocation-cross-language-variant.md) | Relocate EdgeType/TypedEdge into index::graph and add CrossLanguage(BridgeType) variant | ACCEPTED | 2026-04-01 |
 | [0133](0133-incremental-rebuild-mtime-tracking.md) | Incremental index rebuild via mtime/size tracking on IndexedFile | ACCEPTED | 2026-04-01 |
 | [0134](0134-lsp-server-tower-lsp-feature-gated.md) | LSP server over stdio via tower-lsp behind an lsp feature flag, with 4 standard + 14 custom methods | ACCEPTED | 2026-04-01 |
-| [0135](0135-mcp-html-inline-1mb-spill-to-disk.md) | Spill MCP visual HTML responses over 1MB to disk, return file path | ACCEPTED | 2026-04-01 |
+| [0135](0135-mcp-html-inline-1mb-spill-to-disk.md) | Spill MCP visual HTML responses over 1MB to disk, return file path | SUPERSEDED by 0208 | 2026-04-01 |
 | [0136](0136-monorepo-workspace-prefix-scoping.md) | Monorepo workspace support via path-prefix scoping and per-workspace cache namespaces | ACCEPTED | 2026-04-01 |
 | [0137](0137-onboarding-canonical-in-intelligence-thin-visual-layer.md) | Canonical onboarding logic in intelligence module; visual layer is render-only | ACCEPTED | 2026-04-01 |
 | [0138](0138-onboarding-topo-order-kahn-lexicographic-cyclebreak.md) | Dependency-first onboarding order via Kahn topological sort with lexicographic cycle-break | ACCEPTED | 2026-04-01 |
@@ -209,4 +209,5 @@
 | [0203](0203-self-package-import-resolution-deferred.md) | Self-package import resolution (`use <own-crate>::`) — deferred, limitation documented | ACCEPTED | 2026-07-16 |
 | [0206](0206-an-unread-file-is-not-an-empty-one.md) | An unread file leaves the index rather than entering it empty — `read_indexable` returns `Option`, unreadable/non-UTF-8/over-cap files are skipped with a stderr reason and excluded from totals and the fingerprint; `CXPAK_MAX_FILE_BYTES` (default 5 MiB) decides from `size_bytes` before the read; a genuinely empty file is still indexed | ACCEPTED | 2026-09-03 |
 | [0207](0207-repo-text-is-untrusted-at-the-point-it-becomes-output.md) | Repo text is untrusted at the point it becomes output — one control-char policy across renderers, content-sized fences at all six packing sites | ACCEPTED | 2026-09-03 |
+| [0208](0208-the-mcp-visual-ceiling-is-a-context-budget.md) | The MCP `visual` ceiling is a context budget, not a transport limit — token-based, caller-overridable, all formats (supersedes 0135) | ACCEPTED | 2026-09-03 |
 | [0209](0209-the-lsp-server-anchors-on-an-absolute-root.md) | The LSP server anchors on an absolute canonical root — a `file://` URI resolves against the root or not at all, no placeholder URIs, and the CLI path wins over the client's `rootUri` because the index predates the handshake | ACCEPTED | 2026-09-05 |

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -805,6 +805,38 @@ pub fn normalize_symbol_param(value: &str) -> Result<String, (StatusCode, Json<V
     Ok(value.to_string())
 }
 
+/// The token ceiling for `cxpak_insight op=visual` before the payload is written
+/// to disk instead of returned (#62).
+///
+/// Deliberately the same number as [`MAX_MCP_CONVENTIONS_TOKENS`] — `visual` is
+/// one entry in a menu of eight ops, and an agent picking it off that list should
+/// not pay two orders of magnitude more than its neighbours cost. It is a
+/// default, not a cap: a caller that wants the whole artifact inline passes a
+/// larger `tokens`.
+pub const MAX_MCP_VISUAL_TOKENS: usize = crate::conventions::render::MAX_MCP_CONVENTIONS_TOKENS;
+
+/// The file extension for a spilled `visual` payload.
+///
+/// The spill used to hardcode `.html` because it only ever fired for HTML. Now
+/// that every format can spill, a mermaid graph saved as `.html` is a file no
+/// tool will open — the extension is the only thing telling the human what they
+/// have.
+///
+/// The `_` arm is `html` to match the renderer's own default (`format` is
+/// free-form and anything unrecognised falls through to HTML there), so the two
+/// cannot disagree about what was written.
+pub fn visual_format_extension(format: &str) -> &'static str {
+    match format {
+        "mermaid" => "mmd",
+        "svg" => "svg",
+        "c4" => "dsl",
+        "json" => "json",
+        "cypher" => "cypher",
+        "graphml" => "graphml",
+        _ => "html",
+    }
+}
+
 pub fn validate_visual_type_slug(s: &str) -> Result<&'static str, String> {
     match s {
         "dashboard" => Ok("dashboard"),
@@ -4433,15 +4465,59 @@ fn dispatch_capability_op(
                         _ => html, // html is the default
                     };
 
-                const MCP_INLINE_LIMIT: usize = 1_048_576; // 1 MB
-                if format == "html" && content.len() > MCP_INLINE_LIMIT {
+                // #62: the ceiling is a CONTEXT budget, not a transport one.
+                //
+                // The spill-to-file path below already existed. What it was
+                // measured against was `1_048_576` bytes — a number from the
+                // memory/transport domain, three orders of magnitude past what
+                // a caller's context window can take. A 340 KB dashboard on a
+                // THREE-FILE repository sailed under it and went straight into
+                // the caller's context, next to sibling ops that return ~1 KB.
+                //
+                // Two things were wrong and they are one defect: the limit came
+                // from the wrong domain, and `format == "html"` applied it to
+                // one of eight formats. `graphml` and `json` over a large graph
+                // are not small either, and neither was bounded at all.
+                //
+                // The budget is the same 5 000 tokens the `conventions` op caps
+                // at, deliberately: an op that is one item in a menu of eight
+                // should not cost two orders of magnitude more than its
+                // neighbours just because a caller picked it off the list.
+                //
+                // SPILL, NOT TRUNCATE. Every format here is structured — HTML,
+                // SVG, mermaid, C4, JSON, Cypher, GraphML — and half of a
+                // structured document is not a smaller document, it is a broken
+                // one. `conventions` truncates because its payload degrades
+                // gracefully; this one does not, so it writes the whole artifact
+                // and returns where it went. That also matches what the CLI's
+                // `--out` says this command is for.
+                let token_budget = args
+                    .get("tokens")
+                    .and_then(|t| t.as_str())
+                    .and_then(|t| crate::cli::parse_token_count(t).ok())
+                    .or_else(|| {
+                        args.get("tokens")
+                            .and_then(|t| t.as_u64())
+                            .map(|n| n as usize)
+                    })
+                    .unwrap_or(MAX_MCP_VISUAL_TOKENS);
+
+                let counter = TokenCounter::new();
+                let used = counter.count(&content);
+                if used > token_budget {
                     let validated_slug = match validate_visual_type_slug(visual_type) {
                         Ok(s) => s,
                         Err(e) => return mcp_tool_error(id, &format!("Error: {e}")),
                     };
+                    let ext = visual_format_extension(format);
                     let visual_dir = repo_path.join(".cxpak/visual");
-                    std::fs::create_dir_all(&visual_dir).ok();
-                    let filepath = visual_dir.join(format!("cxpak-{validated_slug}.html"));
+                    if let Err(e) = std::fs::create_dir_all(&visual_dir) {
+                        return mcp_tool_error(
+                            id,
+                            &format!("Error creating {}: {e}", visual_dir.display()),
+                        );
+                    }
+                    let filepath = visual_dir.join(format!("cxpak-{validated_slug}.{ext}"));
                     let canon_dir = match visual_dir.canonicalize() {
                         Ok(d) => d,
                         Err(e) => return mcp_tool_error(id, &format!("canonicalize failed: {e}")),
@@ -4454,13 +4530,23 @@ fn dispatch_capability_op(
                         return mcp_tool_error(id, "Error: path escape detected");
                     }
                     match std::fs::write(&filepath, &content) {
+                        // Machine-readable, because the caller has to decide what
+                        // to do next and a prose sentence makes it guess. It also
+                        // states the budget it was measured against, so a caller
+                        // that wants the payload inline knows what to raise.
                         Ok(()) => mcp_tool_result(
                             id,
-                            &format!(
-                                "Output written to {} ({} bytes)",
-                                filepath.display(),
-                                content.len()
-                            ),
+                            &serde_json::to_string_pretty(&json!({
+                                "path": filepath.display().to_string(),
+                                "bytes": content.len(),
+                                "tokens": used,
+                                "token_budget": token_budget,
+                                "format": format,
+                                "note": "Payload exceeded the token budget and was written to \
+                                         disk instead of returned. Open the file, or re-run with \
+                                         a larger `tokens` value to receive it inline.",
+                            }))
+                            .unwrap_or_default(),
                         ),
                         Err(e) => mcp_tool_error(id, &format!("Error writing output: {e}")),
                     }
@@ -10751,6 +10837,154 @@ mod tests {
         assert!(
             resp["error"]["message"].as_str().unwrap().contains("Batch"),
             "batch request error message must mention Batch"
+        );
+    }
+
+    // --- #62: a dashboard is a file, not a context ---
+
+    /// The measured defect. The ticket recorded **340,432 bytes** from a
+    /// three-file repository, under a 1 MB ceiling, straight into the caller's
+    /// context — beside sibling ops returning 57 to 3,916 bytes.
+    ///
+    /// This asserts the shape of the answer, not the size of the dashboard: the
+    /// payload does not come back inline, and what does come back tells the
+    /// caller where it went and what budget it failed.
+    #[test]
+    #[cfg(feature = "visual")]
+    fn an_over_budget_visual_is_written_to_disk_not_returned() {
+        let dir = std::env::temp_dir().join("cx62_spill_html");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let index = make_test_index();
+        let snap = make_shared_snapshot();
+        let resp = handle_tool_call(
+            Some(json!(1)),
+            "cxpak_visual",
+            &json!({"type": "dashboard", "format": "html"}),
+            &index,
+            &dir,
+            &snap,
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(
+            !text.contains("<script"),
+            "the d3 bundle reached the caller's context: {} bytes",
+            text.len()
+        );
+
+        let v: Value = serde_json::from_str(text)
+            .unwrap_or_else(|e| panic!("the spill answer must be machine-readable: {e}; {text}"));
+        assert_eq!(v["token_budget"], json!(MAX_MCP_VISUAL_TOKENS), "{text}");
+        assert!(
+            v["tokens"].as_u64().unwrap() > MAX_MCP_VISUAL_TOKENS as u64,
+            "it spilled, so it must report exceeding the budget: {text}"
+        );
+        let path = std::path::PathBuf::from(v["path"].as_str().unwrap());
+        assert!(path.is_file(), "the artifact must exist at {path:?}");
+        assert_eq!(path.extension().unwrap(), "html", "{path:?}");
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().len(),
+            v["bytes"].as_u64().unwrap(),
+            "the reported byte count must be the file's: {text}"
+        );
+    }
+
+    /// The control, and the one that stops "return nothing" passing as a fix.
+    /// A payload inside the budget must still come back INLINE — spilling
+    /// everything would satisfy the test above and destroy the op.
+    #[test]
+    #[cfg(feature = "visual")]
+    fn a_within_budget_visual_is_still_returned_inline() {
+        let dir = std::env::temp_dir().join("cx62_inline_mermaid");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let index = make_test_index();
+        let snap = make_shared_snapshot();
+        let resp = handle_tool_call(
+            Some(json!(2)),
+            "cxpak_visual",
+            &json!({"type": "dashboard", "format": "mermaid"}),
+            &index,
+            &dir,
+            &snap,
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(
+            !text.contains("\"path\""),
+            "a small payload must not be spilled: {text}"
+        );
+        assert!(
+            !dir.join(".cxpak/visual").exists(),
+            "nothing should have been written for an in-budget payload"
+        );
+    }
+
+    /// `tokens` is the caller's lever. Before #62 there was none, which is half
+    /// of what the issue is about — the other half being that the ceiling that
+    /// did exist was a transport number.
+    #[test]
+    #[cfg(feature = "visual")]
+    fn a_larger_tokens_budget_returns_the_payload_inline() {
+        let dir = std::env::temp_dir().join("cx62_budget_raised");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let index = make_test_index();
+        let snap = make_shared_snapshot();
+        let resp = handle_tool_call(
+            Some(json!(3)),
+            "cxpak_visual",
+            &json!({"type": "dashboard", "format": "html", "tokens": 5_000_000u64}),
+            &index,
+            &dir,
+            &snap,
+        );
+        let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(
+            text.contains("<script") || text.contains("<html"),
+            "a caller that asked for it must get it: {}",
+            &text[..text.len().min(200)]
+        );
+    }
+
+    /// Every format can spill now, so the extension has to say what the file is.
+    /// A mermaid graph written as `.html` is a file nothing will open.
+    #[test]
+    fn every_visual_format_spills_under_its_own_extension() {
+        // Hand-written from the CLI's documented `--format` set, not read back
+        // from the function — a table derived from the code under test can only
+        // confirm it agrees with itself.
+        for (format, want) in [
+            ("html", "html"),
+            ("mermaid", "mmd"),
+            ("svg", "svg"),
+            ("c4", "dsl"),
+            ("json", "json"),
+            ("cypher", "cypher"),
+            ("graphml", "graphml"),
+        ] {
+            assert_eq!(
+                visual_format_extension(format),
+                want,
+                "format {format:?} must spill as .{want}"
+            );
+        }
+        // Unrecognised falls through to HTML, matching the renderer's own
+        // default — so the extension cannot disagree with what was written.
+        assert_eq!(visual_format_extension("png"), "html");
+        assert_eq!(visual_format_extension(""), "html");
+    }
+
+    /// The budget is not a number invented for this op. It is the same ceiling
+    /// `conventions` uses, which is the point: `visual` sits in a menu of eight
+    /// and must not cost orders of magnitude more than the ops beside it.
+    #[test]
+    fn the_visual_budget_matches_the_other_capped_op() {
+        assert_eq!(
+            MAX_MCP_VISUAL_TOKENS,
+            crate::conventions::render::MAX_MCP_CONVENTIONS_TOKENS
         );
     }
 }

--- a/tests/mcp_visual_onboard.rs
+++ b/tests/mcp_visual_onboard.rs
@@ -259,16 +259,43 @@ mod mcp_visual_onboard_tests {
             .as_str()
             .expect("result.content[0].text must be a string");
 
-        // Large HTML may be written to file; we accept either:
-        // (a) inline HTML starting with <!DOCTYPE html>
-        // (b) a message containing "Output written to" (MCP 1 MB limit)
+        // Either the artifact or a pointer to it. Which one depends on the token
+        // budget (#62, ADR-0208) — on a repo this small the d3 bundle alone puts
+        // the dashboard well over the default, so in practice this takes the
+        // pointer branch; the test accepts both so it stays about the CONTRACT
+        // and not about how big the fixture happens to be.
+        //
+        // The pointer used to be the prose "Output written to <path> (N bytes)"
+        // and is now JSON, because the caller has to decide what to do next. That
+        // is the change #62 makes here, and matching on the sentence is what made
+        // this test the one place in the tree that noticed.
         let is_html = text.contains("<!DOCTYPE html>");
-        let is_file_ref = text.contains("Output written to");
+        let pointer: Option<Value> = serde_json::from_str(text).ok();
+        let is_file_ref = pointer
+            .as_ref()
+            .is_some_and(|v| v.get("path").and_then(|p| p.as_str()).is_some());
         assert!(
             is_html || is_file_ref,
-            "cxpak_visual dashboard must return HTML or a file reference, got first 200 chars: {}",
+            "cxpak_visual dashboard must return the HTML or a machine-readable pointer to it, \
+             got first 200 chars: {}",
             &text[..text.len().min(200)]
         );
+
+        // If it spilled, the pointer must name a file that is really there and
+        // say what it cost — a path the caller cannot open is not a pointer.
+        if let Some(v) = pointer.filter(|_| is_file_ref) {
+            let path = std::path::PathBuf::from(v["path"].as_str().unwrap());
+            assert!(path.is_file(), "spill pointer names no file: {v}");
+            assert_eq!(
+                std::fs::metadata(&path).unwrap().len(),
+                v["bytes"].as_u64().expect("bytes must be reported"),
+                "the reported size must be the file's: {v}"
+            );
+            assert!(
+                v["tokens"].as_u64().unwrap() > v["token_budget"].as_u64().unwrap(),
+                "it spilled, so it must report exceeding the budget: {v}"
+            );
+        }
     }
 
     #[test]

--- a/tests/v210_dependency_invariants.rs
+++ b/tests/v210_dependency_invariants.rs
@@ -86,17 +86,40 @@ fn invariant_onboarding_excludes_test_files() {
     );
 }
 
+/// The `visual` spill invariant, repointed from ADR-0135 to ADR-0208 (#62).
+///
+/// This test did its job: it is the tripwire that noticed `MCP_INLINE_LIMIT`
+/// leaving the tree, which is exactly what a pinned invariant is for. What it
+/// pinned is what changed — the ceiling is now a TOKEN budget rather than a
+/// 1 MiB byte threshold, because 1 MiB is a transport figure and a 340 KB
+/// dashboard from a three-file repo sailed under it into a caller's context.
+///
+/// Deliberately NOT deleted along with the constant. The mechanism it guards —
+/// spill to `.cxpak/visual/`, do not stream an artifact into a context window —
+/// survived; only the number and the units moved. Removing the guard because
+/// the constant was renamed would retire a real invariant on a technicality.
+///
+/// It stays a grep over the source for the same reason it always was: it
+/// catches ACCIDENTAL REMOVAL, which a behavioural test cannot, because a
+/// behavioural test for "the limit still exists" passes on any limit at all.
 #[test]
-fn invariant_mcp_inline_limit_constant_present() {
-    // Grep-style check against the source file — this test catches accidental removal.
+fn invariant_mcp_visual_token_ceiling_present() {
     let src = std::fs::read_to_string("src/commands/serve.rs").unwrap();
     assert!(
-        src.contains("MCP_INLINE_LIMIT"),
-        "MCP_INLINE_LIMIT must remain defined in serve.rs"
+        src.contains("MAX_MCP_VISUAL_TOKENS"),
+        "the visual token ceiling must remain defined in serve.rs (ADR-0208)"
     );
-    assert!(src.contains("1_048_576"), "1 MiB threshold must remain");
+    assert!(
+        !src.contains("MCP_INLINE_LIMIT"),
+        "the superseded byte threshold must not come back alongside the token one — \
+         two ceilings on one payload is how they drift"
+    );
     assert!(
         src.contains(".cxpak/visual"),
         "write-to-file target directory must remain"
+    );
+    assert!(
+        src.contains("visual_format_extension"),
+        "a spilled artifact must carry the extension of what was written"
     );
 }


### PR DESCRIPTION
Closes #62.

**Provenance: `never-worked`** — as the issue records. `visual` has been in the `cxpak_insight` op set since the tool was consolidated, and no version of this surface has ever returned a context-sized payload. So there is no gate that should have fired, only a threshold that was never in the right units.

---

## The guard was there. It was measuring the wrong thing.

```rust
const MCP_INLINE_LIMIT: usize = 1_048_576; // 1 MB
if format == "html" && content.len() > MCP_INLINE_LIMIT {
```

[ADR-0135](../blob/main/docs/adrs/0135-mcp-html-inline-1mb-spill-to-disk.md) names the hazard correctly — *"can blow **context/transport** limits"* — and then picks a number for the second word. 1 MB is a transport figure; a context window is three orders of magnitude smaller in the units that matter.

The measured payload is **340,432 bytes from a three-file repository**, ~90% of it an inlined d3 bundle. That is **32× under** the ceiling, so the guard ran, reported nothing, and did not do its job — sitting in a menu beside seven ops that return 57 to 3,916 bytes.

Two faults, one cause:

| | |
|---|---|
| the limit came from the wrong **domain** | bytes of transport, not tokens of context |
| `format == "html"` covered the wrong **set** | one of eight formats; `graphml`, `json` and `cypher` over a large graph are not small, and none of them was bounded at all |

ADR-0135 lists that second one under **Neutral**. It is not neutral.

**Its revisit conditions could not fire.** They are *"MCP transport limits change"* and *"inline vs path handling confuses tool consumers"*. Neither can describe a payload **under** the threshold exhausting a context window — the guard's own trigger conditions were blind to its own failure mode.

## What changes

- **`MAX_MCP_VISUAL_TOKENS` = `MAX_MCP_CONVENTIONS_TOKENS` (5,000).** Not a new number, deliberately: `visual` is one entry in a menu of eight, and an agent picking it off that list should not pay two orders of magnitude more than its neighbours cost. Pinned by an assertion so the two cannot drift.
- **`tokens` is honoured**, parsed exactly as `conventions` parses it. Before this the op had **no caller lever at all**, which is half of what the issue is about.
- **The spill covers every format**, and the file carries the extension of what was written — a mermaid graph saved as `.html` is a file nothing will open.
- **The spill result is JSON** — `{path, bytes, tokens, token_budget, format, note}` — because the caller has to decide what to do next and a prose sentence makes it guess.

**Spill, not truncate.** Every format here is structured, and half a structured document is not a smaller document, it is a broken one. `conventions` truncates because its payload degrades gracefully; this one writes the whole artifact and returns where it went — which is also what the CLI's `--out` says the command is for.

**Kept unchanged from 0135:** the spill mechanism, `.cxpak/visual/` as the destination, and the path-escape check.

---

## Adversarial self-check

**Mutations: 5/5 killed.**

| | mutation | killed by |
|---|---|---|
| V1 | the pre-fix 1 MB byte ceiling, html only | `an_over_budget_visual_is_written_to_disk_not_returned` |
| V2 | `tokens` read but ignored | `a_larger_tokens_budget_returns_the_payload_inline` |
| V3 | **CONTROL** — spill *everything* | `a_within_budget_visual_is_still_returned_inline` |
| V4 | mermaid spills as `.html` | `every_visual_format_spills_under_its_own_extension` |
| V5 | the budget drifts from `conventions`' cap | `the_visual_budget_matches_the_other_capped_op` |

**V3 is the control that matters.** "Do not return the payload" is trivially satisfied by never returning it — which passes V1's test and destroys the op. The inline test fails if the fix takes that route.

The format→extension table is **hand-written from the CLI's documented `--format` set**, not read back from the function under test, so it states what the mapping must be rather than confirming the code agrees with itself.

### Two guardians caught the behaviour change, and both were right

**1. `mcp_visual_dashboard_returns_html`** (live MCP server, end to end) already accepted either branch — but detected the spill by matching the prose `"Output written to"`, which this replaces with JSON. It failed. Now asserts the **contract**: a pointer must parse, name a file that really exists, report that file's real byte count, and report tokens over the budget it names.

`grep -rn "Output written to"` over `src`, `tests`, `docs` and `README.md` returns only that test's two lines, so that is the whole radius for the message shape.

**2. `invariant_mcp_inline_limit_constant_present`** is a grep over `serve.rs` pinning ADR-0135's constant. Removing the constant made it red — exactly what a pinned invariant is for.

**Repointed, not deleted.** The mechanism it guards survived; only the number and the units moved, and deleting the guard because the constant was renamed would retire a real invariant on a technicality. It now pins `MAX_MCP_VISUAL_TOKENS` and `visual_format_extension`, and asserts the byte threshold does **not** come back beside the token one — two ceilings on one payload is how they drift. It stays a grep for the reason it always was: it catches accidental *removal*, which no behavioural test can, since a behavioural test for "a limit exists" passes on any limit including 1 MB.

**The sibling formats are the control for the widened condition.** `mcp_visual_architecture_returns_mermaid_with_graph_header`, `_c4_contains_workspace`, `_json_parseable_content` and `_svg_is_non_empty` all still pass **inline**. Those formats are now bounded too and did not become "always writes a file".

### What I did NOT verify

- **No live MCP server was driven against a large real repository.** The over-budget case is exercised through the in-process handler and through the spawned-server integration test on the fixture repo; I did not reproduce the issue's original 340 KB measurement end to end.
- **Whether any consumer depends on the inline HTML.** This is a behaviour change on a published MCP surface — that is the point, and it is recorded as a negative consequence in ADR-0208, but I did not survey consumers.
- **The rendering cost itself.** The token count is computed over the fully rendered payload, so a large dashboard is still built before being written. This bounds what the caller *receives*, not what the server *does*.
- **Windows/Linux path behaviour** of the spill. Unchanged from 0135, and untested there before or after.

### Not in scope

`tools/list` still advertises only `op`, so `tokens` is honoured but **not discoverable**. `additionalProperties: true` and per-op parameter schemas are **cxpak#45**, which #62 itself names as the same gap seen from the other side. Recorded in ADR-0208's revisit conditions rather than half-fixed here.

### Docs

- **ADR-0208** supersedes **ADR-0135**, which is marked `SUPERSEDED` with a pointer rather than left to contradict the code.
- `docs/MIGRATION-3.0.md` line 81 enumerated this op's params and now names `tokens` and the spill contract (`docs-with-code`).
- ADR numbering: 0206 is taken by PR #127 (issue #40) and 0207 by PR #128 (issue #43), both open. `INDEX.md` will conflict on adjacent lines if those land in a different order — see **cxpak#126**, where 0204 and 0205 are on disk and absent from the index, which is why the high-water mark cannot simply be read off it.
