### PR TITLE
fix(test): stop scanning cxpak's own generated packs as user documentation

### DIFF
--- a/tests/advertised_tool_names.rs
+++ b/tests/advertised_tool_names.rs
@@ -322,7 +322,20 @@ fn markdown_files(dir: &Path, out: &mut Vec<PathBuf>) {
         let name = name.to_string_lossy();
         if path.is_dir() {
             // Build output and vendored trees are not this repo's documentation.
-            if name == "target" || name == ".git" || name == "node_modules" {
+            //
+            // `.cxpak/` is this tool's OWN generated context packs, and it is gitignored
+            // (`.gitignore:7`) — untracked build output, the same category as `target`, and it
+            // was missed. `modules.md` and `signatures.md` index every identifier in the repo,
+            // so they name Rust test functions (`cxpak_diff_respects_max_files_and_per_file_byte_cap`,
+            // `cxpak_cleaned_on_single_file_mode`) and every historical tool name the source
+            // still mentions. That is not documentation a user reads to learn the current
+            // surface — it is a machine index of this repo's identifiers — and this guard was
+            // failing on `main` because of it, which made every PR look partly red.
+            //
+            // It has to be a RULE and cannot be the in-file `advertised-tool-names: exempt`
+            // marker: these files are regenerated, so any marker written into one is erased the
+            // next time cxpak runs on itself.
+            if name == "target" || name == ".git" || name == "node_modules" || name == ".cxpak" {
                 continue;
             }
             markdown_files(&path, out);


### PR DESCRIPTION
`every_tool_name_in_current_docs_is_advertised` is red on `main` (`ce714b3f`, today), which
makes every open PR look partly red — #129 inherited this, it did not cause it. That is how a real
regression gets waved through.

`markdown_files` skips `target`, `.git` and `node_modules` on the stated rule that "build output
and vendored trees are not this repo's documentation", and misses **`.cxpak/`** — this tool's own
generated context packs, gitignored at `.gitignore:7`, so untracked build output in exactly that
category.

`modules.md` and `signatures.md` index every identifier in the repo, so they name Rust test
functions (`cxpak_diff_respects_max_files_and_per_file_byte_cap`, `cxpak_cleaned_on_single_file_mode`)
alongside every historical tool name the source still mentions. The test's own doc comment says it
scans "markdown that a user reads to learn the CURRENT surface". A machine index of this repo's
identifiers is not that, and it can never be made to pass — regenerating brings the names back.

It must be a **rule**, not the in-file `advertised-tool-names: exempt` marker this test offers for
exactly this purpose: the packs are regenerated, so a marker written into one is erased the next
time cxpak runs on itself. Same reasoning as the `docs/adrs` exclusion directly above it.

## Verified by before/after, not by a green run

`.cxpak/` does not exist in a fresh checkout, so the test passes locally either way and a plain
run proves nothing. With a planted `.cxpak/modules.md`:

```
without the exclusion:  FAILED — .cxpak/modules.md:1 names "cxpak_definitely_not_a_tool"
with the exclusion:     ok. 2 passed
```

The three positive controls this test carries — `scanned >= 2`, `checked > 0`, `exempt > 0` — all
still hold, so the guard has not been widened into a no-op.

Unblocks #129, whose `coverage` check fails on this and nothing else.

https://claude.ai/code/session_01KCX1sNmEkPtYXArEgUVUFP