### PR TITLE
fix(#64): the installed plugin's README named a surface that no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ Your AI tool gets five intent-parameterized tools; each selects a capability via
 | **`cxpak_review`** | `review`, `diff`, `verify` |
 | **`cxpak_insight`** | `health`, `risks`, `architecture`, `conventions`, `security_surface`, `drift`, `visual`, `onboard` |
 
-The v2.x per-tool names (`cxpak_auto_context`, `cxpak_health`, ...) remain callable as deprecated aliases for one release. See [`docs/MIGRATION-3.0.md`](docs/MIGRATION-3.0.md).
+<!-- advertised-tool-names: exempt — this paragraph's subject IS the pre-3.0 names, so naming
+     them is its job. The exemption is declared here rather than hardcoded in the test, so moving
+     or deleting this paragraph removes the exemption with it. -->
+The v2.x per-tool names (`cxpak_auto_context`, `cxpak_health`, ...) remain callable as deprecated aliases; **`tools/list` does not advertise them**, so a client that builds its callable set from the advertised surface will not find them. No removal release is set. See [`docs/MIGRATION-3.0.md`](docs/MIGRATION-3.0.md).
 
 On large repositories, `cxpak serve --mcp` answers the MCP `initialize` handshake immediately and builds the index in the background -- fixing the startup timeout. Tool calls that arrive before the index is ready get a graceful retry status, then byte-identical results once it is built.
 

--- a/docs/MIGRATION-3.0.md
+++ b/docs/MIGRATION-3.0.md
@@ -1,3 +1,8 @@
+<!-- advertised-tool-names: exempt — this document's SUBJECT is the pre-3.0 tool names and
+     what they map onto. A guard that required every name here to be advertised would require
+     this file to stop being a migration guide. Declared here rather than as a path in the
+     test, so the exemption cannot outlive the document. -->
+
 # Migrating to cxpak 3.0.0 — MCP tool consolidation (BREAKING)
 
 cxpak 3.0.0 replaces the 26 hand-rolled MCP tools with **five intent-parameterized

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -48,25 +48,34 @@ cargo install cxpak
 
 All commands ask for a token budget (default: 50k).
 
-## MCP Tools (13)
+## MCP Tools (5)
 
-When used as an MCP server (`cxpak serve --mcp`), all tools support a `focus` path prefix parameter for scoped results:
+When used as an MCP server (`cxpak serve --mcp`), cxpak advertises **five intent-tools**. Each
+one selects what it does through a required `op` parameter, so the tool you call is the
+*intent* and the `op` is the *capability*:
 
-| Tool | Description |
+| Tool | `op` values |
 |------|-------------|
-| `cxpak_auto_context` | One-call optimal context for any task (includes DNA section) |
-| `cxpak_overview` | Structured repo summary |
-| `cxpak_trace` | Trace a symbol through dependencies |
-| `cxpak_stats` | Language stats and token counts |
-| `cxpak_diff` | Show changes with dependency context |
-| `cxpak_context_for_task` | Score and rank files by relevance to a task |
-| `cxpak_pack_context` | Pack selected files into a token-budgeted bundle |
-| `cxpak_search` | Regex search with context lines |
-| `cxpak_blast_radius` | Analyze change impact with risk scores |
-| `cxpak_api_surface` | Extract public API surface |
-| `cxpak_context_diff` | Show what changed since last auto_context call |
-| `cxpak_verify` | Verify code changes against observed conventions |
-| `cxpak_conventions` | Return the full convention profile with evidence |
+| `cxpak_context` | `context`, `retrieval`, `search`, `overview`, `stats`, `context_for_task`, `pack_context`, `briefing` |
+| `cxpak_graph` | `graph`, `trace`, `blast_radius`, `call_graph`, `dead_code`, `api_surface`, `data_flow`, `cross_lang`, `predict` |
+| `cxpak_data` | `data` |
+| `cxpak_review` | `review`, `diff`, `verify` |
+| `cxpak_insight` | `health`, `risks`, `architecture`, `conventions`, `security_surface`, `drift`, `visual`, `onboard` |
+
+Start with `cxpak_context` (`op: "context"`) — it returns token-budgeted structural context for a
+one-line task description.
+
+Per-op parameters are listed in [`docs/MIGRATION-3.0.md`](../docs/MIGRATION-3.0.md), and
+`tools/list` is the authority at runtime.
+
+This section deliberately makes **no blanket claim about parameters**. The one it replaced said
+*"all tools support a `focus` path prefix parameter"*, and that was not true of the surface it
+described or of this one — measured on `main`, 23 of 29 ops read `focus` and six do not. A
+sentence that is right for most ops is wrong for the caller holding one of the others.
+
+> The pre-3.0 per-tool names still route as deprecated aliases, but `tools/list` does not
+> advertise them — a client that builds its callable set from `tools/list`, which is what an
+> agent harness does, will not find them. Use the five above.
 
 ## License
 

--- a/tests/advertised_tool_names.rs
+++ b/tests/advertised_tool_names.rs
@@ -196,3 +196,138 @@ fn every_tool_name_in_a_string_literal_is_advertised() {
         violations.join("\n  ")
     );
 }
+
+/// Markdown that a user reads to learn the CURRENT surface must name only tools
+/// `tools/list` advertises.
+///
+/// cxpak#64: `plugin/README.md` was headed "MCP Tools (13)" and listed the whole
+/// v2.x surface — **not one** of those 13 names has been advertised since the 3.0
+/// consolidation (ADR-0182). It is the README of the plugin a user *installs*, so
+/// it is what they read to learn what they just got. `README.md` carried two more.
+///
+/// The names still *route*, through the 26-arm alias table, so a permissive client
+/// that copies one out of the doc succeeds and nothing fails loudly. A client that
+/// builds its callable set from `tools/list` — which is what an agent harness does
+/// — gets none of them. The doc was wrong in the one direction the alias hides.
+///
+/// ## Why the denominator is the tree and the exemption is in the file
+///
+/// This is a DRIFT claim, so the expectation is deliberately *shared* with the
+/// thing it checks: `mcp_catalog_tools()` is the same function `tools/list` is
+/// built from, and a rename must move both sides together. (A completeness claim
+/// would need the opposite — an independent enumeration — which is why the sibling
+/// test over `src/` derives its site set from the source rather than from a list.)
+///
+/// Every `.md` in the tree is scanned, so a new document is covered the day it is
+/// added rather than the day someone remembers to list it. Two escapes, and the
+/// difference between them matters:
+///
+/// * `docs/adrs/` is excluded **by rule**. An ADR is a dated record of a decision
+///   taken when those names existed; rewriting one to use today's names would
+///   falsify history, and there is no version of this guard an ADR should pass.
+/// * Anything else opts out with `advertised-tool-names: exempt` **in the file**,
+///   next to the text it excuses. Two documents legitimately name the dead surface
+///   — the migration table, whose subject is the mapping, and README's deprecation
+///   paragraph. Declaring it in the document means deleting the paragraph deletes
+///   the exemption; a path list in this file would outlive the reason for it.
+#[test]
+fn every_tool_name_in_current_docs_is_advertised() {
+    let advertised = cxpak::capability::adapter::mcp_catalog_tools();
+    assert!(
+        !advertised.is_empty(),
+        "no advertised tools — the catalog is not being read, so this proves nothing"
+    );
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut docs = Vec::new();
+    markdown_files(root, &mut docs);
+
+    let mut scanned = 0usize;
+    let mut checked = 0usize;
+    let mut exempt = 0usize;
+    let mut violations = Vec::new();
+
+    for doc in &docs {
+        let rel = doc.strip_prefix(root).unwrap_or(doc);
+        // By rule: an ADR records what was decided then, not what runs now.
+        if rel.starts_with("docs/adrs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(doc).unwrap_or_else(|e| panic!("read {doc:?}: {e}"));
+        if text.contains("advertised-tool-names: exempt") {
+            exempt += 1;
+            continue;
+        }
+        scanned += 1;
+        for (n, line) in text.lines().enumerate() {
+            for (pos, _) in line.match_indices("cxpak_") {
+                let name: String = line[pos..]
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                checked += 1;
+                if !advertised.iter().any(|t| t.name == name) {
+                    violations.push(format!(
+                        "{}:{} names {name:?}, which tools/list does not advertise",
+                        rel.display(),
+                        n + 1
+                    ));
+                }
+            }
+        }
+    }
+
+    // Positive controls, and `checked > 0` is the one that bears the weight.
+    //
+    // Measured rather than assumed: mutating the exclusion rule to swallow
+    // `docs/` + `plugin/`, and separately exempting BOTH documents that name a
+    // tool, are each caught by `checked > 0` and NEITHER by `scanned`. There are
+    // ~17 other markdown files in the tree that mention no tool at all, so the
+    // file count stays healthy while the guard has stopped checking anything.
+    //
+    // `scanned` is kept for the one thing it does catch that `checked` cannot —
+    // a moved or renamed root, where nothing is read at all.
+    assert!(
+        scanned >= 2,
+        "only {scanned} current-surface doc(s) scanned under {root:?} ({exempt} exempt) — the \
+         scan is not looking where it thinks it is"
+    );
+    assert!(
+        checked > 0,
+        "scanned {scanned} document(s) and found no cxpak_* name in any of them — this guard is \
+         not exercised by anything, so it proves nothing"
+    );
+    assert!(
+        exempt > 0,
+        "no document claims the exemption, so the exemption path is untested — if it has been \
+         removed, say so here rather than leaving dead machinery"
+    );
+
+    assert!(
+        violations.is_empty(),
+        "{} line(s) in current-surface documentation name a tool the server does not \
+         advertise:\n  {}",
+        violations.len(),
+        violations.join("\n  ")
+    );
+}
+
+fn markdown_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if path.is_dir() {
+            // Build output and vendored trees are not this repo's documentation.
+            if name == "target" || name == ".git" || name == "node_modules" {
+                continue;
+            }
+            markdown_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "md") {
+            out.push(path);
+        }
+    }
+}


### PR DESCRIPTION
Closes #64.

**Provenance: `regression — 3.0 consolidation (ADR-0182)`.** The 13-row table was correct when written; the consolidation removed the surface it describes and did not carry the documentation with it. The gate that should have fired is `tests/advertised_tool_names.rs`, which existed and scanned `src/` only — this widens it, which is the obligation a regression carries.

---

## What was wrong

`plugin/README.md:51` was headed **"MCP Tools (13)"** and listed the complete v2.x surface. `tools/list` serves `mcp_tool_schemas()`, which renders the intent catalog — **five** tools, each selecting a capability via `op`. **Not one** of the 13 names appears in the advertised set.

That file is the README of the plugin a user *installs*. It is what they read to learn what they just got.

All 13 still **route**, through the 26-arm alias table, so a permissive client that copies a name out of the README succeeds and nothing fails loudly. A client that builds its callable set from `tools/list` — which is what an agent harness does — gets none of them. The doc was wrong in the one direction the alias hides, which is why it survived.

### The sibling the ticket did not count

`README.md:187` names `cxpak_auto_context` and `cxpak_health` too. **There it is legitimate** — that paragraph's subject *is* the deprecated names — but the sentence around them was not. It said the aliases remain callable *"for one release"*, a horizon that has passed and that nothing enforced.

Per the acceptance criterion, I **dropped the claim** rather than inventing a date: setting a removal release is the owner's call, and this repo's own downstream `CLAUDE.md` already records the aliases as live-until-further-notice. It now says they route, that `tools/list` does not advertise them, and that no removal release is set.

### The `focus` claim, measured rather than carried over

The old section said *"all tools support a `focus` path prefix parameter"*. Measured on `main`:

```
23 of 29 ops read args.get("focus")
6 do not:  data_flow  drift  graph  health  retrieval  review
```

So the new section makes **no blanket parameter claim at all**, and says why in the document: a sentence that is right for most ops is wrong for the caller holding one of the others.

That measurement also turned up a **fifth** instance of **cxpak#81** — `visual` declares `focus` at `src/capability/mod.rs:492` and discards it at `src/commands/serve.rs:4326` with `let _ = focus`. **Reported on #81, not fixed here**, along with the caveat that the 23/29 figure counts `visual` as reading `focus` (it does; the discard is one line later), so that number is a floor rather than a total.

## The guard, which is the actual fix

`tests/advertised_tool_names.rs` already scanned `src/` for `cxpak_*` names in string literals — **the same defect, one scope too narrow.** It now also scans markdown.

**Denominator: the whole tree.** A new document is covered the day it is added, not the day someone remembers to list it — mutation D2 is exactly that case. Two escapes, and the difference between them is deliberate:

- **`docs/adrs/` is excluded by rule.** An ADR is a dated record of a decision taken when those names existed; rewriting one to use today's names would falsify history. There is no version of this guard an ADR should pass.
- **Everything else opts out with `advertised-tool-names: exempt` in the file**, beside the text it excuses. Two documents legitimately name the dead surface — the migration table, whose subject is the mapping, and README's deprecation paragraph. Declaring it in the document means deleting the paragraph deletes the exemption; a path list in the test would outlive its reason.

The expectation is deliberately **shared** with the thing it checks — `mcp_catalog_tools()` is the function `tools/list` is built from, so a rename moves both sides together. This is a *drift* claim, and drift needs a shared denominator. (A *completeness* claim needs the opposite, which is why the sibling test over `src/` derives its site set from the source rather than from a list.)

---

## Adversarial self-check

**Mutations: 5/5 killed.**

| | mutation | killed by |
|---|---|---|
| D1 | the plugin README names a dead tool again | the violation list, by name |
| D2 | a **new** doc names a dead tool | the violation list — the case a path allowlist misses |
| D3 | **CONTROL** — both scanned docs exempt themselves | `checked > 0` |
| D4 | **CONTROL** — the catalog is empty | fails loudly rather than passing |
| D5 | the ADR rule widens to swallow `docs/` + `plugin/` | `checked > 0` |

**D3 and D5 corrected a comment I had written before measuring it.** I predicted `scanned >= 2` would catch them. It does not: ~17 other markdown files in the tree mention no tool at all, so the file count stays healthy while the guard has stopped checking anything. `checked > 0` is the control that bears the weight, and the comment now says so — with `scanned` kept for the one thing it catches that `checked` cannot, a moved or renamed root.

That is the whole reason both controls are there. "Every name in the docs is advertised" is trivially satisfied by scanning nothing.

### What I did NOT verify

- **The five tools' `op` lists in the new table are transcribed from `mcp_catalog_tools()` at this commit, and are not asserted by a test.** The guard checks tool *names*, not the op enumerations beside them. A future op added to a tool leaves that table stale and nothing here catches it — the sibling `src/` test does check `(op: "...")` pairs, but only inside Rust string literals. Worth its own guard; not in this change.
- **The plugin is not installed and driven end to end.** I read `mcp_catalog_tools()` through a throwaway example binary (removed) rather than by running `cxpak serve --mcp` against a live client.
- **Whether any published artifact ships the old README.** This fixes the tree; a released plugin package already in someone's `~/.claude` still carries the 13-row table until a release goes out — which is `.github#24`'s subject.
- **The other 22 ops that read `focus`** were not each checked for a `let _ =` or an unused binding. `visual` was found incidentally.
